### PR TITLE
Disable all failing tests : Part 2

### DIFF
--- a/spec/atom-paths-spec.js
+++ b/spec/atom-paths-spec.js
@@ -32,7 +32,11 @@ describe('AtomPaths', () => {
         fs.removeSync(portableAtomHomePath);
       });
 
-      it('sets ATOM_HOME to the portable .atom folder if it has permission', () => {
+      /**
+      * TODO: FAILING TEST - This test fails with the following output:
+      * Expected '/home/runner/.pulsar' to equal '/home/runner/work/pulsar/pulsar/node_modules/electron/.atom'
+      */
+      xit('sets ATOM_HOME to the portable .atom folder if it has permission', () => {
         atomPaths.setAtomHome(app.getPath('home'));
         expect(process.env.ATOM_HOME).toEqual(portableAtomHomePath);
       });
@@ -65,7 +69,11 @@ describe('AtomPaths', () => {
         expect(process.env.ATOM_HOME).toEqual(temporaryHome);
       });
 
-      it('sets ATOM_HOME to a default location if not yet set', () => {
+      /**
+      * TODO: FAILING TEST - This test fails with the following output:
+      * Expected '/home/runner/.pulsar' to equal '/home/runner/work/pulsar/pulsar/node_modules/electron/.atom'
+      */
+      xit('sets ATOM_HOME to a default location if not yet set', () => {
         const expectedPath = path.join(app.getPath('home'), '.atom');
         atomPaths.setAtomHome(app.getPath('home'));
         expect(process.env.ATOM_HOME).toEqual(expectedPath);
@@ -101,7 +109,11 @@ describe('AtomPaths', () => {
     });
 
     describe('when an electronUserData folder exists', () => {
-      it('sets userData path to the folder if it has permission', () => {
+      /**
+      * TODO: FAILING TEST - This test fails with the following output:
+      * Expected '/tmp/atom-test-data2022824-26037-orl5og.n4n0b' to equal '/tmp/atom-paths-specs-userdata-home2022824-26084-14syl0h.bmd6/.atom/electronUserData'.
+      */
+      xit('sets userData path to the folder if it has permission', () => {
         fs.mkdirSync(electronUserDataPath);
         atomPaths.setUserData(app);
         expect(app.getPath('userData')).toEqual(electronUserDataPath);

--- a/spec/buffered-process-spec.js
+++ b/spec/buffered-process-spec.js
@@ -93,7 +93,11 @@ describe('BufferedProcess', function() {
   });
 
   describe('when autoStart is false', () =>
-    it('doesnt start unless start method is called', function() {
+    /**
+    * TODO: FAILING TEST - This test fails with the following output:
+    * timeout: timed out after 120000 msec waiting for condition
+    */
+    xit('doesnt start unless start method is called', function() {
       let stdout = '';
       let stderr = '';
       const exitCallback = jasmine.createSpy('exit callback');
@@ -121,8 +125,11 @@ describe('BufferedProcess', function() {
         expect(stdout).toEqual('');
       });
     }));
-
-  it('calls the specified stdout, stderr, and exit callbacks', function() {
+  /**
+  * TODO: FAILING TEST - This test fails with the following output:
+  * timeout: timed out after 120000 msec waiting for condition 
+  */
+  xit('calls the specified stdout, stderr, and exit callbacks', function() {
     let stdout = '';
     let stderr = '';
     const exitCallback = jasmine.createSpy('exit callback');

--- a/spec/command-installer-spec.js
+++ b/spec/command-installer-spec.js
@@ -141,7 +141,11 @@ describe('CommandInstaller on #darwin', () => {
       installer.initialize('2.2.0-beta.0');
     });
 
-    it("symlinks the atom command as 'atom-beta'", () => {
+    /**
+    * TODO: FAILING TEST - This test fails with the following output: (macos only)
+    * timeout: timed out after 120000 msec waiting for condition
+    */
+    xit("symlinks the atom command as 'atom-beta'", () => {
       const installedAtomPath = path.join(installationPath, 'atom-beta');
       expect(fs.isFileSync(installedAtomPath)).toBeFalsy();
 
@@ -160,11 +164,7 @@ describe('CommandInstaller on #darwin', () => {
       });
     });
 
-    /**
-    * TODO: FAILING TEST - This test fails with the following output: (macos only)
-    * timeout: timed out after 120000 msec waiting for condition
-    */
-    xit("symlinks the apm command as 'apm-beta'", () => {
+    it("symlinks the apm command as 'apm-beta'", () => {
       const installedApmPath = path.join(installationPath, 'apm-beta');
       expect(fs.isFileSync(installedApmPath)).toBeFalsy();
 
@@ -188,7 +188,11 @@ describe('CommandInstaller on #darwin', () => {
       installer.initialize('2.2.0-nightly0');
     });
 
-    it("symlinks the atom command as 'atom-nightly'", () => {
+    /**
+    * TODO: FAILING TEST - This test fails with the following output: (macos only)
+    * timeout: timed out after 120000 msec waiting for condition
+    */
+    xit("symlinks the atom command as 'atom-nightly'", () => {
       const installedAtomPath = path.join(installationPath, 'atom-nightly');
       expect(fs.isFileSync(installedAtomPath)).toBeFalsy();
 
@@ -207,11 +211,7 @@ describe('CommandInstaller on #darwin', () => {
       });
     });
 
-    /**
-    * TODO: FAILING TEST - This test fails with the following output: (macos only)
-    * timeout: timed out after 120000 msec waiting for condition
-    */
-    xit("symlinks the apm command as 'apm-nightly'", () => {
+    it("symlinks the apm command as 'apm-nightly'", () => {
       const installedApmPath = path.join(installationPath, 'apm-nightly');
       expect(fs.isFileSync(installedApmPath)).toBeFalsy();
 

--- a/spec/command-installer-spec.js
+++ b/spec/command-installer-spec.js
@@ -92,7 +92,11 @@ describe('CommandInstaller on #darwin', () => {
       installer.initialize('2.0.2');
     });
 
-    it("symlinks the atom command as 'atom'", () => {
+    /**
+    * TODO: FAILING TEST - This test fails with the following output: (macos only)
+    * timeout: timed out after 120000 msec waiting for condition
+    */
+    xit("symlinks the atom command as 'atom'", () => {
       const installedAtomPath = path.join(installationPath, 'atom');
       expect(fs.isFileSync(installedAtomPath)).toBeFalsy();
 
@@ -156,7 +160,11 @@ describe('CommandInstaller on #darwin', () => {
       });
     });
 
-    it("symlinks the apm command as 'apm-beta'", () => {
+    /**
+    * TODO: FAILING TEST - This test fails with the following output: (macos only)
+    * timeout: timed out after 120000 msec waiting for condition
+    */
+    xit("symlinks the apm command as 'apm-beta'", () => {
       const installedApmPath = path.join(installationPath, 'apm-beta');
       expect(fs.isFileSync(installedApmPath)).toBeFalsy();
 
@@ -199,7 +207,11 @@ describe('CommandInstaller on #darwin', () => {
       });
     });
 
-    it("symlinks the apm command as 'apm-nightly'", () => {
+    /**
+    * TODO: FAILING TEST - This test fails with the following output: (macos only)
+    * timeout: timed out after 120000 msec waiting for condition
+    */
+    xit("symlinks the apm command as 'apm-nightly'", () => {
       const installedApmPath = path.join(installationPath, 'apm-nightly');
       expect(fs.isFileSync(installedApmPath)).toBeFalsy();
 

--- a/spec/compile-cache-spec.js
+++ b/spec/compile-cache-spec.js
@@ -42,7 +42,11 @@ describe('CompileCache', () => {
       return expect(CompileCache.getCacheStats()['.js']).toEqual({hits: 0, misses: 0});
   }));
 
-    describe('when the given file uses babel', () => it('compiles the file with babel and caches it', function() {
+    /**
+    * TODO: FAILING TEST - This test fails with the following output:
+    * TypeError: The "data" argument must be of type string or an instance of Buffer, TypedArray, or DataView. Received undefined
+    */
+    xdescribe('when the given file uses babel', () => it('compiles the file with babel and caches it', function() {
       CompileCache.addPathToCache(path.join(fixtures, 'babel', 'babel-comment.js'), atomHome);
       expect(CompileCache.getCacheStats()['.js']).toEqual({hits: 0, misses: 1});
       expect(babelCompiler.compile.callCount).toBe(1);

--- a/spec/integration/smoke-spec.js
+++ b/spec/integration/smoke-spec.js
@@ -24,7 +24,11 @@ describe('Smoke Test', () => {
     });
   });
 
-  it('can open a file in Atom and perform basic operations on it', async () => {
+  /**
+  * TODO: FAILING TEST - This test fails with the following output: (macos only)
+  * timeout: timed out after 15000 msec waiting for webdriver to start 
+  */
+  xit('can open a file in Atom and perform basic operations on it', async () => {
     const tempDirPath = temp.mkdirSync('empty-dir');
     const filePath = path.join(tempDirPath, 'new-file');
 

--- a/spec/package-manager-spec.js
+++ b/spec/package-manager-spec.js
@@ -50,7 +50,12 @@ describe('PackageManager', () => {
   });
 
   describe('::getApmPath()', () => {
-    it('returns the path to the apm command', () => {
+    /**
+    * TODO: FAILING TEST - This test fails with the following output:
+    * Expected '/home/runner/work/pulsar/pulsar/apm/node_modules/ppm/bin/apm' to be
+    * '/home/runner/work/pulsar/pulsar/node_modules/electron/dist/resources/app/apm/bin/apm'
+    */
+    xit('returns the path to the apm command', () => {
       let apmPath = path.join(
         process.resourcesPath,
         'app',

--- a/spec/text-editor-component-spec.js
+++ b/spec/text-editor-component-spec.js
@@ -605,7 +605,12 @@ describe('TextEditorComponent', () => {
       }
     });
 
-    it('blinks cursors when the editor is focused and the cursors are not moving', async () => {
+    /**
+    * TODO: FAILING TEST - This test fails with the following output:
+    * Error: Timed out waiting on anonymous condition at
+    * conditionPromise (/home/runner/work/pulsar/pulsar/spec/async-spec-helpers.js:20:13)
+    */
+    xit('blinks cursors when the editor is focused and the cursors are not moving', async () => {
       assertDocumentFocused();
       const { component, element, editor } = buildComponent();
       component.props.cursorBlinkPeriod = 30;
@@ -5520,7 +5525,13 @@ describe('TextEditorComponent', () => {
   });
 
   describe('styling changes', () => {
-    it('updates the rendered content based on new measurements when the font dimensions change', async () => {
+    /**
+    * TODO: FAILING TEST - This test fails with the following output:
+    * Expected 7.234375 not to be 7.234375.
+    * Expected 7.234375 not to be 7.234375.
+    * Expected 7.234375 not to be 7.234375.
+    */
+    xit('updates the rendered content based on new measurements when the font dimensions change', async () => {
       const { component, element, editor } = buildComponent({
         rowsPerTile: 1,
         autoHeight: false

--- a/spec/tree-indenter-spec.js
+++ b/spec/tree-indenter-spec.js
@@ -134,7 +134,12 @@ describe('TreeIndenter', () => {
     );
 
     fixtures.forEach(filename => {
-      it(`suggests correct indentations for ${filename}`, () => {
+      /**
+      * TODO: FAILING TEST - This test fails with the following output:
+      * it suggests correct indentations for if_then_else.js
+      * Error: failure in file row 5: suggested 1 but 0 is correct (else)
+      */
+      xit(`suggests correct indentations for ${filename}`, () => {
         compareFile(path.join(__dirname, 'fixtures', 'indentation', filename));
       });
     });

--- a/spec/workspace-element-spec.js
+++ b/spec/workspace-element-spec.js
@@ -580,7 +580,55 @@ describe('WorkspaceElement', () => {
     });
   });
 
-  describe('mousing over docks', () => {
+  /**
+  * TODO: FAILING TEST - This test fails with the following output:
+  * ---
+  * Expected '<div class="atom-dock-toggle-button right atom-dock-toggle-button-visible"><div class="atom-dock-toggle-button-inner right"><span class="icon icon-chevron-right"></span></div></div>'
+  * not to have class 'atom-dock-toggle-button-visible'.
+  * ---
+  * Expected '<div class="atom-dock-toggle-button right atom-dock-toggle-button-visible"><div class="atom-dock-toggle-button-inner right"><span class="icon icon-chevron-left"></span></div></div>'
+  * not to have class 'atom-dock-toggle-button-visible'.
+  * ---
+  * Expected '<div class="atom-dock-toggle-button left"><div class="atom-dock-toggle-button-inner left"><span class="icon icon-chevron-left"></span></div></div>'
+  * to have class 'atom-dock-toggle-button-visible'.
+  * ---
+  * Expected '<div class="atom-dock-toggle-button right atom-dock-toggle-button-visible"><div class="atom-dock-toggle-button-inner right"><span class="icon icon-chevron-right"></span></div></div>'
+  * not to have class 'atom-dock-toggle-button-visible'.
+  * ---
+  * Expected '<div class="atom-dock-toggle-button left"><div class="atom-dock-toggle-button-inner left"><span class="icon icon-chevron-left"></span></div></div>'
+  * to have class 'atom-dock-toggle-button-visible'.
+  * ---
+  * Expected '<div class="atom-dock-toggle-button right atom-dock-toggle-button-visible"><div class="atom-dock-toggle-button-inner right"><span class="icon icon-chevron-right"></span></div></div>'
+  * not to have class 'atom-dock-toggle-button-visible'.
+  * ---
+  * Expected '<div class="atom-dock-toggle-button left"><div class="atom-dock-toggle-button-inner left"><span class="icon icon-chevron-right"></span></div></div>'
+  * to have class 'atom-dock-toggle-button-visible'.
+  * ---
+  * Expected '<div class="atom-dock-toggle-button left"><div class="atom-dock-toggle-button-inner left"><span class="icon icon-chevron-left"></span></div></div>'
+  * to have class 'atom-dock-toggle-button-visible'.
+  * ---
+  * Expected '<div class="atom-dock-toggle-button right atom-dock-toggle-button-visible"><div class="atom-dock-toggle-button-inner right"><span class="icon icon-chevron-right"></span></div></div>'
+  * not to have class 'atom-dock-toggle-button-visible'.
+  * ---
+  * Expected '<div class="atom-dock-toggle-button right atom-dock-toggle-button-visible"><div class="atom-dock-toggle-button-inner right"><span class="icon icon-chevron-right"></span></div></div>'
+  * not to have class 'atom-dock-toggle-button-visible'.
+  * ---
+  * Expected '<div class="atom-dock-toggle-button bottom"><div class="atom-dock-toggle-button-inner bottom"><span class="icon icon-chevron-down"></span></div></div>'
+  * to have class 'atom-dock-toggle-button-visible'.
+  * ---
+  * Expected '<div class="atom-dock-toggle-button right atom-dock-toggle-button-visible"><div class="atom-dock-toggle-button-inner right"><span class="icon icon-chevron-right"></span></div></div>'
+  * not to have class 'atom-dock-toggle-button-visible'.
+  * ---
+  * Expected '<div class="atom-dock-toggle-button bottom"><div class="atom-dock-toggle-button-inner bottom"><span class="icon icon-chevron-down"></span></div></div>'
+  * to have class 'atom-dock-toggle-button-visible'.
+  * ---
+  * Expected '<div class="atom-dock-toggle-button bottom"><div class="atom-dock-toggle-button-inner bottom"><span class="icon icon-chevron-up"></span></div></div>'
+  * to have class 'atom-dock-toggle-button-visible'.
+  * ---
+  * Expected '<div class="atom-dock-toggle-button bottom"><div class="atom-dock-toggle-button-inner bottom"><span class="icon icon-chevron-down"></span></div></div>'
+  * to have class 'atom-dock-toggle-button-visible'.
+  */
+  xdescribe('mousing over docks', () => {
     let workspaceElement;
     let originalTimeout = jasmine.getEnv().defaultTimeoutInterval;
 


### PR DESCRIPTION
This PR aims to disable all currently failing tests. While very similar to the effort previously made by @mauricioszabo in PR #32 

The difference here, is that many of those tests have now been fixed via other methods, or the methods taken from them and have been merged in PR #48 

Now with this PR, all the remaining tests have been disabled using built in features of Jasmine to add `x` before the `describe` or `it` of test suites or tests themselves.

Additionally comments have been added before each failing tests, with the output of them failing to make it easier to contributors to investigate the failure.

The tests that were commented out are based on the failing tests present in PR #67 
Additional tests are added based on what is still failing in this PR. OS Specific tests are marked as such

---

Side Note: If this is the plan for further development, it seems a smart idea would be to disable the tests that are failing in packages as well.