### PR TITLE
Fix File->Open not responding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ spec/fixtures/evil-files/
 !spec/fixtures/packages/package-with-incompatible-native-module-loaded-conditionally/node_modules/
 out/
 /electron/
+binaries
+dist

--- a/.gitignore
+++ b/.gitignore
@@ -19,5 +19,5 @@ spec/fixtures/evil-files/
 !spec/fixtures/packages/package-with-incompatible-native-module-loaded-conditionally/node_modules/
 out/
 /electron/
-binaries
-dist
+binaries/
+dist/

--- a/src/main-process/atom-application.js
+++ b/src/main-process/atom-application.js
@@ -625,13 +625,6 @@ module.exports = class AtomApplication extends EventEmitter {
         this.openPaths({ pathsToOpen: paths });
       });
 
-      this.on('application:open', () => {
-        this.promptForPathToOpen(
-          'all',
-          createOpenSettings({ sameWindow: true }),
-          getDefaultPath()
-        );
-      });
       this.on('application:open-file', () => {
         this.promptForPathToOpen(
           'file',


### PR DESCRIPTION
### Identify the Bug

When a user clicks on File > Open to open a project, the user expects a window to open to select the project. Instead, nothing will happen. This is the stack trace in the log:
```
2022-10-10 09:12:47.125 Electron[13550:10020502] atom is not defined
2022-10-10 09:12:47.126 Electron[13550:10020502] ReferenceError: atom is not defined
    at getDefaultPath (/Users/bongnguyen/projects/pulsar/src/main-process/atom-application.js:43:18)
    at AtomApplication.<anonymous> (/Users/bongnguyen/projects/pulsar/src/main-process/atom-application.js:632:11)
    at AtomApplication.emit (events.js:315:20)
    at AtomApplication.sendCommand (/Users/bongnguyen/projects/pulsar/src/main-process/atom-application.js:1092:15)
    at item.click (/Users/bongnguyen/projects/pulsar/src/main-process/application-menu.js:244:34)
    at MenuItem.click (electron/js2c/browser_init.js:73:1742)
    at Object.a._executeCommand (electron/js2c/browser_init.js:81:2492)
```

### Description of the Change

When an user clicks on File->Open, the event application:open is sent. It's handled in 2 places: `atom-application.js` and
`register-default-commands.coffee`. Because `getDefaultPath()` requires AtomEnvironment which isn't available in the main process, the handler in `atom-application.js` will fail. Although `global.atom` is set in the renderer, Electron 12 seems to separate these 2 environments and as a result global.atom is undefined. Therefore, the fix is to remove that handler so the default handler will be used.

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Possible Drawbacks

Other places using `getDefaultPath` may fail too.

### Verification Process

Open Pulsar, clicks on File > Open to see if a window shows up or not.

### Release Notes

- Fix File->Open not responding
