### PR TITLE
Added Branding to GlobalConfig

### DIFF
--- a/src/config-schema.js
+++ b/src/config-schema.js
@@ -7,18 +7,18 @@ const configSchema = {
     properties: {
       name: {
         type: 'string',
-        default: 'pulsar',
-        description: 'Casual name to refer to the Editor.'
-      },
-      properName: {
-        type: 'string',
         default: 'Pulsar',
         description: 'Captilized version of the standard name, to refer to the Editor.'
       },
-      longName: {
+      fullName: {
         type: 'string',
         default: 'Pulsar Edit',
         description: 'Proper Long Name of the Editor.'
+      },
+      id: {
+        type: 'string',
+        default: 'pulsar',
+        description: 'Casual name to refer to the Editor.'
       }
     }
   },

--- a/src/config-schema.js
+++ b/src/config-schema.js
@@ -2,6 +2,26 @@
 // https://atom.io/docs/api/latest/Config for more information about config
 // schemas.
 const configSchema = {
+  branding: {
+    type: 'object',
+    properties: {
+      name: {
+        type: 'string',
+        default: 'pulsar',
+        description: 'Casual name to refer to the Editor.'
+      },
+      properName: {
+        type: 'string',
+        default: 'Pulsar',
+        description: 'Captilized version of the standard name, to refer to the Editor.'
+      },
+      longName: {
+        type: 'string',
+        default: 'Pulsar Edit',
+        description: 'Proper Long Name of the Editor.'
+      }
+    }
+  },
   core: {
     type: 'object',
     properties: {

--- a/src/config-schema.js
+++ b/src/config-schema.js
@@ -5,7 +5,7 @@ const configSchema = {
   branding: {
     type: 'object',
     properties: {
-      name: {
+      propername: {
         type: 'string',
         default: 'Pulsar',
         description: 'Captilized version of the standard name, to refer to the Editor.'


### PR DESCRIPTION
A proposed solution to adding easy rebranding within the editor and all core packages.

Using this in the core config would allow use to use it like any other Scoped Setting.

Meaning we could access the branding like so:

```javascript
atom.config.get('branding.name');
```

When creating this suggestion I know we wanted some variability, so added three different settings.

* branding.name: 'pulsar'
* branding.properName: 'Pulsar'
* branding.longName: 'Pulsar Edit'

Please let me know what everyone thinks.