### PR TITLE
Updating builds on linux as a test

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -36,8 +36,13 @@ linux_task:
       format: junit
   build_binary_script:
     - yarn dist || yarn dist
-  binary_artifacts:
-    path: ./binaries/*
+  deb_artifacts:
+    path: ./binaries/pulsar-dev/`date -u +%Y%m%d%H`/pulsar-edit-dev.deb
+  rpm_artifacts:
+    path: ./binaries/pulsar-dev/`date -u +%Y%m%d%H`/pulsar-edit-dev.rpm
+  appImage_artifacts:
+    path: ./binaries/pulsar-dev/`date -u +%Y%m%d%H`/pulsar-edit-dev.appImage
+  
 
 silicon_mac_task:
   alias: mac


### PR DESCRIPTION
Adding this as a proposal to see if it works for builds to enable easier URLs after what I already did before using part of the sed command since I assume the bit I copied just inserts the current date.

Since this would make it easier to grab this, I hope, assuming the build goes through properly. We'll see.
