### PR TITLE
Adding branding info to global API

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,11 @@
   "productName": "Atom",
   "version": "1.63.0-dev",
   "description": "A hackable text editor for the 21st Century.",
+  "branding": {
+    "id": "pulsar",
+    "fullName": "Pulsar Edit",
+    "properName": "Pulsar"
+  },
   "main": "./src/main-process/main.js",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "description": "A hackable text editor for the 21st Century.",
   "branding": {
     "id": "pulsar",
-    "fullName": "Pulsar Edit",
     "properName": "Pulsar"
   },
   "main": "./src/main-process/main.js",

--- a/src/atom-environment.js
+++ b/src/atom-environment.js
@@ -46,6 +46,7 @@ const TextEditorRegistry = require('./text-editor-registry');
 const AutoUpdateManager = require('./auto-update-manager');
 const StartupTime = require('./startup-time');
 const getReleaseChannel = require('./get-release-channel');
+const packagejson = require("../package.json");
 
 const stat = util.promisify(fs.stat);
 
@@ -219,6 +220,12 @@ class AtomEnvironment {
       commands: this.commands,
       stateStore: this.stateStore
     });
+    
+    this.branding = {
+      id: packagejson.branding.id,
+      fullName: packagejson.branding.fullName,
+      properName: packagejson.branding.properName
+    };
 
     // Keep instances of HistoryManager in sync
     this.disposables.add(

--- a/src/atom-environment.js
+++ b/src/atom-environment.js
@@ -223,7 +223,6 @@ class AtomEnvironment {
     
     this.branding = {
       id: packagejson.branding.id,
-      fullName: packagejson.branding.fullName,
       properName: packagejson.branding.properName
     };
 


### PR DESCRIPTION
While admittedly this was giving me some issues during testing, (The old branding of Atom still showed up) that likely means it was pulling the welcome package data from my current instance, since in testing any changes (including just new words) weren't showing up. So there may be something missing.

This at least could be a basis on using a global branding API as suggested in #5.

Using these changes and going into the Developer Tools console, all new Branding API is available under 

```javascript
console.log(atom.branding.fullName);
// Outputs: Pulsar Edit
console.log(atom.branding.id);
// Outputs: pulsar
console.log(atom.branding.properName);
// Outputs: Pulsar
```

Interested to hear what everyone thinks