### PR TITLE
MacOS Editor Test Installation

### DIFF
--- a/.github/workflows/editor-tests.yml
+++ b/.github/workflows/editor-tests.yml
@@ -2,6 +2,9 @@ name: Editor tests
 on:
   - push
   - pull_request
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  
 jobs:
   tests:
     name: tests


### PR DESCRIPTION
Looking through our GitHub Actions, many of them fail when attempting to run `vscode-ripgrep`.

It seems this is because during that process it attempts to download `ripgrep`. According to that [packages documentation](https://github.com/microsoft/vscode-ripgrep#github-api-limit-note) this is because of a GitHub API Rate Limit issue.

So by setting a `GITHUB_TOKEN` as an environment variable it becomes available to that package, to allow this package installation to be successful more often. 

On an additional note we should look into updating this dependency when we can as it is a bit out of date, with Pulsar using v1.9.0 and its latest being v1.13.2