### PR TITLE
Integrate PPM with Pulsar

### DIFF
--- a/package.json
+++ b/package.json
@@ -161,6 +161,7 @@
     "spell-check": "https://codeload.github.com/atom/spell-check/legacy.tar.gz/refs/tags/v0.77.1",
     "status-bar": "https://codeload.github.com/atom/status-bar/legacy.tar.gz/refs/tags/v1.8.17",
     "styleguide": "https://codeload.github.com/atom/styleguide/legacy.tar.gz/refs/tags/v0.49.12",
+    "superagent": "^8.0.3",
     "superstring": "^2.4.4",
     "symbols-view": "https://codeload.github.com/atom/symbols-view/legacy.tar.gz/refs/tags/v0.118.4",
     "tabs": "https://codeload.github.com/atom/tabs/legacy.tar.gz/refs/tags/v0.110.2",

--- a/src/atom-environment.js
+++ b/src/atom-environment.js
@@ -45,6 +45,7 @@ const TextBuffer = require('text-buffer');
 const TextEditorRegistry = require('./text-editor-registry');
 const AutoUpdateManager = require('./auto-update-manager');
 const StartupTime = require('./startup-time');
+const ppm = require('./ppm');
 const getReleaseChannel = require('./get-release-channel');
 const packagejson = require("../package.json");
 
@@ -220,6 +221,10 @@ class AtomEnvironment {
       commands: this.commands,
       stateStore: this.stateStore
     });
+
+    // Exposes the Integrated PPM Functions
+
+    this.ppm = ppm;
 
     this.branding = {
       id: packagejson.branding.id,

--- a/src/ppm.js
+++ b/src/ppm.js
@@ -6,24 +6,34 @@ const apiUrl = "https://api.pulsar-edit.dev/api";
 
 // Operates on the API Search Endpoint.
 // Takes optional values of `packages` and `themes` to act as a filter for either, similar to the original APM.
-// Takes additional optional values to expose all API parameters compatible with the api server. Taking their same defaults.
-async function search(qs, packages = false, themes = false, page = 0, sort = "relevance", direction = "desc") {
-  if (packages || !themes) {
+// Takes an object, with a required `qs` object as the query, with additional optional arguments.
+async function search(args) {
+  args = {
+    qs: args.qs ? args.qs : "",
+    packages: args.packages ? args.packages : false,
+    themes: args.themes ? args.themes : false,
+    page: args.page ? args.page : 0,
+    sort: args.sort ? args.sort : "relevance",
+    direction: args.direction ? args.direction : "desc"
+  };
+
+  if (args.packages || !args.themes) {
     // default handling for search, and packages specific filtered search
     let res = await superagent
       .get(`${apiUrl}/packages/search`)
-      .query({ sort: sort, page: page, direction: direction, q: qs })
+      .query({ sort: args.sort, page: args.page, direction: args.direction, q: args.qs })
       .then(res => {
+        console.log(res.body);
         return res.body;
       })
       .catch(err => {
         console.log(err);
         return [];
       });
-  } else if (themes) {
+  } else if (args.themes) {
     let res = await superagent
       .get(`${apiUrl}/themes/search`)
-      .query({ sort: sort, page: page, direction: direction, q: qs })
+      .query({ sort: args.sort, page: args.page, direction: args.direction, q: args.qs })
       .then(res => {
         return res.body;
       })

--- a/src/ppm.js
+++ b/src/ppm.js
@@ -2,13 +2,36 @@
 // Allowing PPM to be used as a Global API rather than a totally seperate Package.
 
 const superagent = require("superagent");
-const apiUrl = "https://api.pulsar-edit.com/api";
+const apiUrl = "https://api.pulsar-edit.dev/api";
 
 // Operates on the API Search Endpoint.
 // Takes optional values of `packages` and `themes` to act as a filter for either, similar to the original APM.
 // Takes additional optional values to expose all API parameters compatible with the api server. Taking their same defaults.
-async function search(qs, packages = false, themes = false, page = 1, sort = "relevance", direction = "desc") {
-  
+async function search(qs, packages = false, themes = false, page = 0, sort = "relevance", direction = "desc") {
+  if (packages || !themes) {
+    // default handling for search, and packages specific filtered search
+    let res = await superagent
+      .get(`${apiUrl}/packages/search`)
+      .query({ sort: sort, page: page, direction: direction, q: qs })
+      .then(res => {
+        return res.body;
+      })
+      .catch(err => {
+        console.log(err);
+        return [];
+      });
+  } else if (themes) {
+    let res = await superagent
+      .get(`${apiUrl}/themes/search`)
+      .query({ sort: sort, page: page, direction: direction, q: qs })
+      .then(res => {
+        return res.body;
+      })
+      .catch(err => {
+        console.log(err);
+        return [];
+      });
+  }
 }
 
 module.exports = {

--- a/src/ppm.js
+++ b/src/ppm.js
@@ -17,9 +17,13 @@ async function search(args) {
     direction: args.direction ? args.direction : "desc"
   };
 
+  if (args.qs == "") {
+    return "Missing equired Search String";
+  }
+
   if (args.packages || !args.themes) {
     // default handling for search, and packages specific filtered search
-    let res = await superagent
+    superagent
       .get(`${apiUrl}/packages/search`)
       .query({ sort: args.sort, page: args.page, direction: args.direction, q: args.qs })
       .then(res => {
@@ -28,7 +32,7 @@ async function search(args) {
       })
       .catch(err => {
         console.log(err);
-        return [];
+        return err;
       });
   } else if (args.themes) {
     let res = await superagent
@@ -39,11 +43,29 @@ async function search(args) {
       })
       .catch(err => {
         console.log(err);
-        return [];
+        return err;
       });
   }
 }
 
+async function view(packageName) {
+  if (!packageName || packageName == "") {
+    return "Missing required package name";
+  }
+
+  superagent
+    .get(`${apiUrl}/packages/${packageName}`)
+    .then(res => {
+      console.log(res.body);
+      return res.body;
+    })
+    .catch(err => {
+      console.log(err);
+      return err;
+    });
+}
+
 module.exports = {
   search,
+  view,
 };

--- a/src/ppm.js
+++ b/src/ppm.js
@@ -1,0 +1,16 @@
+// This will be the parent to help expose all PPM functions from the PPM folder.
+// Allowing PPM to be used as a Global API rather than a totally seperate Package.
+
+const superagent = require("superagent");
+const apiUrl = "https://api.pulsar-edit.com/api";
+
+// Operates on the API Search Endpoint.
+// Takes optional values of `packages` and `themes` to act as a filter for either, similar to the original APM.
+// Takes additional optional values to expose all API parameters compatible with the api server. Taking their same defaults.
+async function search(qs, packages = false, themes = false, page = 1, sort = "relevance", direction = "desc") {
+  
+}
+
+module.exports = {
+  search,
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -43,16 +43,6 @@
   dependencies:
     source-map "0.1.32"
 
-"@atom/watcher@^1.3.5":
-  version "1.3.5"
-  resolved "https://registry.yarnpkg.com/@atom/watcher/-/watcher-1.3.5.tgz#30efe6ecb8cf0985116f25765ce467b41bca3d6b"
-  integrity sha512-QP95EnVtpQmlNVL3ravmVBbTDFteRi99CGvlP925d0+WvjPHSPOKYLxDUP3WyT+fCKqW0sboKrpPSwnbMZvCJw==
-  dependencies:
-    event-kit "2.5.3"
-    fs-extra "7.0.1"
-    nan "2.14.1"
-    prebuild-install "5.3.3"
-
 "@babel/cli@^7":
   version "7.18.10"
   resolved "https://registry.yarnpkg.com/@babel/cli/-/cli-7.18.10.tgz#4211adfc45ffa7d4f3cee6b60bb92e9fe68fe56a"
@@ -2072,7 +2062,7 @@ array.prototype.reduce@^1.0.4:
     es-array-method-boxes-properly "^1.0.0"
     is-string "^1.0.7"
 
-asap@~2.0.3:
+asap@^2.0.0, asap@~2.0.3:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/asap/-/asap-2.0.6.tgz#e50347611d7e690943208bbdafebcbc2fb866d46"
   integrity sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==
@@ -3106,6 +3096,11 @@ compare-version@^0.1.2:
   resolved "https://registry.yarnpkg.com/compare-version/-/compare-version-0.1.2.tgz#0162ec2d9351f5ddd59a9202cba935366a725080"
   integrity sha512-pJDh5/4wrEnXX/VWRZvruAGHkzKdr46z11OlTPN+VrATlWWhSKewNCJ1futCO5C7eJB3nPMFZA1LeYtcFboZ2A==
 
+component-emitter@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.3.0.tgz#16e4070fba8ae29b679f2215853ee181ab2eabc0"
+  integrity sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==
+
 compress-commons@^4.1.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/compress-commons/-/compress-commons-4.1.1.tgz#df2a09a7ed17447642bad10a85cc9a19e5c42a7d"
@@ -3162,6 +3157,11 @@ convert-source-map@^1.1.0, convert-source-map@^1.7.0:
   integrity sha512-+OQdjP49zViI/6i7nIJpA8rAl4sV/JdPfU9nZs3VqOwGIgizICvuN2ru6fMd+4llL0tar18UYJXfZ/TWtmhUjA==
   dependencies:
     safe-buffer "~5.1.1"
+
+cookiejar@^2.1.3:
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/cookiejar/-/cookiejar-2.1.3.tgz#fc7a6216e408e74414b90230050842dacda75acc"
+  integrity sha512-JxbCBUdrfr6AQjOXrxoTvAMJO4HBTUIlBzslcJPAz+/KT8yk53fXun51u+RenNYvad/+Vc2DIz5o9UxlCDymFQ==
 
 core-js-compat@^3.21.0, core-js-compat@^3.22.1, core-js-compat@^3.6.2:
   version "3.25.3"
@@ -3515,6 +3515,14 @@ devtron@1.4.0:
     accessibility-developer-tools "^2.11.0"
     highlight.js "^9.3.0"
     humanize-plus "^1.8.1"
+
+dezalgo@1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/dezalgo/-/dezalgo-1.0.3.tgz#7f742de066fc748bc8db820569dddce49bf0d456"
+  integrity sha512-K7i4zNfT2kgQz3GylDw40ot9GAE47sFZ9EXHFSPP6zONLgH6kWXE0KWJchkbQJLBkRazq4APwZ4OwiFFlT95OQ==
+  dependencies:
+    asap "^2.0.0"
+    wrappy "1"
 
 diff@3.5.0:
   version "3.5.0"
@@ -4119,6 +4127,11 @@ fast-json-stable-stringify@^2.0.0:
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz#874bf69c6f404c2b5d99c481341399fd55892633"
   integrity sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==
 
+fast-safe-stringify@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz#c406a83b6e70d9e35ce3b30a81141df30aeba884"
+  integrity sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==
+
 fbjs-css-vars@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/fbjs-css-vars/-/fbjs-css-vars-1.0.2.tgz#216551136ae02fe255932c3ec8775f18e2c078b8"
@@ -4261,6 +4274,16 @@ form-data@~2.3.2:
     combined-stream "^1.0.6"
     mime-types "^2.1.12"
 
+formidable@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/formidable/-/formidable-2.0.1.tgz#4310bc7965d185536f9565184dee74fbb75557ff"
+  integrity sha512-rjTMNbp2BpfQShhFbR3Ruk3qk2y9jKpvMW78nJgx8QKtxjDVrwbZG+wvDOmVbifHyOUOQJXxqEy6r0faRrPzTQ==
+  dependencies:
+    dezalgo "1.0.3"
+    hexoid "1.0.0"
+    once "1.4.0"
+    qs "6.9.3"
+
 from@~0:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/from/-/from-0.1.7.tgz#83c60afc58b9c56997007ed1a768b3ab303a44fe"
@@ -4283,15 +4306,6 @@ fs-extra@4.0.3:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-4.0.3.tgz#0d852122e5bc5beb453fb028e9c0c9bf36340c94"
   integrity sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==
-  dependencies:
-    graceful-fs "^4.1.2"
-    jsonfile "^4.0.0"
-    universalify "^0.1.0"
-
-fs-extra@7.0.1:
-  version "7.0.1"
-  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-7.0.1.tgz#4f189c44aa123b895f722804f55ea23eadc348e9"
-  integrity sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==
   dependencies:
     graceful-fs "^4.1.2"
     jsonfile "^4.0.0"
@@ -4864,6 +4878,11 @@ he@1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
+
+hexoid@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/hexoid/-/hexoid-1.0.0.tgz#ad10c6573fb907de23d9ec63a711267d9dc9bc18"
+  integrity sha512-QFLV0taWQOZtvIRIAdBChesmogZrtuXvVWsFHZTk2SU+anspqZ2vMnoLg7IE1+Uk16N19APic1BuF8bC8c2m5g==
 
 highlight.js@^9.3.0:
   version "9.18.5"
@@ -6093,6 +6112,11 @@ md5@^2.1.0:
     crypt "0.0.2"
     is-buffer "~1.1.6"
 
+methods@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/methods/-/methods-1.1.2.tgz#5529a4d67654134edcc5266656835b0f851afcee"
+  integrity sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==
+
 mime-db@1.52.0:
   version "1.52.0"
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.52.0.tgz#bbabcdc02859f4987301c856e3387ce5ec43bf70"
@@ -6105,15 +6129,15 @@ mime-types@^2.1.12, mime-types@~2.1.19, mime-types@~2.1.7:
   dependencies:
     mime-db "1.52.0"
 
+mime@2.6.0, mime@^2.5.2:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/mime/-/mime-2.6.0.tgz#a2a682a95cd4d0cb1d6257e28f83da7e35800367"
+  integrity sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==
+
 mime@^1.2.11:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.6.0.tgz#32cd9e5c64553bd58d19a568af452acff04981b1"
   integrity sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==
-
-mime@^2.5.2:
-  version "2.6.0"
-  resolved "https://registry.yarnpkg.com/mime/-/mime-2.6.0.tgz#a2a682a95cd4d0cb1d6257e28f83da7e35800367"
-  integrity sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==
 
 mimic-fn@^2.1.0:
   version "2.1.0"
@@ -6396,11 +6420,6 @@ nan@2.14.0:
   version "2.14.0"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.0.tgz#7818f722027b2459a86f0295d434d1fc2336c52c"
   integrity sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==
-
-nan@2.14.1:
-  version "2.14.1"
-  resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.1.tgz#d7be34dfa3105b91494c3147089315eff8874b01"
-  integrity sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw==
 
 nan@^2.10.0, nan@^2.12.1, nan@^2.13.2, nan@^2.14.0, nan@^2.14.1, nan@^2.14.2:
   version "2.16.0"
@@ -6719,7 +6738,7 @@ object.getownpropertydescriptors@^2.0.3:
     define-properties "^1.1.4"
     es-abstract "^1.20.1"
 
-once@^1.3.0, once@^1.3.1, once@^1.4.0:
+once@1.4.0, once@^1.3.0, once@^1.3.1, once@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
   integrity sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==
@@ -7066,27 +7085,6 @@ prebuild-install@5.3.0:
     tunnel-agent "^0.6.0"
     which-pm-runs "^1.0.0"
 
-prebuild-install@5.3.3:
-  version "5.3.3"
-  resolved "https://registry.yarnpkg.com/prebuild-install/-/prebuild-install-5.3.3.tgz#ef4052baac60d465f5ba6bf003c9c1de79b9da8e"
-  integrity sha512-GV+nsUXuPW2p8Zy7SarF/2W/oiK8bFQgJcncoJ0d7kRpekEA0ftChjfEaF9/Y+QJEc/wFR7RAEa8lYByuUIe2g==
-  dependencies:
-    detect-libc "^1.0.3"
-    expand-template "^2.0.3"
-    github-from-package "0.0.0"
-    minimist "^1.2.0"
-    mkdirp "^0.5.1"
-    napi-build-utils "^1.0.1"
-    node-abi "^2.7.0"
-    noop-logger "^0.1.1"
-    npmlog "^4.0.1"
-    pump "^3.0.0"
-    rc "^1.2.7"
-    simple-get "^3.0.3"
-    tar-fs "^2.0.0"
-    tunnel-agent "^0.6.0"
-    which-pm-runs "^1.0.0"
-
 prebuild-install@6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/prebuild-install/-/prebuild-install-6.0.0.tgz#669022bcde57c710a869e39c5ca6bf9cd207f316"
@@ -7287,6 +7285,18 @@ puppeteer-core@^13.1.3:
     tar-fs "2.1.1"
     unbzip2-stream "1.4.3"
     ws "8.5.0"
+
+qs@6.9.3:
+  version "6.9.3"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.9.3.tgz#bfadcd296c2d549f1dffa560619132c977f5008e"
+  integrity sha512-EbZYNarm6138UKKq46tdx08Yo/q9ZhFoAXAI1meAFd2GtbRDhbZY2WQSICskT0c5q99aFzLG1D4nvTk9tqfXIw==
+
+qs@^6.11.0:
+  version "6.11.0"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.11.0.tgz#fd0d963446f7a65e1367e01abd85429453f0c37a"
+  integrity sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==
+  dependencies:
+    side-channel "^1.0.4"
 
 qs@~6.4.0:
   version "6.4.1"
@@ -7827,6 +7837,13 @@ semver@^7.3.2, semver@^7.3.4, semver@^7.3.5, semver@^7.3.7:
   dependencies:
     lru-cache "^6.0.0"
 
+semver@^7.3.8:
+  version "7.3.8"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.8.tgz#07a78feafb3f7b32347d725e33de7e2a2df67798"
+  integrity sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==
+  dependencies:
+    lru-cache "^6.0.0"
+
 serializable@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/serializable/-/serializable-1.0.3.tgz#0a5a8b6b7777cb24544df11a6f889a6d2b3e1189"
@@ -8320,6 +8337,22 @@ sumchecker@^3.0.1:
   integrity sha512-MvjXzkz/BOfyVDkG0oFOtBxHX2u3gKbMHIF/dXblZsgD3BWOFLmHovIpZY7BykJdAjcqRCBi1WYBNdEC9yI7vg==
   dependencies:
     debug "^4.1.0"
+
+superagent@^8.0.3:
+  version "8.0.3"
+  resolved "https://registry.yarnpkg.com/superagent/-/superagent-8.0.3.tgz#15c8ec5611a1f01386994cfeeda5aa138bcb7b17"
+  integrity sha512-oBC+aNsCjzzjmO5AOPBPFS+Z7HPzlx+DQr/aHwM08kI+R24gsDmAS1LMfza1fK+P+SKlTAoNZpOvooE/pRO1HA==
+  dependencies:
+    component-emitter "^1.3.0"
+    cookiejar "^2.1.3"
+    debug "^4.3.4"
+    fast-safe-stringify "^2.1.1"
+    form-data "^4.0.0"
+    formidable "^2.0.1"
+    methods "^1.1.2"
+    mime "2.6.0"
+    qs "^6.11.0"
+    semver "^7.3.8"
 
 superstring@^2.4.4:
   version "2.4.4"


### PR DESCRIPTION
While currently a draft and requiring much more work...

---

This PR integrates PPM into Pulsar Core as discussed on GitHub. This would mean that the abilities of PPM are exposed as an `atom` global API, while additionally still allowing it to be used as a CLI application.

This could mean that things like `pulsar-edit/settings-view` could just take advantage of the PPM application and greatly reduce the complexity within, as well as any other location that needs to interact with the API itself.

The API for this new Global `atom` API will need to be documented on the website, and ideally will be complete once this PR is complete as well.

The advantage of this is to reduce our tech debt of having to maintain APM/PPM as a separate submodule/repo, and hopefully will be able to find a way around the bundled Node versioning of APM/PPM and the bundled NPM of APM/PPM. Additionally we hope this PR can find a way to work around deeply integrated git connections. But that is currently yet to be seen as this PR is created. Just publishing this as a PR so other Core contributors can see how this evolves and is intended to work.

This text of this PR of course will be updated when it is complete. Any and all suggestions are welcome.

---

## Dependencies:

* `superagent`: This PR does add another dependency to  the Editor Codebase of `superagent` this is what is used to contact the remote API itself.
