### PR TITLE
Small fixes on build

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -34,7 +34,7 @@ linux_task:
       type: text/xml
       format: junit
   build_binary_script:
-    - yarn dist || rm dist && yarn dist
+    - yarn dist || yarn dist
   binary_artifacts:
     path: ./binaries/*
 
@@ -62,7 +62,7 @@ silicon_mac_task:
       format: junit
   build_arm_binary_script:
     - export PATH="/opt/homebrew/bin:/opt/homebrew/opt/node@16/bin:$PATH"
-    - yarn dist || rm dist && yarn dist
+    - yarn dist || yarn dist
   binary_artifacts:
     path: ./binaries/*
   build_x86_dependencies_script:
@@ -80,7 +80,7 @@ silicon_mac_task:
     - export PATH="/opt/homebrew/bin:/opt/homebrew/opt/node@16/bin:$PATH"
     - sudo rm -rf /Library/Developer/CommandLineTools
     - arch -x86_64 xcode-select --install
-    - arch -x86_64 npx yarn dist || rm dist && arch -x86_64 npx yarn dist
+    - arch -x86_64 npx yarn dist || arch -x86_64 npx yarn dist
   binary_artifacts:
     path: ./binaries/*
 

--- a/script/electron-builder.js
+++ b/script/electron-builder.js
@@ -44,7 +44,7 @@ const pngIcon = 'resources/app-icons/nightly/png/1024.png'
 const icoIcon = 'resources/app-icons/nightly/pulsar.ico'
 
 let options = {
-  "appId": "link.mauricioszabo.pulsar",
+  "appId": "com.pulsar-edit.pulsar",
   "npmRebuild": false,
   "publish": null,
   files: [


### PR DESCRIPTION
Just 2 small changes:

1. Changed `appId`
2. Because we found out the exact glob of files that need to be inserted into the final binary, we don't need the `rm dist` anymore for the build scripts