### PR TITLE
Deciding what to build on `yarn dist`

### DIFF
--- a/script/electron-builder.js
+++ b/script/electron-builder.js
@@ -115,8 +115,23 @@ let options = {
   }
 }
 
+function whatToBuild() {
+  const argvStartingWith = process.argv.findIndex(e => e.match('electron-builder.js'))
+  const what = process.argv[argvStartingWith + 1]
+  if(what) {
+    const filter = e => e.target === what
+    options.linux.target = options.linux.target.filter(filter)
+    options.win.target = options.win.target.filter(filter)
+    // options.mac.target = options.mac.target.filter(filter)
+    return options
+  } else {
+    return options
+  }
+}
+
 async function main() {
   const package = await fs.readFile('package.json', "utf-8")
+  let options = whatToBuild()
   options.extraMetadata = generateMetadata(JSON.parse(package))
   builder.build({
     //targets: Platform.LINUX.createTarget(),


### PR DESCRIPTION
`yarn dist` now accepts an argument, that basically allows us to do `yarn dist rpm` and it'll only build the `rpm` version