### PR TITLE
Reduce space inbetween Badges to keep 2 lines

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,14 +7,14 @@
 
 # Pulsar
 
-[![Button Install]][Install]   
-[![Button Documentation]][Documentation]   
+[![Button Install]][Install] 
+[![Button Documentation]][Documentation] 
 [![Button Build]][Build] 
 
-[![Badge License]][License]    
-[![Badge Guidelines]][Guidelines]    
-[![Badge Status]][Status]    
-[![Badge Sunset]][Retired]    
+[![Badge License]][License] 
+[![Badge Guidelines]][Guidelines] 
+[![Badge Status]][Status] 
+[![Badge Sunset]][Retired] 
 [![Badge Discord]][Discord]
 
 <br>


### PR DESCRIPTION
When viewing the file directly, the width of the interface is larger than when you are viewing the repo directly. This should hopefully remove enough space to keep the badges on the two lines.