### PR TITLE
Update Cirrus Badge link

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@
 [Guidelines]: https://github.com/logos 'Branding Guidelines'
 [Electron]: https://github.com/electron/electron
 [Discord]: https://discord.gg/7aEbB9dGRT 'Join the Pulsar Discord today!'
-[Status]: https://cirrus-ci.com/github/pulsar-edit/pulsar
+[Status]: https://cirrus-ci.com/github/pulsar-edit/pulsar/master
 
 [#]: #
 


### PR DESCRIPTION
Update link to specifically point to the master branch. The badge itself is fine, as master is the base branch, and is where shields.io already points to

However, the link is a slightly different story as if you don't specify a branch, it shows all runs for the entire repo, which could be detrimental to new users, and possibly lead to non-standard or test installations, instead of the "release-ready" master build.
