### PR TITLE
Disable middle-click paste for cursor position test.

### DIFF
--- a/spec/text-editor-component-spec.js
+++ b/spec/text-editor-component-spec.js
@@ -4059,7 +4059,7 @@ describe('TextEditorComponent', () => {
     describe('on the lines', () => {
       describe('when there is only one cursor', () => {
         it('positions the cursor on single-click or when middle-clicking', async () => {
-          atom.config.set('editor.selectionClipboard', true);
+          atom.config.set('editor.selectionClipboard', false);
           for (const button of [0, 1]) {
             const { component, editor } = buildComponent();
             const { lineHeight } = component.measurements;


### PR DESCRIPTION
When you run the test on Linux you get this error message
```
mouse input
  on the lines
    when there is only one cursor
      it positions the cursor on single-click or when middle-clicking
        Expected { row : 0, column : 25 } to equal [ 0, 0 ].
          at jasmine.Spec.<anonymous> (pulsar/spec/text-editor-component-spec.js:4076:54)
        Expected { row : 0, column : 54 } to equal [ 0, 79 ].
          at jasmine.Spec.<anonymous> (pulsar/spec/text-editor-component-spec.js:4109:54)
        Expected { row : 1, column : 25 } to equal [ 1, 0 ].
          at jasmine.Spec.<anonymous> (pulsar/spec/text-editor-component-spec.js:4123:54)
        Expected { row : 3, column : 39 } to equal [ 3, 14 ].
          at jasmine.Spec.<anonymous> (pulsar/spec/text-editor-component-spec.js:4134:54)
        Expected { row : 3, column : 40 } to equal [ 3, 15 ].
          at jasmine.Spec.<anonymous> (pulsar/spec/text-editor-component-spec.js:4146:54)
        Expected { row : 3, column : 39 } to equal [ 3, 14 ].
          at jasmine.Spec.<anonymous> (pulsar/spec/text-editor-component-spec.js:4160:54)
        Expected { row : 3, column : 41 } to equal [ 3, 16 ].
          at jasmine.Spec.<anonymous> (pulsar/spec/text-editor-component-spec.js:4172:54)
        Expected [ { screenRange : { start : { row : 0, column : 0 }, end : { row : 0, column : 1 } }, options : { clip : false } }, { screenRange : { start : { row : 0, column : 25 }, end : { row : 0, column : 26 } }, options : { clip : false } }, { screenRange : { start : { row : 12, column : 2 }, end : { row : 12, column : 3 } }, options : { clip : false } }, { screenRange : { start : { row : 12, column : 27 }, end : { row : 12, column : 28 } }, options : { clip : false } }, { screenRange : { start : { row : 0, column : 29 }, end : { row : 0, column : 30 } }, options : { clip : false } }, { screenRange : { start : { row : 0, column : 54 }, end : { row : 0, column : 55 } }, options : { clip : false } }, { screenRange : { start : { row : 1, column : 0 }, end : { row : 1, column : 1 } }, options : { clip : false } }, { screenRange : { start : { row : 1, column : 25 }, end : { row : 1, column : 26 } }, options : { clip : false } }, { screenRange : { start : { row : 3, column : 14 }, end : { row : 3, column : 15 } }, options : { clip : false } }, { screenRange : { start : { row : 3, column : 39 }, end : { row : 3, column : 40 } }, options : { clip : false } }, { screenRange : { start : { row : 3, column : 15 }, end : { row : 3, column : 16 } }, options : { clip : false } }, { screenRange : { start : { row : 3, column : 40 }, end : { row : 3, column : 41 } }, options : { clip : false } }, { screenRange : { start : { row : 3, column : 14 }, end : { row : 3, column : 15 } }, options : { clip : false } }, { screenRange : { start : { row : 3, column : 39 }, end : { row : 3, column : 40 } }, options : { clip : false } }, { screenRange : { start : { row : 3, column : 16 }, end : { row : 3, column : 17 } }, options : { clip : false } }, { screenRange : { start : { row : 3, column : 41 }, end : { row : 3, column : 42 } }, options : { clip : false } } ] to equal [  ].
          at jasmine.Spec.<anonymous> (pulsar/spec/text-editor-component-spec.js:4174:51)

```
Middle-click is for pasting text on Linux. You have to disable this feature in order to pass these tests. There is already a line for that but it setting the wrong value.