### PR TITLE
Fixing failing tests

### DIFF
--- a/spec/config-spec.js
+++ b/spec/config-spec.js
@@ -589,7 +589,8 @@ describe('Config', () => {
           atom.config.get('foo.bar.baz', { scope: ['.source.coffee'] })
         ).toBe(55);
 
-        advanceClock(150);
+        //advanceClock(150);
+        atom.config.save();
         savedSettings.length = 0;
 
         atom.config.unset('foo.bar.baz', { scopeSelector: '.source.coffee' });
@@ -600,7 +601,8 @@ describe('Config', () => {
           atom.config.get('foo.bar.ok', { scope: ['.source.coffee'] })
         ).toBe(20);
 
-        advanceClock(150);
+        //advanceClock(150);
+        atom.config.save();
         expect(savedSettings[0]['.coffee.source']).toEqual({
           foo: {
             bar: {
@@ -611,7 +613,8 @@ describe('Config', () => {
 
         atom.config.unset('foo.bar.ok', { scopeSelector: '.source.coffee' });
 
-        advanceClock(150);
+        //advanceClock(150);
+        atom.config.save();
         expect(savedSettings.length).toBe(2);
         expect(savedSettings[1]['.coffee.source']).toBeUndefined();
       });
@@ -1265,7 +1268,8 @@ describe('Config', () => {
 
       atom.config.set('foo.int', 50, { scopeSelector: '*' });
 
-      advanceClock(100);
+      //advanceClock(100);
+      atom.config.save();
 
       expect(savedSettings[0]['*'].foo).toEqual({
         bar: 'baz',

--- a/spec/panel-container-element-spec.js
+++ b/spec/panel-container-element-spec.js
@@ -226,6 +226,7 @@ describe('PanelContainerElement', () => {
 
         panel.show();
         expect(document.activeElement).toBe(inputEl);
+        panel.destroy();
       });
 
       it('focuses the autoFocus element if available', () => {
@@ -240,6 +241,7 @@ describe('PanelContainerElement', () => {
 
         panel.show();
         expect(document.activeElement).toBe(inputEl2);
+        panel.destroy();
       });
 
       it('focuses the entire panel item when no tabbable item is available and the panel is focusable', () => {
@@ -249,6 +251,7 @@ describe('PanelContainerElement', () => {
         spyOn(panelEl, 'focus');
         panel.show();
         expect(panelEl.focus).toHaveBeenCalled();
+        panel.destroy()
       });
 
       it('returns focus to the original activeElement', () => {

--- a/spec/text-editor-component-spec.js
+++ b/spec/text-editor-component-spec.js
@@ -4059,7 +4059,7 @@ describe('TextEditorComponent', () => {
     describe('on the lines', () => {
       describe('when there is only one cursor', () => {
         it('positions the cursor on single-click or when middle-clicking', async () => {
-          atom.config.set('editor.selectionClipboard', true);
+          atom.config.set('editor.selectionClipboard', false);
           for (const button of [0, 1]) {
             const { component, editor } = buildComponent();
             const { lineHeight } = component.measurements;

--- a/src/workspace.js
+++ b/src/workspace.js
@@ -1301,7 +1301,12 @@ module.exports = class Workspace extends Model {
 
   // Open Atom's license in the active pane.
   openLicense() {
-    return this.open(path.join(process.resourcesPath, 'LICENSE.md'));
+    const resPath = path.join(process.resourcesPath, 'LICENSE.md')
+    if(fs.existsSync(resPath)) {
+      return this.open(resPath);
+    } else {
+      return this.open(path.join(__dirname, '..', 'LICENSE.md'))
+    }
   }
 
   // Synchronously open the given URI in the active pane. **Only use this method


### PR DESCRIPTION
This commit cherry picks several commits from the `pulsar-edit/pulsar:disable-failing-tests` branch. 

Implementing strictly the fixed that were made on that branch rather than disabling the tests.

* Some changes were mirrored from @mauricioszabo's Commit 51a1f7599846a64d83af110e507413c0bf00bb9e
* Cherry-Picked Commit: 0863b3a7f7ade8e422d606ca8b4a119401aacf99
* Cherry-Picked Commit: b48db24392cd7fef181986fc53ca8d69770e9a99
* Cherry-Picked Commit: 3c3b40b53ef692dc80a030b80fa381b5d665becd

---

Edit:

With a failed test expectancy of 55 Editor Tests and 22 Package Tests, this PR takes advantage of the fixes merged to main since those numbers where found, and with its own changes achieves 30 Failing Editor Tests! 

Thanks to all the contributors that have submitted fixes to the tests to allow this to happen, its great progress to see.