### PR TITLE
fixed unloaded README from core packages

### DIFF
--- a/script/generate-metadata-for-builder.js
+++ b/script/generate-metadata-for-builder.js
@@ -20,6 +20,8 @@ function buildBundledPackagesMetadata(packageJSON) {
     const packagePath = path.join('node_modules', packageName);
     const packageMetadataPath = path.join(packagePath, 'package.json');
     const packageMetadata = JSON.parse(fs.readFileSync(packageMetadataPath, 'utf8'));
+    const packageReadmePath = path.join(packagePath, 'README.md');
+    packageMetadata.readme = fs.readFileSync(packageReadmePath, 'utf8').toString();
     normalizePackageData(
       packageMetadata,
       msg => {
@@ -45,7 +47,6 @@ function buildBundledPackagesMetadata(packageJSON) {
     delete packageMetadata['_from'];
     delete packageMetadata['_id'];
     delete packageMetadata['dist'];
-    delete packageMetadata['readme'];
     delete packageMetadata['readmeFilename'];
 
     const packageModuleCache = packageMetadata._atomModuleCache || {};


### PR DESCRIPTION
This fixes #57. The problem seemed to be that the `README.md` files are never read. This is one possible fix. Another approach would be to read these files at runtime.

This if condition might be wrong with this change:
https://github.com/pulsar-edit/pulsar/blob/c3c8640ecdd43b85a10421a214e331059e366a6a/script/generate-metadata-for-builder.js#L26-L30