### PR TITLE
Extra comma stopping yarn install from starting

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "id": "pulsar",
     "name": "Pulsar",
     "urlWeb": "https://atom.io/",
-    "urlGH": "https://github.com/pulsar-edit",
+    "urlGH": "https://github.com/pulsar-edit"
   },
   "main": "./src/main-process/main.js",
   "repository": {


### PR DESCRIPTION
JSON wasn't valid so was failing at step 1 of `yarn install`:

```
 ~/d/pulsar ~> yarn install                                                                               
yarn install v1.22.11
error An unexpected error occurred: "/home/dae/dev/pulsar/package.json: Unexpected token } in JSON at position 278".
info If you think this is a bug, please open a bug report with the information provided in "/home/dae/dev/pulsar/yarn-error.log".
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
```

Removed comma from end of L10 which allows it to progress. (Not currently building for me but that is a different issue).
