### PR TITLE
Destroy panels after test.

### DIFF
--- a/spec/panel-container-element-spec.js
+++ b/spec/panel-container-element-spec.js
@@ -226,6 +226,7 @@ describe('PanelContainerElement', () => {
 
         panel.show();
         expect(document.activeElement).toBe(inputEl);
+        panel.destroy();
       });
 
       it('focuses the autoFocus element if available', () => {
@@ -240,6 +241,7 @@ describe('PanelContainerElement', () => {
 
         panel.show();
         expect(document.activeElement).toBe(inputEl2);
+        panel.destroy();
       });
 
       it('focuses the entire panel item when no tabbable item is available and the panel is focusable', () => {
@@ -249,6 +251,7 @@ describe('PanelContainerElement', () => {
         spyOn(panelEl, 'focus');
         panel.show();
         expect(panelEl.focus).toHaveBeenCalled();
+        panel.destroy()
       });
 
       it('returns focus to the original activeElement', () => {


### PR DESCRIPTION
Currently, when you run the test you get the following error.
```
::add(target, options)
  when the trigger is 'click'
    it shows and hides the tooltip when the target element is clicked
      Expected null not to be null.
        at jasmine.Spec.<anonymous> (pulsar/spec/tooltip-manager-spec.js:98:61)
        at jasmine.Spec.args.<computed> (atom/out/app/spec/jasmine-test-runner.coffee:89:27)
      Expected null not to be null.
        at jasmine.Spec.<anonymous> (pulsar/spec/tooltip-manager-spec.js:104:61)
        at jasmine.Spec.args.<computed> (atom/out/app/spec/jasmine-test-runner.coffee:89:27)
      TypeError: Cannot read property 'click' of null
        at jasmine.Spec.<anonymous> (pulsar/spec/tooltip-manager-spec.js:105:48)
        at jasmine.Spec.args.<computed> (atom/out/app/spec/jasmine-test-runner.coffee:89:27)
  it does not hide the tooltip on keyboard input
    Expected null not to be null.
      at jasmine.Spec.<anonymous> (pulsar/spec/tooltip-manager-spec.js:122:59)
      at jasmine.Spec.args.<computed> (atom/out/app/spec/jasmine-test-runner.coffee:89:27)
    Expected null not to be null.
      at jasmine.Spec.<anonymous> (pulsar/spec/tooltip-manager-spec.js:128:59)
      at jasmine.Spec.args.<computed> (atom/out/app/spec/jasmine-test-runner.coffee:89:27)
```
Those tests run ok by themselves but fail if they are executed after `spec/panel-container-element-spec.js`. Panels created in that test file are interfering with the tooltip tests. I added some lines to remove those panels. But tooltips should work along with panels so we should keep updating these tests.