### PR TITLE
rename global to core

### DIFF
--- a/benchmarks/benchmark-runner.js
+++ b/benchmarks/benchmark-runner.js
@@ -67,7 +67,7 @@ module.exports = async ({ test, benchmarkPaths }) => {
         console.log(textualOutput);
       }
 
-      await global.atom.reset();
+      await global.core.reset();
     }
   }
 

--- a/benchmarks/text-editor-large-file-construction.bench.js
+++ b/benchmarks/text-editor-large-file-construction.bench.js
@@ -11,12 +11,12 @@ const TEXT = LINE_TEXT.repeat(
 module.exports = async ({ test }) => {
   const data = [];
 
-  document.body.appendChild(atom.workspace.getElement());
+  document.body.appendChild(core.workspace.getElement());
 
-  atom.packages.loadPackages();
-  await atom.packages.activate();
+  core.packages.loadPackages();
+  await core.packages.activate();
 
-  for (let pane of atom.workspace.getPanes()) {
+  for (let pane of core.workspace.getPanes()) {
     pane.destroy();
   }
 
@@ -35,8 +35,8 @@ module.exports = async ({ test }) => {
       autoHeight: false,
       largeFileMode: true
     });
-    atom.grammars.autoAssignLanguageMode(buffer);
-    atom.workspace.getActivePane().activateItem(editor);
+    core.grammars.autoAssignLanguageMode(buffer);
+    core.workspace.getActivePane().activateItem(editor);
     let t1 = window.performance.now();
 
     data.push({
@@ -90,7 +90,7 @@ module.exports = async ({ test }) => {
     await timeout(10000);
   }
 
-  atom.workspace.getElement().remove();
+  core.workspace.getElement().remove();
 
   return data;
 };

--- a/benchmarks/text-editor-long-lines.bench.js
+++ b/benchmarks/text-editor-long-lines.bench.js
@@ -16,15 +16,15 @@ const TEXT = REPEATED_TEXT.repeat(
 module.exports = async ({ test }) => {
   const data = [];
 
-  const workspaceElement = atom.workspace.getElement();
+  const workspaceElement = core.workspace.getElement();
   document.body.appendChild(workspaceElement);
 
-  atom.packages.loadPackages();
-  await atom.packages.activate();
+  core.packages.loadPackages();
+  await core.packages.activate();
 
-  console.log(atom.getLoadSettings().resourcePath);
+  console.log(core.getLoadSettings().resourcePath);
 
-  for (let pane of atom.workspace.getPanes()) {
+  for (let pane of core.workspace.getPanes()) {
     pane.destroy();
   }
 
@@ -39,8 +39,8 @@ module.exports = async ({ test }) => {
       autoHeight: false,
       largeFileMode: true
     });
-    atom.grammars.assignLanguageMode(buffer, 'source.js');
-    atom.workspace.getActivePane().activateItem(editor);
+    core.grammars.assignLanguageMode(buffer, 'source.js');
+    core.workspace.getActivePane().activateItem(editor);
     let t1 = window.performance.now();
 
     data.push({

--- a/dot-atom/init.coffee
+++ b/dot-atom/init.coffee
@@ -6,6 +6,6 @@
 #
 # An example hack to log to the console when each text editor is saved.
 #
-# atom.workspace.observeTextEditors (editor) ->
+# core.workspace.observeTextEditors (editor) ->
 #   editor.onDidSave ->
 #     console.log "Saved! #{editor.getPath()}"

--- a/packages/about/lib/about.js
+++ b/packages/about/lib/about.js
@@ -15,7 +15,7 @@ module.exports = class About {
     };
 
     this.subscriptions.add(
-      atom.workspace.addOpener(uriToOpen => {
+      core.workspace.addOpener(uriToOpen => {
         if (uriToOpen === this.state.uri) {
           return this.deserialize();
         }
@@ -23,7 +23,7 @@ module.exports = class About {
     );
 
     this.subscriptions.add(
-      atom.commands.add('atom-workspace', 'about:view-release-notes', () => {
+      core.commands.add('atom-workspace', 'about:view-release-notes', () => {
         shell = shell || require('electron').shell;
         shell.openExternal(
           this.state.updateManager.getReleaseNotesURLForCurrentVersion()

--- a/packages/about/lib/components/about-status-bar.js
+++ b/packages/about/lib/components/about-status-bar.js
@@ -10,7 +10,7 @@ module.exports = class AboutStatusBar extends EtchComponent {
     this.subscriptions = new CompositeDisposable();
 
     this.subscriptions.add(
-      atom.tooltips.add(this.element, {
+      core.tooltips.add(this.element, {
         title:
           'An update will be installed the next time Pulsar is relaunched.<br/><br/>Click the squirrel icon for more information.'
       })
@@ -18,7 +18,7 @@ module.exports = class AboutStatusBar extends EtchComponent {
   }
 
   handleClick() {
-    atom.workspace.open('atom://about');
+    core.workspace.open('atom://about');
   }
 
   render() {

--- a/packages/about/lib/components/about-view.js
+++ b/packages/about/lib/components/about-view.js
@@ -10,22 +10,22 @@ const $ = etch.dom;
 module.exports = class AboutView extends EtchComponent {
   handleAtomVersionClick(e) {
     e.preventDefault();
-    atom.clipboard.write(this.props.currentAtomVersion);
+    core.clipboard.write(this.props.currentAtomVersion);
   }
 
   handleElectronVersionClick(e) {
     e.preventDefault();
-    atom.clipboard.write(this.props.currentElectronVersion);
+    core.clipboard.write(this.props.currentElectronVersion);
   }
 
   handleChromeVersionClick(e) {
     e.preventDefault();
-    atom.clipboard.write(this.props.currentChromeVersion);
+    core.clipboard.write(this.props.currentChromeVersion);
   }
 
   handleNodeVersionClick(e) {
     e.preventDefault();
-    atom.clipboard.write(this.props.currentNodeVersion);
+    core.clipboard.write(this.props.currentNodeVersion);
   }
 
   handleReleaseNotesClick(e) {
@@ -37,8 +37,8 @@ module.exports = class AboutView extends EtchComponent {
 
   handleLicenseClick(e) {
     e.preventDefault();
-    atom.commands.dispatch(
-      atom.views.getView(atom.workspace),
+    core.commands.dispatch(
+      core.views.getView(core.workspace),
       'application:open-license'
     );
   }

--- a/packages/about/lib/components/update-view.js
+++ b/packages/about/lib/components/update-view.js
@@ -17,7 +17,7 @@ module.exports = class UpdateView extends EtchComponent {
   }
 
   handleAutoUpdateCheckbox(e) {
-    atom.config.set('core.automaticallyUpdate', e.target.checked);
+    core.config.set('core.automaticallyUpdate', e.target.checked);
   }
 
   shouldUpdateActionButtonBeDisabled() {

--- a/packages/about/lib/etch-component.js
+++ b/packages/about/lib/etch-component.js
@@ -9,7 +9,7 @@ module.exports = class EtchComponent {
     this.props = props;
 
     etch.initialize(this);
-    EtchComponent.setScheduler(atom.views);
+    EtchComponent.setScheduler(core.views);
   }
 
   /*

--- a/packages/about/lib/main.js
+++ b/packages/about/lib/main.js
@@ -17,8 +17,8 @@ module.exports = {
 
     let availableVersion = window.localStorage.getItem(AvailableUpdateVersion);
     if (
-      atom.getReleaseChannel() === 'dev' ||
-      (availableVersion && semver.lte(availableVersion, atom.getVersion()))
+      core.getReleaseChannel() === 'dev' ||
+      (availableVersion && semver.lte(availableVersion, core.getVersion()))
     ) {
       this.clearUpdateState();
     }
@@ -39,7 +39,7 @@ module.exports = {
     );
 
     this.subscriptions.add(
-      atom.commands.add('atom-workspace', 'about:clear-update-state', () => {
+      core.commands.add('atom-workspace', 'about:clear-update-state', () => {
         this.clearUpdateState();
       })
     );
@@ -77,7 +77,7 @@ module.exports = {
 
     this.model = new About({
       uri: AboutURI,
-      currentAtomVersion: atom.getVersion(),
+      currentAtomVersion: core.getVersion(),
       currentElectronVersion: process.versions.electron,
       currentChromeVersion: process.versions.chrome,
       currentNodeVersion: process.version,
@@ -87,7 +87,7 @@ module.exports = {
 
   isUpdateAvailable() {
     let availableVersion = window.localStorage.getItem(AvailableUpdateVersion);
-    return availableVersion && semver.gt(availableVersion, atom.getVersion());
+    return availableVersion && semver.gt(availableVersion, core.getVersion());
   },
 
   showStatusBarIfNeeded() {

--- a/packages/about/lib/update-manager.js
+++ b/packages/about/lib/update-manager.js
@@ -11,8 +11,8 @@ const ErrorState = 'error';
 let UpdateManager = class UpdateManager {
   constructor() {
     this.emitter = new Emitter();
-    this.currentVersion = atom.getVersion();
-    this.availableVersion = atom.getVersion();
+    this.currentVersion = core.getVersion();
+    this.availableVersion = core.getVersion();
     this.resetState();
     this.listenForAtomEvents();
   }
@@ -21,29 +21,29 @@ let UpdateManager = class UpdateManager {
     this.subscriptions = new CompositeDisposable();
 
     this.subscriptions.add(
-      atom.autoUpdater.onDidBeginCheckingForUpdate(() => {
+      core.autoUpdater.onDidBeginCheckingForUpdate(() => {
         this.setState(CheckingForUpdate);
       }),
-      atom.autoUpdater.onDidBeginDownloadingUpdate(() => {
+      core.autoUpdater.onDidBeginDownloadingUpdate(() => {
         this.setState(DownloadingUpdate);
       }),
-      atom.autoUpdater.onDidCompleteDownloadingUpdate(({ releaseVersion }) => {
+      core.autoUpdater.onDidCompleteDownloadingUpdate(({ releaseVersion }) => {
         this.setAvailableVersion(releaseVersion);
       }),
-      atom.autoUpdater.onUpdateNotAvailable(() => {
+      core.autoUpdater.onUpdateNotAvailable(() => {
         this.setState(UpToDate);
       }),
-      atom.autoUpdater.onUpdateError(() => {
+      core.autoUpdater.onUpdateError(() => {
         this.setState(ErrorState);
       }),
-      atom.config.observe('core.automaticallyUpdate', value => {
+      core.config.observe('core.automaticallyUpdate', value => {
         this.autoUpdatesEnabled = value;
         this.emitDidChange();
       })
     );
 
     // TODO: When https://github.com/atom/electron/issues/4587 is closed we can add this support.
-    // atom.autoUpdater.onUpdateAvailable =>
+    // core.autoUpdater.onUpdateAvailable =>
     //   @find('.about-updates-item').removeClass('is-shown')
     //   @updateAvailable.addClass('is-shown')
   }
@@ -67,11 +67,11 @@ let UpdateManager = class UpdateManager {
   }
 
   setAutoUpdatesEnabled(enabled) {
-    return atom.config.set('core.automaticallyUpdate', enabled);
+    return core.config.set('core.automaticallyUpdate', enabled);
   }
 
   getErrorMessage() {
-    return atom.autoUpdater.getErrorMessage();
+    return core.autoUpdater.getErrorMessage();
   }
 
   getState() {
@@ -84,8 +84,8 @@ let UpdateManager = class UpdateManager {
   }
 
   resetState() {
-    this.state = atom.autoUpdater.platformSupportsUpdates()
-      ? atom.autoUpdater.getState()
+    this.state = core.autoUpdater.platformSupportsUpdates()
+      ? core.autoUpdater.getState()
       : Unsupported;
     this.emitDidChange();
   }
@@ -107,11 +107,11 @@ let UpdateManager = class UpdateManager {
   }
 
   checkForUpdate() {
-    atom.autoUpdater.checkForUpdate();
+    core.autoUpdater.checkForUpdate();
   }
 
   restartAndInstallUpdate() {
-    atom.autoUpdater.restartAndInstallUpdate();
+    core.autoUpdater.restartAndInstallUpdate();
   }
 
   getReleaseNotesURLForCurrentVersion() {

--- a/packages/about/spec/about-spec.js
+++ b/packages/about/spec/about-spec.js
@@ -11,12 +11,12 @@ describe('About', () => {
       return storage[key];
     });
 
-    workspaceElement = atom.views.getView(atom.workspace);
-    await atom.packages.activatePackage('about');
+    workspaceElement = core.views.getView(core.workspace);
+    await core.packages.activatePackage('about');
   });
 
   it('deserializes correctly', () => {
-    let deserializedAboutView = atom.deserializers.deserialize({
+    let deserializedAboutView = core.deserializers.deserialize({
       deserializer: 'AboutView',
       uri: 'atom://about'
     });
@@ -33,7 +33,7 @@ describe('About', () => {
       jasmine.attachToDOM(workspaceElement);
 
       expect(workspaceElement.querySelector('.about')).not.toExist();
-      await atom.workspace.open('atom://about');
+      await core.workspace.open('atom://about');
 
       let aboutElement = workspaceElement.querySelector('.about');
       expect(aboutElement).toBeVisible();
@@ -42,19 +42,19 @@ describe('About', () => {
 
   describe('when the Atom version number is clicked', () => {
     it('copies the version number to the clipboard', async () => {
-      await atom.workspace.open('atom://about');
+      await core.workspace.open('atom://about');
       jasmine.attachToDOM(workspaceElement);
 
       let aboutElement = workspaceElement.querySelector('.about');
       let versionContainer = aboutElement.querySelector('.atom');
       versionContainer.click();
-      expect(atom.clipboard.read()).toBe(atom.getVersion());
+      expect(core.clipboard.read()).toBe(core.getVersion());
     });
   });
 
   describe('when the show more link is clicked', () => {
     it('expands to show additional version numbers', async () => {
-      await atom.workspace.open('atom://about');
+      await core.workspace.open('atom://about');
       jasmine.attachToDOM(workspaceElement);
 
       let aboutElement = workspaceElement.querySelector('.about');
@@ -67,37 +67,37 @@ describe('About', () => {
 
   describe('when the Electron version number is clicked', () => {
     it('copies the version number to the clipboard', async () => {
-      await atom.workspace.open('atom://about');
+      await core.workspace.open('atom://about');
       jasmine.attachToDOM(workspaceElement);
 
       let aboutElement = workspaceElement.querySelector('.about');
       let versionContainer = aboutElement.querySelector('.electron');
       versionContainer.click();
-      expect(atom.clipboard.read()).toBe(process.versions.electron);
+      expect(core.clipboard.read()).toBe(process.versions.electron);
     });
   });
 
   describe('when the Chrome version number is clicked', () => {
     it('copies the version number to the clipboard', async () => {
-      await atom.workspace.open('atom://about');
+      await core.workspace.open('atom://about');
       jasmine.attachToDOM(workspaceElement);
 
       let aboutElement = workspaceElement.querySelector('.about');
       let versionContainer = aboutElement.querySelector('.chrome');
       versionContainer.click();
-      expect(atom.clipboard.read()).toBe(process.versions.chrome);
+      expect(core.clipboard.read()).toBe(process.versions.chrome);
     });
   });
 
   describe('when the Node version number is clicked', () => {
     it('copies the version number to the clipboard', async () => {
-      await atom.workspace.open('atom://about');
+      await core.workspace.open('atom://about');
       jasmine.attachToDOM(workspaceElement);
 
       let aboutElement = workspaceElement.querySelector('.about');
       let versionContainer = aboutElement.querySelector('.node');
       versionContainer.click();
-      expect(atom.clipboard.read()).toBe(process.version);
+      expect(core.clipboard.read()).toBe(process.version);
     });
   });
 });

--- a/packages/about/spec/about-status-bar-spec.js
+++ b/packages/about/spec/about-status-bar-spec.js
@@ -14,27 +14,27 @@ describe('the status bar', () => {
     spyOn(window.localStorage, 'getItem').andCallFake(key => {
       return storage[key];
     });
-    spyOn(atom, 'getVersion').andCallFake(() => {
-      return atomVersion;
+    spyOn(core, 'getVersion').andCallFake(() => {
+      return coreVersion;
     });
 
-    workspaceElement = atom.views.getView(atom.workspace);
+    workspaceElement = core.views.getView(core.workspace);
 
-    await atom.packages.activatePackage('status-bar');
-    await atom.workspace.open('sample.js');
+    await core.packages.activatePackage('status-bar');
+    await core.workspace.open('sample.js');
     jasmine.attachToDOM(workspaceElement);
   });
 
   afterEach(async () => {
-    await atom.packages.deactivatePackage('about');
-    await atom.packages.deactivatePackage('status-bar');
+    await core.packages.deactivatePackage('about');
+    await core.packages.deactivatePackage('status-bar');
   });
 
   describe('on a stable version', function() {
     beforeEach(async () => {
       atomVersion = '1.2.3';
 
-      await atom.packages.activatePackage('about');
+      await core.packages.activatePackage('about');
     });
 
     describe('with no update', () => {
@@ -64,18 +64,18 @@ describe('the status bar', () => {
         MockUpdater.finishDownloadingUpdate('42.0.0');
         expect(workspaceElement).toContain('.about-release-notes');
 
-        await atom.packages.deactivatePackage('about');
+        await core.packages.deactivatePackage('about');
         expect(workspaceElement).not.toContain('.about-release-notes');
 
-        await atom.packages.activatePackage('about');
+        await core.packages.activatePackage('about');
         await Promise.resolve(); // Service consumption hooks are deferred until the next tick
         expect(workspaceElement).toContain('.about-release-notes');
 
-        await atom.packages.deactivatePackage('about');
+        await core.packages.deactivatePackage('about');
         expect(workspaceElement).not.toContain('.about-release-notes');
 
         atomVersion = '42.0.0';
-        await atom.packages.activatePackage('about');
+        await core.packages.activatePackage('about');
 
         await Promise.resolve(); // Service consumption hooks are deferred until the next tick
         expect(workspaceElement).not.toContain('.about-release-notes');
@@ -84,10 +84,10 @@ describe('the status bar', () => {
       it('does not show the view if Atom is updated to a newer version than notified', async () => {
         MockUpdater.finishDownloadingUpdate('42.0.0');
 
-        await atom.packages.deactivatePackage('about');
+        await core.packages.deactivatePackage('about');
 
         atomVersion = '43.0.0';
-        await atom.packages.activatePackage('about');
+        await core.packages.activatePackage('about');
 
         await Promise.resolve(); // Service consumption hooks are deferred until the next tick
         expect(workspaceElement).not.toContain('.about-release-notes');
@@ -99,7 +99,7 @@ describe('the status bar', () => {
     beforeEach(async () => {
       atomVersion = '1.2.3-beta4';
 
-      await atom.packages.activatePackage('about');
+      await core.packages.activatePackage('about');
     });
 
     describe('with no update', () => {
@@ -129,18 +129,18 @@ describe('the status bar', () => {
         MockUpdater.finishDownloadingUpdate('42.0.0');
         expect(workspaceElement).toContain('.about-release-notes');
 
-        await atom.packages.deactivatePackage('about');
+        await core.packages.deactivatePackage('about');
         expect(workspaceElement).not.toContain('.about-release-notes');
 
-        await atom.packages.activatePackage('about');
+        await core.packages.activatePackage('about');
         await Promise.resolve(); // Service consumption hooks are deferred until the next tick
         expect(workspaceElement).toContain('.about-release-notes');
 
-        await atom.packages.deactivatePackage('about');
+        await core.packages.deactivatePackage('about');
         expect(workspaceElement).not.toContain('.about-release-notes');
 
         atomVersion = '42.0.0';
-        await atom.packages.activatePackage('about');
+        await core.packages.activatePackage('about');
 
         await Promise.resolve(); // Service consumption hooks are deferred until the next tick
         expect(workspaceElement).not.toContain('.about-release-notes');
@@ -149,10 +149,10 @@ describe('the status bar', () => {
       it('does not show the view if Atom is updated to a newer version than notified', async () => {
         MockUpdater.finishDownloadingUpdate('42.0.0');
 
-        await atom.packages.deactivatePackage('about');
+        await core.packages.deactivatePackage('about');
 
         atomVersion = '43.0.0';
-        await atom.packages.activatePackage('about');
+        await core.packages.activatePackage('about');
 
         await Promise.resolve(); // Service consumption hooks are deferred until the next tick
         expect(workspaceElement).not.toContain('.about-release-notes');
@@ -164,7 +164,7 @@ describe('the status bar', () => {
     beforeEach(async () => {
       atomVersion = '1.2.3-dev-0123abcd';
 
-      await atom.packages.activatePackage('about');
+      await core.packages.activatePackage('about');
     });
 
     describe('with no update', () => {

--- a/packages/about/spec/about-status-bar-spec.js
+++ b/packages/about/spec/about-status-bar-spec.js
@@ -15,7 +15,7 @@ describe('the status bar', () => {
       return storage[key];
     });
     spyOn(core, 'getVersion').andCallFake(() => {
-      return coreVersion;
+      return atomVersion;
     });
 
     workspaceElement = core.views.getView(core.workspace);

--- a/packages/about/spec/mocks/updater.js
+++ b/packages/about/spec/mocks/updater.js
@@ -1,22 +1,22 @@
 module.exports = {
   updateError() {
-    atom.autoUpdater.emitter.emit('update-error');
+    core.autoUpdater.emitter.emit('update-error');
   },
 
   checkForUpdate() {
-    atom.autoUpdater.emitter.emit('did-begin-checking-for-update');
+    core.autoUpdater.emitter.emit('did-begin-checking-for-update');
   },
 
   updateNotAvailable() {
-    atom.autoUpdater.emitter.emit('update-not-available');
+    core.autoUpdater.emitter.emit('update-not-available');
   },
 
   downloadUpdate() {
-    atom.autoUpdater.emitter.emit('did-begin-downloading-update');
+    core.autoUpdater.emitter.emit('did-begin-downloading-update');
   },
 
   finishDownloadingUpdate(releaseVersion) {
-    atom.autoUpdater.emitter.emit('did-complete-downloading-update', {
+    core.autoUpdater.emitter.emit('did-complete-downloading-update', {
       releaseVersion
     });
   }

--- a/packages/about/spec/update-view-spec.js
+++ b/packages/about/spec/update-view-spec.js
@@ -20,17 +20,17 @@ describe('UpdateView', () => {
       return storage[key];
     });
 
-    workspaceElement = atom.views.getView(atom.workspace);
-    await atom.packages.activatePackage('about');
-    spyOn(atom.autoUpdater, 'getState').andReturn('idle');
-    spyOn(atom.autoUpdater, 'checkForUpdate');
-    spyOn(atom.autoUpdater, 'platformSupportsUpdates').andReturn(true);
+    workspaceElement = core.views.getView(core.workspace);
+    await core.packages.activatePackage('about');
+    spyOn(core.autoUpdater, 'getState').andReturn('idle');
+    spyOn(core.autoUpdater, 'checkForUpdate');
+    spyOn(core.autoUpdater, 'platformSupportsUpdates').andReturn(true);
   });
 
   describe('when the About page is open', () => {
     beforeEach(async () => {
       jasmine.attachToDOM(workspaceElement);
-      await atom.workspace.open('atom://about');
+      await core.workspace.open('atom://about');
       aboutElement = workspaceElement.querySelector('.about');
       updateManager = main.model.state.updateManager;
       scheduler = AboutView.getScheduler();
@@ -38,7 +38,7 @@ describe('UpdateView', () => {
 
     describe('when the updates are not supported by the platform', () => {
       beforeEach(async () => {
-        atom.autoUpdater.platformSupportsUpdates.andReturn(false);
+        core.autoUpdater.platformSupportsUpdates.andReturn(false);
         updateManager.resetState();
         await scheduler.getNextUpdatePromise();
       });
@@ -67,7 +67,7 @@ describe('UpdateView', () => {
 
     describe('when updates are supported by the platform', () => {
       beforeEach(async () => {
-        atom.autoUpdater.platformSupportsUpdates.andReturn(true);
+        core.autoUpdater.platformSupportsUpdates.andReturn(true);
         updateManager.resetState();
         await scheduler.getNextUpdatePromise();
       });
@@ -108,7 +108,7 @@ describe('UpdateView', () => {
           aboutElement.querySelector('.app-checking-for-updates')
         ).toBeVisible();
 
-        spyOn(atom.autoUpdater, 'getErrorMessage').andReturn(
+        spyOn(core.autoUpdater, 'getErrorMessage').andReturn(
           'an error message'
         );
         MockUpdater.updateError();
@@ -209,21 +209,21 @@ describe('UpdateView', () => {
       it('executes checkForUpdate() when the check for update button is clicked', () => {
         let button = aboutElement.querySelector('.about-update-action-button');
         button.click();
-        expect(atom.autoUpdater.checkForUpdate).toHaveBeenCalled();
+        expect(core.autoUpdater.checkForUpdate).toHaveBeenCalled();
       });
 
       it('executes restartAndInstallUpdate() when the restart and install button is clicked', async () => {
-        spyOn(atom.autoUpdater, 'restartAndInstallUpdate');
+        spyOn(core.autoUpdater, 'restartAndInstallUpdate');
         MockUpdater.finishDownloadingUpdate('42.0.0');
         await scheduler.getNextUpdatePromise();
 
         let button = aboutElement.querySelector('.about-update-action-button');
         button.click();
-        expect(atom.autoUpdater.restartAndInstallUpdate).toHaveBeenCalled();
+        expect(core.autoUpdater.restartAndInstallUpdate).toHaveBeenCalled();
       });
 
       it("starts in the same state as atom's AutoUpdateManager", async () => {
-        atom.autoUpdater.getState.andReturn('downloading');
+        core.autoUpdater.getState.andReturn('downloading');
         updateManager.resetState();
 
         await scheduler.getNextUpdatePromise();
@@ -243,8 +243,8 @@ describe('UpdateView', () => {
 
       describe('when core.automaticallyUpdate is toggled', () => {
         beforeEach(async () => {
-          expect(atom.config.get('core.automaticallyUpdate')).toBe(true);
-          atom.autoUpdater.checkForUpdate.reset();
+          expect(core.config.get('core.automaticallyUpdate')).toBe(true);
+          core.autoUpdater.checkForUpdate.reset();
         });
 
         it('shows the auto update UI', async () => {
@@ -259,7 +259,7 @@ describe('UpdateView', () => {
               .textContent
           ).toBe('Atom will check for updates automatically');
 
-          atom.config.set('core.automaticallyUpdate', false);
+          core.config.set('core.automaticallyUpdate', false);
           await scheduler.getNextUpdatePromise();
 
           expect(
@@ -282,7 +282,7 @@ describe('UpdateView', () => {
           aboutElement.querySelector('.about-auto-updates input').click();
           await scheduler.getNextUpdatePromise();
 
-          expect(atom.config.get('core.automaticallyUpdate')).toBe(false);
+          expect(core.config.get('core.automaticallyUpdate')).toBe(false);
           expect(
             aboutElement.querySelector('.about-auto-updates input').checked
           ).toBe(false);
@@ -297,7 +297,7 @@ describe('UpdateView', () => {
           aboutElement.querySelector('.about-auto-updates input').click();
           await scheduler.getNextUpdatePromise();
 
-          expect(atom.config.get('core.automaticallyUpdate')).toBe(true);
+          expect(core.config.get('core.automaticallyUpdate')).toBe(true);
           expect(
             aboutElement.querySelector('.about-auto-updates input').checked
           ).toBe(true);
@@ -316,7 +316,7 @@ describe('UpdateView', () => {
           });
 
           it('checks for update when the about page is shown', () => {
-            expect(atom.autoUpdater.checkForUpdate).not.toHaveBeenCalled();
+            expect(core.autoUpdater.checkForUpdate).not.toHaveBeenCalled();
 
             this.updateView = new UpdateView({
               updateManager: updateManager,
@@ -324,13 +324,13 @@ describe('UpdateView', () => {
               viewUpdateReleaseNotes: () => {}
             });
 
-            expect(atom.autoUpdater.checkForUpdate).toHaveBeenCalled();
+            expect(core.autoUpdater.checkForUpdate).toHaveBeenCalled();
           });
 
           it('does not check for update when the about page is shown and the update manager is not in the idle state', () => {
-            atom.autoUpdater.getState.andReturn('downloading');
+            core.autoUpdater.getState.andReturn('downloading');
             updateManager.resetState();
-            expect(atom.autoUpdater.checkForUpdate).not.toHaveBeenCalled();
+            expect(core.autoUpdater.checkForUpdate).not.toHaveBeenCalled();
 
             this.updateView = new UpdateView({
               updateManager: updateManager,
@@ -338,12 +338,12 @@ describe('UpdateView', () => {
               viewUpdateReleaseNotes: () => {}
             });
 
-            expect(atom.autoUpdater.checkForUpdate).not.toHaveBeenCalled();
+            expect(core.autoUpdater.checkForUpdate).not.toHaveBeenCalled();
           });
 
           it('does not check for update when the about page is shown and auto updates are turned off', () => {
-            atom.config.set('core.automaticallyUpdate', false);
-            expect(atom.autoUpdater.checkForUpdate).not.toHaveBeenCalled();
+            core.config.set('core.automaticallyUpdate', false);
+            expect(core.autoUpdater.checkForUpdate).not.toHaveBeenCalled();
 
             this.updateView = new UpdateView({
               updateManager: updateManager,
@@ -351,7 +351,7 @@ describe('UpdateView', () => {
               viewUpdateReleaseNotes: () => {}
             });
 
-            expect(atom.autoUpdater.checkForUpdate).not.toHaveBeenCalled();
+            expect(core.autoUpdater.checkForUpdate).not.toHaveBeenCalled();
           });
         });
       });
@@ -363,7 +363,7 @@ describe('UpdateView', () => {
       MockUpdater.finishDownloadingUpdate('42.0.0');
 
       jasmine.attachToDOM(workspaceElement);
-      await atom.workspace.open('atom://about');
+      await core.workspace.open('atom://about');
       aboutElement = workspaceElement.querySelector('.about');
       updateManager = main.model.state.updateManager;
       scheduler = AboutView.getScheduler();

--- a/packages/autoflow/lib/autoflow.coffee
+++ b/packages/autoflow/lib/autoflow.coffee
@@ -8,7 +8,7 @@ CharacterPattern = ///
 
 module.exports =
   activate: ->
-    @commandDisposable = atom.commands.add 'atom-text-editor',
+    @commandDisposable = core.commands.add 'atom-text-editor',
       'autoflow:reflow-selection': (event) =>
         @reflowSelection(event.currentTarget.getModel())
 
@@ -125,10 +125,10 @@ module.exports =
     return leadingVerticalSpace + paragraphs.join('\n\n') + trailingVerticalSpace
 
   getTabLength: (editor) ->
-    atom.config.get('editor.tabLength', scope: editor.getRootScopeDescriptor()) ? 2
+    core.config.get('editor.tabLength', scope: editor.getRootScopeDescriptor()) ? 2
 
   getPreferredLineLength: (editor) ->
-    atom.config.get('editor.preferredLineLength', scope: editor.getRootScopeDescriptor())
+    core.config.get('editor.preferredLineLength', scope: editor.getRootScopeDescriptor())
 
   wrapSegment: (segment, currentLineLength, wrapColumn) ->
     CharacterPattern.test(segment) and

--- a/packages/autoflow/spec/autoflow-spec.coffee
+++ b/packages/autoflow/spec/autoflow-spec.coffee
@@ -7,27 +7,27 @@ describe "Autoflow package", ->
       activationPromise = null
 
       waitsForPromise ->
-        atom.workspace.open()
+        core.workspace.open()
 
       runs ->
-        editor = atom.workspace.getActiveTextEditor()
-        editorElement = atom.views.getView(editor)
+        editor = core.workspace.getActiveTextEditor()
+        editorElement = core.views.getView(editor)
 
-        atom.config.set('editor.preferredLineLength', 30)
-        atom.config.set('editor.tabLength', tabLength)
+        core.config.set('editor.preferredLineLength', 30)
+        core.config.set('editor.tabLength', tabLength)
 
-        activationPromise = atom.packages.activatePackage('autoflow')
+        activationPromise = core.packages.activatePackage('autoflow')
 
-        atom.commands.dispatch editorElement, 'autoflow:reflow-selection'
+        core.commands.dispatch editorElement, 'autoflow:reflow-selection'
 
       waitsForPromise ->
         activationPromise
 
     it "uses the preferred line length based on the editor's scope", ->
-      atom.config.set('editor.preferredLineLength', 4, scopeSelector: '.text.plain.null-grammar')
+      core.config.set('editor.preferredLineLength', 4, scopeSelector: '.text.plain.null-grammar')
       editor.setText("foo bar")
       editor.selectAll()
-      atom.commands.dispatch editorElement, 'autoflow:reflow-selection'
+      core.commands.dispatch editorElement, 'autoflow:reflow-selection'
 
       expect(editor.getText()).toBe """
         foo
@@ -38,7 +38,7 @@ describe "Autoflow package", ->
       editor.setText "\t\tThis is the first paragraph and it is longer than the preferred line length so it should be reflowed.\n\n\t\tThis is a short paragraph.\n\n\t\tAnother long paragraph, it should also be reflowed with the use of this single command."
 
       editor.selectAll()
-      atom.commands.dispatch editorElement, 'autoflow:reflow-selection'
+      core.commands.dispatch editorElement, 'autoflow:reflow-selection'
 
       exedOut = editor.getText().replace(/\t/g, Array(tabLength+1).join 'X')
       expect(exedOut).toBe "XXXXXXXXThis is the first\nXXXXXXXXparagraph and it is\nXXXXXXXXlonger than the\nXXXXXXXXpreferred line length\nXXXXXXXXso it should be\nXXXXXXXXreflowed.\n\nXXXXXXXXThis is a short\nXXXXXXXXparagraph.\n\nXXXXXXXXAnother long\nXXXXXXXXparagraph, it should\nXXXXXXXXalso be reflowed with\nXXXXXXXXthe use of this single\nXXXXXXXXcommand."
@@ -53,7 +53,7 @@ describe "Autoflow package", ->
       """
 
       editor.selectAll()
-      atom.commands.dispatch editorElement, 'autoflow:reflow-selection'
+      core.commands.dispatch editorElement, 'autoflow:reflow-selection'
 
       expect(editor.getText()).toBe """
         This is the first paragraph
@@ -83,7 +83,7 @@ describe "Autoflow package", ->
 
       editor.setCursorBufferPosition([1, 0])
       editor.selectToBufferPosition([6, 0])
-      atom.commands.dispatch editorElement, 'autoflow:reflow-selection'
+      core.commands.dispatch editorElement, 'autoflow:reflow-selection'
 
       expect(editor.getText()).toBe """
         v--- SELECTION STARTS AT THE BEGINNING OF THE NEXT LINE (pos 1,0)
@@ -114,7 +114,7 @@ describe "Autoflow package", ->
       """
 
       editor.setCursorBufferPosition([3, 5])
-      atom.commands.dispatch editorElement, 'autoflow:reflow-selection'
+      core.commands.dispatch editorElement, 'autoflow:reflow-selection'
 
       expect(editor.getText()).toBe """
         This is a preceding paragraph, which shouldn't be modified by a reflow of the following paragraph.
@@ -134,7 +134,7 @@ describe "Autoflow package", ->
       editor.setText("this-is-a-super-long-word-that-shouldn't-break-autoflow and these are some smaller words")
 
       editor.selectAll()
-      atom.commands.dispatch editorElement, 'autoflow:reflow-selection'
+      core.commands.dispatch editorElement, 'autoflow:reflow-selection'
 
       expect(editor.getText()).toBe """
         this-is-a-super-long-word-that-shouldn't-break-autoflow

--- a/packages/dalek/lib/dalek.js
+++ b/packages/dalek/lib/dalek.js
@@ -5,14 +5,14 @@ const path = require('path');
 
 module.exports = {
   async enumerate() {
-    if (atom.inDevMode()) {
+    if (core.inDevMode()) {
       return [];
     }
 
     const duplicatePackages = [];
-    const names = atom.packages.getAvailablePackageNames();
+    const names = core.packages.getAvailablePackageNames();
     for (let name of names) {
-      if (atom.packages.isBundledPackage(name)) {
+      if (core.packages.isBundledPackage(name)) {
         const isDuplicatedPackage = await this.isInstalledAsCommunityPackage(
           name
         );
@@ -26,7 +26,7 @@ module.exports = {
   },
 
   async isInstalledAsCommunityPackage(name) {
-    const availablePackagePaths = atom.packages.getPackageDirPaths();
+    const availablePackagePaths = core.packages.getPackageDirPaths();
 
     for (let packagePath of availablePackagePaths) {
       const candidate = path.join(packagePath, name);

--- a/packages/dalek/lib/main.js
+++ b/packages/dalek/lib/main.js
@@ -5,7 +5,7 @@ const Grim = require('grim');
 
 module.exports = {
   activate() {
-    atom.packages.onDidActivateInitialPackages(async () => {
+    core.packages.onDidActivateInitialPackages(async () => {
       const duplicates = await dalek.enumerate();
       for (let i = 0; i < duplicates.length; i++) {
         const duplicate = duplicates[i];

--- a/packages/dalek/test/dalek.test.js
+++ b/packages/dalek/test/dalek.test.js
@@ -32,13 +32,13 @@ describe('dalek', function() {
           'duplicated-package'
         ),
         'unduplicated-package': path.join(
-          `${atom.getLoadSettings().resourcePath}`,
+          `${core.getLoadSettings().resourcePath}`,
           'node_modules',
           'unduplicated-package'
         )
       };
 
-      atom.devMode = false;
+      core.devMode = false;
       bundledPackages = ['duplicated-package', 'unduplicated-package'];
       packageDirPaths = [path.join('Users', 'username', '.pulsar', 'packages')];
       sandbox = sinon.createSandbox();
@@ -47,19 +47,19 @@ describe('dalek', function() {
         .callsFake(filePath =>
           Promise.resolve(realPaths[filePath] || filePath)
         );
-      sandbox.stub(atom.packages, 'isBundledPackage').callsFake(packageName => {
+      sandbox.stub(core.packages, 'isBundledPackage').callsFake(packageName => {
         return bundledPackages.includes(packageName);
       });
       sandbox
-        .stub(atom.packages, 'getAvailablePackageNames')
+        .stub(core.packages, 'getAvailablePackageNames')
         .callsFake(() => Object.keys(availablePackages));
-      sandbox.stub(atom.packages, 'getPackageDirPaths').callsFake(() => {
+      sandbox.stub(core.packages, 'getPackageDirPaths').callsFake(() => {
         return packageDirPaths;
       });
       sandbox.stub(fs, 'existsSync').callsFake(candidate => {
         return (
           Object.values(availablePackages).includes(candidate) &&
-          !candidate.includes(atom.getLoadSettings().resourcePath)
+          !candidate.includes(core.getLoadSettings().resourcePath)
         );
       });
     });
@@ -74,7 +74,7 @@ describe('dalek', function() {
 
     describe('when in dev mode', function() {
       beforeEach(function() {
-        atom.devMode = true;
+        core.devMode = true;
       });
 
       it('always returns an empty list', async function() {

--- a/packages/deprecation-cop/lib/deprecation-cop-status-bar-view.coffee
+++ b/packages/deprecation-cop/lib/deprecation-cop-status-bar-view.coffee
@@ -24,8 +24,8 @@ class DeprecationCopStatusBarView
     @element.appendChild(@deprecationNumber)
 
     clickHandler = ->
-      workspaceElement = atom.views.getView(atom.workspace)
-      atom.commands.dispatch workspaceElement, 'deprecation-cop:view'
+      workspaceElement = core.views.getView(core.workspace)
+      core.commands.dispatch workspaceElement, 'deprecation-cop:view'
     @element.addEventListener('click', clickHandler)
     @subscriptions.add(new Disposable(=> @element.removeEventListener('click', clickHandler)))
 
@@ -35,8 +35,8 @@ class DeprecationCopStatusBarView
 
     @subscriptions.add Grim.on 'updated', @update
     # TODO: Remove conditional when the new StyleManager deprecation APIs reach stable.
-    if atom.styles.onDidUpdateDeprecations?
-      @subscriptions.add(atom.styles.onDidUpdateDeprecations(debouncedUpdateDeprecatedSelectorCount))
+    if core.styles.onDidUpdateDeprecations?
+      @subscriptions.add(core.styles.onDidUpdateDeprecations(debouncedUpdateDeprecatedSelectorCount))
 
   destroy: ->
     @subscriptions.dispose()
@@ -47,8 +47,8 @@ class DeprecationCopStatusBarView
 
   getDeprecatedStyleSheetsCount: ->
     # TODO: Remove conditional when the new StyleManager deprecation APIs reach stable.
-    if atom.styles.getDeprecations?
-      Object.keys(atom.styles.getDeprecations()).length
+    if core.styles.getDeprecations?
+      Object.keys(core.styles.getDeprecations()).length
     else
       0
 
@@ -60,7 +60,7 @@ class DeprecationCopStatusBarView
     @lastLength = length
     @deprecationNumber.textContent = "#{_.pluralize(length, 'deprecation')}"
     @toolTipDisposable?.dispose()
-    @toolTipDisposable = atom.tooltips.add @element, title: "#{_.pluralize(length, 'call')} to deprecated methods"
+    @toolTipDisposable = core.tooltips.add @element, title: "#{_.pluralize(length, 'call')} to deprecated methods"
 
     if length is 0
       @element.style.display = 'none'

--- a/packages/deprecation-cop/lib/deprecation-cop-view.js
+++ b/packages/deprecation-cop/lib/deprecation-cop-view.js
@@ -20,16 +20,16 @@ export default class DeprecationCopView {
       })
     );
     // TODO: Remove conditional when the new StyleManager deprecation APIs reach stable.
-    if (atom.styles.onDidUpdateDeprecations) {
+    if (core.styles.onDidUpdateDeprecations) {
       this.subscriptions.add(
-        atom.styles.onDidUpdateDeprecations(() => {
+        core.styles.onDidUpdateDeprecations(() => {
           etch.update(this);
         })
       );
     }
     etch.initialize(this);
     this.subscriptions.add(
-      atom.commands.add(this.element, {
+      core.commands.add(this.element, {
         'core:move-up': () => {
           this.scrollUp();
         },
@@ -238,7 +238,7 @@ export default class DeprecationCopView {
   }
 
   renderPackageActionsIfNeeded(packageName) {
-    if (packageName && atom.packages.getLoadedPackage(packageName)) {
+    if (packageName && core.packages.getLoadedPackage(packageName)) {
       return (
         <div className="padded">
           <div className="btn-group">
@@ -407,7 +407,7 @@ export default class DeprecationCopView {
   }
 
   getRepoURL(packageName) {
-    const loadedPackage = atom.packages.getLoadedPackage(packageName);
+    const loadedPackage = core.packages.getLoadedPackage(packageName);
     if (
       loadedPackage &&
       loadedPackage.metadata &&
@@ -447,8 +447,8 @@ export default class DeprecationCopView {
 
   getDeprecatedSelectorsByPackageName() {
     const deprecatedSelectorsByPackageName = {};
-    if (atom.styles.getDeprecations) {
-      const deprecatedSelectorsBySourcePath = atom.styles.getDeprecations();
+    if (core.styles.getDeprecations) {
+      const deprecatedSelectorsBySourcePath = core.styles.getDeprecations();
       for (const sourcePath of Object.keys(deprecatedSelectorsBySourcePath)) {
         const deprecation = deprecatedSelectorsBySourcePath[sourcePath];
         const components = sourcePath.split(path.sep);
@@ -509,7 +509,7 @@ export default class DeprecationCopView {
         }
       }
 
-      if (atom.getUserInitScriptPath() === fileName) {
+      if (core.getUserInitScriptPath() === fileName) {
         return `Your local ${path.basename(fileName)} file`;
       }
     }
@@ -522,7 +522,7 @@ export default class DeprecationCopView {
       return this.packagePathsByPackageName;
     } else {
       this.packagePathsByPackageName = new Map();
-      for (const pack of atom.packages.getLoadedPackages()) {
+      for (const pack of core.packages.getLoadedPackages()) {
         this.packagePathsByPackageName.set(pack.name, pack.path);
       }
       return this.packagePathsByPackageName;
@@ -530,12 +530,12 @@ export default class DeprecationCopView {
   }
 
   checkForUpdates() {
-    atom.workspace.open('atom://config/updates');
+    core.workspace.open('atom://config/updates');
   }
 
   disablePackage(packageName) {
     if (packageName) {
-      atom.packages.disablePackage(packageName);
+      core.packages.disablePackage(packageName);
     }
   }
 
@@ -544,7 +544,7 @@ export default class DeprecationCopView {
     if (process.platform === 'win32') {
       pathToOpen = pathToOpen.replace(/^\//, '');
     }
-    atom.open({ pathsToOpen: [pathToOpen] });
+    core.open({ pathsToOpen: [pathToOpen] });
   }
 
   getURI() {

--- a/packages/deprecation-cop/lib/main.js
+++ b/packages/deprecation-cop/lib/main.js
@@ -7,22 +7,22 @@ class DeprecationCopPackage {
   activate() {
     this.disposables = new CompositeDisposable();
     this.disposables.add(
-      atom.workspace.addOpener(uri => {
+      core.workspace.addOpener(uri => {
         if (uri === ViewURI) {
           return this.deserializeDeprecationCopView({ uri });
         }
       })
     );
     this.disposables.add(
-      atom.commands.add('atom-workspace', 'deprecation-cop:view', () => {
-        atom.workspace.open(ViewURI);
+      core.commands.add('atom-workspace', 'deprecation-cop:view', () => {
+        core.workspace.open(ViewURI);
       })
     );
   }
 
   deactivate() {
     this.disposables.dispose();
-    const pane = atom.workspace.paneForURI(ViewURI);
+    const pane = core.workspace.paneForURI(ViewURI);
     if (pane) {
       pane.destroyItem(pane.itemForURI(ViewURI));
     }

--- a/packages/deprecation-cop/spec/deprecation-cop-spec.coffee
+++ b/packages/deprecation-cop/spec/deprecation-cop-spec.coffee
@@ -4,33 +4,33 @@ describe "DeprecationCop", ->
   [activationPromise, workspaceElement] = []
 
   beforeEach ->
-    workspaceElement = atom.views.getView(atom.workspace)
-    activationPromise = atom.packages.activatePackage('deprecation-cop')
-    expect(atom.workspace.getActivePane().getActiveItem()).not.toExist()
+    workspaceElement = core.views.getView(core.workspace)
+    activationPromise = core.packages.activatePackage('deprecation-cop')
+    expect(core.workspace.getActivePane().getActiveItem()).not.toExist()
 
   describe "when the deprecation-cop:view event is triggered", ->
     it "displays the deprecation cop pane", ->
-      atom.commands.dispatch workspaceElement, 'deprecation-cop:view'
+      core.commands.dispatch workspaceElement, 'deprecation-cop:view'
 
       waitsForPromise ->
         activationPromise
 
       deprecationCopView = null
       waitsFor ->
-        deprecationCopView = atom.workspace.getActivePane().getActiveItem()
+        deprecationCopView = core.workspace.getActivePane().getActiveItem()
 
       runs ->
         expect(deprecationCopView instanceof DeprecationCopView).toBeTruthy()
 
   describe "deactivating the package", ->
     it "removes the deprecation cop pane item", ->
-      atom.commands.dispatch workspaceElement, 'deprecation-cop:view'
+      core.commands.dispatch workspaceElement, 'deprecation-cop:view'
 
       waitsForPromise ->
         activationPromise
 
       waitsForPromise ->
-        Promise.resolve(atom.packages.deactivatePackage('deprecation-cop')) # Wrapped for Promise & non-Promise deactivate
+        Promise.resolve(core.packages.deactivatePackage('deprecation-cop')) # Wrapped for Promise & non-Promise deactivate
 
       runs ->
-        expect(atom.workspace.getActivePane().getActiveItem()).not.toExist()
+        expect(core.workspace.getActivePane().getActiveItem()).not.toExist()

--- a/packages/deprecation-cop/spec/deprecation-cop-status-bar-view-spec.coffee
+++ b/packages/deprecation-cop/spec/deprecation-cop-status-bar-view-spec.coffee
@@ -14,10 +14,10 @@ describe "DeprecationCopStatusBarView", ->
 
     jasmine.snapshotDeprecations()
 
-    workspaceElement = atom.views.getView(atom.workspace)
+    workspaceElement = core.views.getView(core.workspace)
     jasmine.attachToDOM(workspaceElement)
-    waitsForPromise -> atom.packages.activatePackage('status-bar')
-    waitsForPromise -> atom.packages.activatePackage('deprecation-cop')
+    waitsForPromise -> core.packages.activatePackage('status-bar')
+    waitsForPromise -> core.packages.activatePackage('deprecation-cop')
 
     waitsFor ->
       statusBarView = workspaceElement.querySelector('.deprecation-cop-status')
@@ -49,24 +49,24 @@ describe "DeprecationCopStatusBarView", ->
     expect(statusBarView.offsetHeight).toBeGreaterThan(0)
 
   # TODO: Remove conditional when the new StyleManager deprecation APIs reach stable.
-  if atom.styles.getDeprecations?
+  if core.styles.getDeprecations?
     it "increments when there are deprecated selectors", ->
-      atom.styles.addStyleSheet("""
+      core.styles.addStyleSheet("""
       atom-text-editor::shadow { color: red; }
       """, sourcePath: 'file-1')
       expect(statusBarView.textContent).toBe '1 deprecation'
       expect(statusBarView).toBeVisible()
-      atom.styles.addStyleSheet("""
+      core.styles.addStyleSheet("""
       atom-text-editor::shadow { color: blue; }
       """, sourcePath: 'file-2')
       expect(statusBarView.textContent).toBe '2 deprecations'
       expect(statusBarView).toBeVisible()
 
   it 'opens deprecation cop tab when clicked', ->
-    expect(atom.workspace.getActivePane().getActiveItem()).not.toExist()
+    expect(core.workspace.getActivePane().getActiveItem()).not.toExist()
 
     waitsFor (done) ->
-      atom.workspace.onDidOpen ({item}) ->
+      core.workspace.onDidOpen ({item}) ->
         expect(item instanceof DeprecationCopView).toBe true
         done()
       statusBarView.click()

--- a/packages/deprecation-cop/spec/deprecation-cop-view-spec.coffee
+++ b/packages/deprecation-cop/spec/deprecation-cop-view-spec.coffee
@@ -10,7 +10,7 @@ describe "DeprecationCopView", ->
     spyOn(_, 'debounce').andCallFake (func) ->
       -> func.apply(this, arguments)
 
-    workspaceElement = atom.views.getView(atom.workspace)
+    workspaceElement = core.views.getView(core.workspace)
     jasmine.attachToDOM(workspaceElement)
 
     jasmine.snapshotDeprecations()
@@ -19,14 +19,14 @@ describe "DeprecationCopView", ->
     deprecatedMethod()
 
     spyOn(Grim, 'deprecate') # Don't fail tests if when using deprecated APIs in deprecation cop's activation
-    activationPromise = atom.packages.activatePackage('deprecation-cop')
+    activationPromise = core.packages.activatePackage('deprecation-cop')
 
-    atom.commands.dispatch workspaceElement, 'deprecation-cop:view'
+    core.commands.dispatch workspaceElement, 'deprecation-cop:view'
 
     waitsForPromise ->
       activationPromise
 
-    waitsFor -> deprecationCopView = atom.workspace.getActivePane().getActiveItem()
+    waitsFor -> deprecationCopView = core.workspace.getActivePane().getActiveItem()
 
     runs ->
       jasmine.unspy(Grim, 'deprecate')
@@ -39,12 +39,12 @@ describe "DeprecationCopView", ->
     expect(deprecationCopView.element.textContent).toMatch /This isn't used/
 
   # TODO: Remove conditional when the new StyleManager deprecation APIs reach stable.
-  if atom.styles.getDeprecations?
+  if core.styles.getDeprecations?
     it "displays deprecated selectors", ->
-      atom.styles.addStyleSheet("atom-text-editor::shadow { color: red }", sourcePath: path.join('some-dir', 'packages', 'package-1', 'file-1.css'))
-      atom.styles.addStyleSheet("atom-text-editor::shadow { color: yellow }", context: 'atom-text-editor', sourcePath: path.join('some-dir', 'packages', 'package-1', 'file-2.css'))
-      atom.styles.addStyleSheet('atom-text-editor::shadow { color: blue }', sourcePath: path.join('another-dir', 'packages', 'package-2', 'file-3.css'))
-      atom.styles.addStyleSheet('atom-text-editor::shadow { color: gray }', sourcePath: path.join('another-dir', 'node_modules', 'package-3', 'file-4.css'))
+      core.styles.addStyleSheet("atom-text-editor::shadow { color: red }", sourcePath: path.join('some-dir', 'packages', 'package-1', 'file-1.css'))
+      core.styles.addStyleSheet("atom-text-editor::shadow { color: yellow }", context: 'atom-text-editor', sourcePath: path.join('some-dir', 'packages', 'package-1', 'file-2.css'))
+      core.styles.addStyleSheet('atom-text-editor::shadow { color: blue }', sourcePath: path.join('another-dir', 'packages', 'package-2', 'file-3.css'))
+      core.styles.addStyleSheet('atom-text-editor::shadow { color: gray }', sourcePath: path.join('another-dir', 'node_modules', 'package-3', 'file-4.css'))
 
       promise = etch.getScheduler().getNextUpdatePromise()
       waitsForPromise -> promise

--- a/packages/dev-live-reload/lib/base-theme-watcher.js
+++ b/packages/dev-live-reload/lib/base-theme-watcher.js
@@ -6,7 +6,7 @@ module.exports = class BaseThemeWatcher extends Watcher {
   constructor() {
     super();
     this.stylesheetsPath = path.dirname(
-      atom.themes.resolveStylesheet('../static/atom.less')
+      core.themes.resolveStylesheet('../static/atom.less')
     );
     this.watch();
   }
@@ -26,6 +26,6 @@ module.exports = class BaseThemeWatcher extends Watcher {
   }
 
   loadAllStylesheets() {
-    atom.themes.reloadBaseStylesheets();
+    core.themes.reloadBaseStylesheets();
   }
 };

--- a/packages/dev-live-reload/lib/main.js
+++ b/packages/dev-live-reload/lib/main.js
@@ -1,11 +1,11 @@
 module.exports = {
   activate(state) {
-    if (!atom.inDevMode() || atom.inSpecMode()) return;
+    if (!core.inDevMode() || core.inSpecMode()) return;
 
-    if (atom.packages.hasActivatedInitialPackages()) {
+    if (core.packages.hasActivatedInitialPackages()) {
       this.startWatching();
     } else {
-      this.activatedDisposable = atom.packages.onDidActivateInitialPackages(
+      this.activatedDisposable = core.packages.onDidActivateInitialPackages(
         () => this.startWatching()
       );
     }
@@ -19,8 +19,8 @@ module.exports = {
 
   startWatching() {
     const UIWatcher = require('./ui-watcher');
-    this.uiWatcher = new UIWatcher({ themeManager: atom.themes });
-    this.commandDisposable = atom.commands.add(
+    this.uiWatcher = new UIWatcher({ themeManager: core.themes });
+    this.commandDisposable = core.commands.add(
       'atom-workspace',
       'dev-live-reload:reload-all',
       () => this.uiWatcher.reloadAll()

--- a/packages/dev-live-reload/lib/ui-watcher.js
+++ b/packages/dev-live-reload/lib/ui-watcher.js
@@ -15,10 +15,10 @@ module.exports = class UIWatcher {
   watchPackages() {
     this.watchedThemes = new Map();
     this.watchedPackages = new Map();
-    for (const theme of atom.themes.getActiveThemes()) {
+    for (const theme of core.themes.getActiveThemes()) {
       this.watchTheme(theme);
     }
-    for (const pack of atom.packages.getActivePackages()) {
+    for (const pack of core.packages.getActivePackages()) {
       this.watchPackage(pack);
     }
     this.watchForPackageChanges();
@@ -26,7 +26,7 @@ module.exports = class UIWatcher {
 
   watchForPackageChanges() {
     this.subscriptions.add(
-      atom.themes.onDidChangeActiveThemes(() => {
+      core.themes.onDidChangeActiveThemes(() => {
         // We need to destroy all theme watchers as all theme packages are destroyed
         // when a theme changes.
         for (const theme of this.watchedThemes.values()) {
@@ -36,18 +36,18 @@ module.exports = class UIWatcher {
         this.watchedThemes.clear();
 
         // Rewatch everything!
-        for (const theme of atom.themes.getActiveThemes()) {
+        for (const theme of core.themes.getActiveThemes()) {
           this.watchTheme(theme);
         }
       })
     );
 
     this.subscriptions.add(
-      atom.packages.onDidActivatePackage(pack => this.watchPackage(pack))
+      core.packages.onDidActivatePackage(pack => this.watchPackage(pack))
     );
 
     this.subscriptions.add(
-      atom.packages.onDidDeactivatePackage(pack => {
+      core.packages.onDidDeactivatePackage(pack => {
         // This only handles packages - onDidChangeActiveThemes handles themes
         const watcher = this.watchedPackages.get(pack.name);
         if (watcher) watcher.destroy();
@@ -88,13 +88,13 @@ module.exports = class UIWatcher {
 
   reloadAll() {
     this.baseTheme.loadAllStylesheets();
-    for (const pack of atom.packages.getActivePackages()) {
+    for (const pack of core.packages.getActivePackages()) {
       if (PackageWatcher.supportsPackage(pack, 'atom')) {
         pack.reloadStylesheets();
       }
     }
 
-    for (const theme of atom.themes.getActiveThemes()) {
+    for (const theme of core.themes.getActiveThemes()) {
       if (PackageWatcher.supportsPackage(theme, 'theme')) {
         theme.reloadStylesheets();
       }

--- a/packages/dev-live-reload/lib/watcher.js
+++ b/packages/dev-live-reload/lib/watcher.js
@@ -65,7 +65,7 @@ module.exports = class Watcher {
   }
 
   isInAsarArchive(pathToCheck) {
-    const { resourcePath } = atom.getLoadSettings();
+    const { resourcePath } = core.getLoadSettings();
     return (
       pathToCheck.startsWith(`${resourcePath}${path.sep}`) &&
       path.extname(resourcePath) === '.asar'

--- a/packages/dev-live-reload/spec/dev-live-reload-spec.js
+++ b/packages/dev-live-reload/spec/dev-live-reload-spec.js
@@ -3,73 +3,73 @@ describe('Dev Live Reload', () => {
     let [pack, mainModule] = [];
 
     beforeEach(() => {
-      pack = atom.packages.loadPackage('dev-live-reload');
+      pack = core.packages.loadPackage('dev-live-reload');
       pack.requireMainModule();
       mainModule = pack.mainModule;
       spyOn(mainModule, 'startWatching');
     });
 
     describe('when the window is not in dev mode', () => {
-      beforeEach(() => spyOn(atom, 'inDevMode').andReturn(false));
+      beforeEach(() => spyOn(core, 'inDevMode').andReturn(false));
 
       it('does not watch files', async () => {
-        spyOn(atom.packages, 'hasActivatedInitialPackages').andReturn(true);
+        spyOn(core.packages, 'hasActivatedInitialPackages').andReturn(true);
 
-        await atom.packages.activatePackage('dev-live-reload');
+        await core.packages.activatePackage('dev-live-reload');
         expect(mainModule.startWatching).not.toHaveBeenCalled();
       });
     });
 
     describe('when the window is in spec mode', () => {
-      beforeEach(() => spyOn(atom, 'inSpecMode').andReturn(true));
+      beforeEach(() => spyOn(core, 'inSpecMode').andReturn(true));
 
       it('does not watch files', async () => {
-        spyOn(atom.packages, 'hasActivatedInitialPackages').andReturn(true);
+        spyOn(core.packages, 'hasActivatedInitialPackages').andReturn(true);
 
-        await atom.packages.activatePackage('dev-live-reload');
+        await core.packages.activatePackage('dev-live-reload');
         expect(mainModule.startWatching).not.toHaveBeenCalled();
       });
     });
 
     describe('when the window is in dev mode', () => {
       beforeEach(() => {
-        spyOn(atom, 'inDevMode').andReturn(true);
-        spyOn(atom, 'inSpecMode').andReturn(false);
+        spyOn(core, 'inDevMode').andReturn(true);
+        spyOn(core, 'inSpecMode').andReturn(false);
       });
 
       it('watches files', async () => {
-        spyOn(atom.packages, 'hasActivatedInitialPackages').andReturn(true);
+        spyOn(core.packages, 'hasActivatedInitialPackages').andReturn(true);
 
-        await atom.packages.activatePackage('dev-live-reload');
+        await core.packages.activatePackage('dev-live-reload');
         expect(mainModule.startWatching).toHaveBeenCalled();
       });
     });
 
     describe('when the window is in both dev mode and spec mode', () => {
       beforeEach(() => {
-        spyOn(atom, 'inDevMode').andReturn(true);
-        spyOn(atom, 'inSpecMode').andReturn(true);
+        spyOn(core, 'inDevMode').andReturn(true);
+        spyOn(core, 'inSpecMode').andReturn(true);
       });
 
       it('does not watch files', async () => {
-        spyOn(atom.packages, 'hasActivatedInitialPackages').andReturn(true);
+        spyOn(core.packages, 'hasActivatedInitialPackages').andReturn(true);
 
-        await atom.packages.activatePackage('dev-live-reload');
+        await core.packages.activatePackage('dev-live-reload');
         expect(mainModule.startWatching).not.toHaveBeenCalled();
       });
     });
 
     describe('when the package is activated before initial packages have been activated', () => {
       beforeEach(() => {
-        spyOn(atom, 'inDevMode').andReturn(true);
-        spyOn(atom, 'inSpecMode').andReturn(false);
+        spyOn(core, 'inDevMode').andReturn(true);
+        spyOn(core, 'inSpecMode').andReturn(false);
       });
 
       it('waits until all initial packages have been activated before watching files', async () => {
-        await atom.packages.activatePackage('dev-live-reload');
+        await core.packages.activatePackage('dev-live-reload');
         expect(mainModule.startWatching).not.toHaveBeenCalled();
 
-        atom.packages.emitter.emit('did-activate-initial-packages');
+        core.packages.emitter.emit('did-activate-initial-packages');
         expect(mainModule.startWatching).toHaveBeenCalled();
       });
     });
@@ -77,50 +77,50 @@ describe('Dev Live Reload', () => {
 
   describe('package deactivation', () => {
     beforeEach(() => {
-      spyOn(atom, 'inDevMode').andReturn(true);
-      spyOn(atom, 'inSpecMode').andReturn(false);
+      spyOn(core, 'inDevMode').andReturn(true);
+      spyOn(core, 'inSpecMode').andReturn(false);
     });
 
     it('stops watching all files', async () => {
-      spyOn(atom.packages, 'hasActivatedInitialPackages').andReturn(true);
-      const { mainModule } = await atom.packages.activatePackage(
+      spyOn(core.packages, 'hasActivatedInitialPackages').andReturn(true);
+      const { mainModule } = await core.packages.activatePackage(
         'dev-live-reload'
       );
       expect(mainModule.uiWatcher).not.toBeNull();
 
       spyOn(mainModule.uiWatcher, 'destroy');
 
-      await atom.packages.deactivatePackage('dev-live-reload');
+      await core.packages.deactivatePackage('dev-live-reload');
       expect(mainModule.uiWatcher.destroy).toHaveBeenCalled();
     });
 
     it('unsubscribes from the onDidActivateInitialPackages subscription if it is disabled before all initial packages are activated', async () => {
-      const { mainModule } = await atom.packages.activatePackage(
+      const { mainModule } = await core.packages.activatePackage(
         'dev-live-reload'
       );
       expect(mainModule.activatedDisposable.disposed).toBe(false);
 
-      await atom.packages.deactivatePackage('dev-live-reload');
+      await core.packages.deactivatePackage('dev-live-reload');
       expect(mainModule.activatedDisposable.disposed).toBe(true);
 
       spyOn(mainModule, 'startWatching');
-      atom.packages.emitter.emit('did-activate-initial-packages');
+      core.packages.emitter.emit('did-activate-initial-packages');
       expect(mainModule.startWatching).not.toHaveBeenCalled();
     });
 
     it('removes its commands', async () => {
-      spyOn(atom.packages, 'hasActivatedInitialPackages').andReturn(true);
-      await atom.packages.activatePackage('dev-live-reload');
+      spyOn(core.packages, 'hasActivatedInitialPackages').andReturn(true);
+      await core.packages.activatePackage('dev-live-reload');
       expect(
-        atom.commands
-          .findCommands({ target: atom.views.getView(atom.workspace) })
+        core.commands
+          .findCommands({ target: core.views.getView(core.workspace) })
           .filter(command => command.name.startsWith('dev-live-reload')).length
       ).toBeGreaterThan(0);
 
-      await atom.packages.deactivatePackage('dev-live-reload');
+      await core.packages.deactivatePackage('dev-live-reload');
       expect(
-        atom.commands
-          .findCommands({ target: atom.views.getView(atom.workspace) })
+        core.commands
+          .findCommands({ target: core.views.getView(core.workspace) })
           .filter(command => command.name.startsWith('dev-live-reload')).length
       ).toBe(0);
     });

--- a/packages/dev-live-reload/spec/ui-watcher-spec.js
+++ b/packages/dev-live-reload/spec/ui-watcher-spec.js
@@ -8,28 +8,28 @@ describe('UIWatcher', () => {
   let uiWatcher = null;
 
   beforeEach(() =>
-    atom.packages.packageDirPaths.push(path.join(__dirname, 'fixtures'))
+    core.packages.packageDirPaths.push(path.join(__dirname, 'fixtures'))
   );
 
   afterEach(() => uiWatcher && uiWatcher.destroy());
 
   describe("when a base theme's file changes", () => {
     beforeEach(() => {
-      spyOn(atom.themes, 'resolveStylesheet').andReturn(
+      spyOn(core.themes, 'resolveStylesheet').andReturn(
         path.join(__dirname, 'fixtures', 'static', 'atom.less')
       );
       uiWatcher = new UIWatcher();
     });
 
     it('reloads all the base styles', () => {
-      spyOn(atom.themes, 'reloadBaseStylesheets');
+      spyOn(core.themes, 'reloadBaseStylesheets');
 
       expect(uiWatcher.baseTheme.entities[0].getPath()).toContain(
         `${path.sep}static${path.sep}`
       );
 
       uiWatcher.baseTheme.entities[0].emitter.emit('did-change');
-      expect(atom.themes.reloadBaseStylesheets).toHaveBeenCalled();
+      expect(core.themes.reloadBaseStylesheets).toHaveBeenCalled();
     });
   });
 
@@ -40,7 +40,7 @@ describe('UIWatcher', () => {
       'package-with-styles-folder'
     );
 
-    await atom.packages.activatePackage(packagePath);
+    await core.packages.activatePackage(packagePath);
     uiWatcher = new UIWatcher();
 
     const lastWatcher = uiWatcher.watchers[uiWatcher.watchers.length - 1];
@@ -62,14 +62,14 @@ describe('UIWatcher', () => {
 
   describe('when a package stylesheet file changes', async () => {
     beforeEach(async () => {
-      await atom.packages.activatePackage(
+      await core.packages.activatePackage(
         path.join(__dirname, 'fixtures', 'package-with-styles-manifest')
       );
       uiWatcher = new UIWatcher();
     });
 
     it('reloads all package styles', () => {
-      const pack = atom.packages.getActivePackages()[0];
+      const pack = core.packages.getActivePackages()[0];
       spyOn(pack, 'reloadStylesheets');
 
       uiWatcher.watchers[
@@ -82,7 +82,7 @@ describe('UIWatcher', () => {
 
   describe('when a package does not have a stylesheet', () => {
     beforeEach(async () => {
-      await atom.packages.activatePackage('package-with-index');
+      await core.packages.activatePackage('package-with-index');
       uiWatcher = new UIWatcher();
     });
 
@@ -93,20 +93,20 @@ describe('UIWatcher', () => {
 
   describe('when a package global file changes', () => {
     beforeEach(async () => {
-      atom.config.set('core.themes', [
+      core.config.set('core.themes', [
         'theme-with-ui-variables',
         'theme-with-multiple-imported-files'
       ]);
 
-      await atom.themes.activateThemes();
+      await core.themes.activateThemes();
       uiWatcher = new UIWatcher();
     });
 
-    afterEach(() => atom.themes.deactivateThemes());
+    afterEach(() => core.themes.deactivateThemes());
 
     it('reloads every package when the variables file changes', () => {
       let varEntity;
-      for (const theme of atom.themes.getActiveThemes()) {
+      for (const theme of core.themes.getActiveThemes()) {
         spyOn(theme, 'reloadStylesheets');
       }
 
@@ -117,7 +117,7 @@ describe('UIWatcher', () => {
       }
       varEntity.emitter.emit('did-change');
 
-      for (const theme of atom.themes.getActiveThemes()) {
+      for (const theme of core.themes.getActiveThemes()) {
         expect(theme.reloadStylesheets).toHaveBeenCalled();
       }
     });
@@ -128,7 +128,7 @@ describe('UIWatcher', () => {
       uiWatcher = new UIWatcher();
       expect(uiWatcher.watchedPackages.size).toBe(0);
 
-      await atom.packages.activatePackage(
+      await core.packages.activatePackage(
         path.join(__dirname, 'fixtures', 'package-with-styles-folder')
       );
       expect(
@@ -137,7 +137,7 @@ describe('UIWatcher', () => {
     });
 
     it('unwatches a package after it is deactivated', async () => {
-      await atom.packages.activatePackage(
+      await core.packages.activatePackage(
         path.join(__dirname, 'fixtures', 'package-with-styles-folder')
       );
       uiWatcher = new UIWatcher();
@@ -149,7 +149,7 @@ describe('UIWatcher', () => {
       const watcherDestructionSpy = jasmine.createSpy('watcher-on-did-destroy');
       watcher.onDidDestroy(watcherDestructionSpy);
 
-      await atom.packages.deactivatePackage('package-with-styles-folder');
+      await core.packages.deactivatePackage('package-with-styles-folder');
       expect(
         uiWatcher.watchedPackages.get('package-with-styles-folder')
       ).toBeUndefined();
@@ -161,7 +161,7 @@ describe('UIWatcher', () => {
       uiWatcher = new UIWatcher();
       uiWatcher.destroy();
 
-      await atom.packages.activatePackage(
+      await core.packages.activatePackage(
         path.join(__dirname, 'fixtures', 'package-with-styles-folder')
       );
       expect(uiWatcher.watchedPackages.size).toBe(0);
@@ -171,20 +171,20 @@ describe('UIWatcher', () => {
   describe('minimal theme packages', () => {
     let pack = null;
     beforeEach(async () => {
-      atom.config.set('core.themes', [
+      core.config.set('core.themes', [
         'theme-with-syntax-variables',
         'theme-with-index-less'
       ]);
-      await atom.themes.activateThemes();
+      await core.themes.activateThemes();
       uiWatcher = new UIWatcher();
-      pack = atom.themes.getActiveThemes()[0];
+      pack = core.themes.getActiveThemes()[0];
     });
 
-    afterEach(() => atom.themes.deactivateThemes());
+    afterEach(() => core.themes.deactivateThemes());
 
     it('watches themes without a styles directory', () => {
       spyOn(pack, 'reloadStylesheets');
-      spyOn(atom.themes, 'reloadBaseStylesheets');
+      spyOn(core.themes, 'reloadBaseStylesheets');
 
       const watcher = uiWatcher.watchedThemes.get('theme-with-index-less');
 
@@ -192,28 +192,28 @@ describe('UIWatcher', () => {
 
       watcher.entities[0].emitter.emit('did-change');
       expect(pack.reloadStylesheets).toHaveBeenCalled();
-      expect(atom.themes.reloadBaseStylesheets).not.toHaveBeenCalled();
+      expect(core.themes.reloadBaseStylesheets).not.toHaveBeenCalled();
     });
   });
 
   describe('theme packages', () => {
     let pack = null;
     beforeEach(async () => {
-      atom.config.set('core.themes', [
+      core.config.set('core.themes', [
         'theme-with-syntax-variables',
         'theme-with-multiple-imported-files'
       ]);
 
-      await atom.themes.activateThemes();
+      await core.themes.activateThemes();
       uiWatcher = new UIWatcher();
-      pack = atom.themes.getActiveThemes()[0];
+      pack = core.themes.getActiveThemes()[0];
     });
 
-    afterEach(() => atom.themes.deactivateThemes());
+    afterEach(() => core.themes.deactivateThemes());
 
     it('reloads the theme when anything within the theme changes', () => {
       spyOn(pack, 'reloadStylesheets');
-      spyOn(atom.themes, 'reloadBaseStylesheets');
+      spyOn(core.themes, 'reloadBaseStylesheets');
 
       const watcher = uiWatcher.watchedThemes.get(
         'theme-with-multiple-imported-files'
@@ -223,16 +223,16 @@ describe('UIWatcher', () => {
 
       watcher.entities[2].emitter.emit('did-change');
       expect(pack.reloadStylesheets).toHaveBeenCalled();
-      expect(atom.themes.reloadBaseStylesheets).not.toHaveBeenCalled();
+      expect(core.themes.reloadBaseStylesheets).not.toHaveBeenCalled();
 
       watcher.entities[watcher.entities.length - 1].emitter.emit('did-change');
-      expect(atom.themes.reloadBaseStylesheets).toHaveBeenCalled();
+      expect(core.themes.reloadBaseStylesheets).toHaveBeenCalled();
     });
 
     it('unwatches when a theme is deactivated', async () => {
       jasmine.useRealClock();
 
-      atom.config.set('core.themes', []);
+      core.config.set('core.themes', []);
       await conditionPromise(
         () => !uiWatcher.watchedThemes['theme-with-multiple-imported-files']
       );
@@ -241,7 +241,7 @@ describe('UIWatcher', () => {
     it('watches a new theme when it is deactivated', async () => {
       jasmine.useRealClock();
 
-      atom.config.set('core.themes', [
+      core.config.set('core.themes', [
         'theme-with-syntax-variables',
         'theme-with-package-file'
       ]);
@@ -249,7 +249,7 @@ describe('UIWatcher', () => {
         uiWatcher.watchedThemes.get('theme-with-package-file')
       );
 
-      pack = atom.themes.getActiveThemes()[0];
+      pack = core.themes.getActiveThemes()[0];
       spyOn(pack, 'reloadStylesheets');
 
       expect(pack.name).toBe('theme-with-package-file');

--- a/packages/exception-reporting/lib/main.js
+++ b/packages/exception-reporting/lib/main.js
@@ -16,12 +16,12 @@ export default {
   activate() {
     this.subscriptions = new CompositeDisposable();
 
-    if (!atom.config.get('exception-reporting.userId')) {
-      atom.config.set('exception-reporting.userId', require('node-uuid').v4());
+    if (!core.config.get('exception-reporting.userId')) {
+      core.config.set('exception-reporting.userId', require('node-uuid').v4());
     }
 
     this.subscriptions.add(
-      atom.onDidThrowError(({ message, url, line, column, originalError }) => {
+      core.onDidThrowError(({ message, url, line, column, originalError }) => {
         try {
           getReporter().reportUncaughtException(originalError);
         } catch (secondaryException) {
@@ -36,9 +36,9 @@ export default {
       })
     );
 
-    if (atom.onDidFailAssertion != null) {
+    if (core.onDidFailAssertion != null) {
       this.subscriptions.add(
-        atom.onDidFailAssertion(error => {
+        core.onDidFailAssertion(error => {
           try {
             getReporter().reportFailedAssertion(error);
           } catch (secondaryException) {

--- a/packages/exception-reporting/lib/reporter.js
+++ b/packages/exception-reporting/lib/reporter.js
@@ -95,10 +95,10 @@ export default class Reporter {
 
   getDefaultNotificationParams() {
     return {
-      userId: atom.config.get('exception-reporting.userId'),
-      appVersion: atom.getVersion(),
-      releaseStage: this.getReleaseChannel(atom.getVersion()),
-      projectRoot: atom.getLoadSettings().resourcePath,
+      userId: core.config.get('exception-reporting.userId'),
+      appVersion: core.getVersion(),
+      releaseStage: this.getReleaseChannel(core.getVersion()),
+      projectRoot: core.getLoadSettings().resourcePath,
       osVersion: `${os.platform()}-${os.arch()}-${os.release()}`
     };
   }
@@ -172,7 +172,7 @@ export default class Reporter {
       }
     }
 
-    notification = atom.notifications.addInfo(message, {
+    notification = core.notifications.addInfo(message, {
       detail: error.privateMetadataDescription,
       description:
         'Are you willing to submit this information to a private server for debugging purposes?',
@@ -195,12 +195,12 @@ export default class Reporter {
   }
 
   addPackageMetadata(error) {
-    let activePackages = atom.packages.getActivePackages();
-    const availablePackagePaths = atom.packages.getPackageDirPaths();
+    let activePackages = core.packages.getActivePackages();
+    const availablePackagePaths = core.packages.getPackageDirPaths();
     if (activePackages.length > 0) {
       let userPackages = {};
       let bundledPackages = {};
-      for (let pack of atom.packages.getActivePackages()) {
+      for (let pack of core.packages.getActivePackages()) {
         if (availablePackagePaths.includes(path.dirname(pack.path))) {
           userPackages[pack.name] = pack.metadata.version;
         } else {
@@ -285,7 +285,7 @@ export default class Reporter {
   }
 
   isTeletypeFile(fileName) {
-    const teletypePath = atom.packages.resolvePackagePath('teletype');
+    const teletypePath = core.packages.resolvePackagePath('teletype');
     return (
       teletypePath && this.normalizePath(fileName).indexOf(teletypePath) === 0
     );

--- a/packages/exception-reporting/spec/reporter-spec.js
+++ b/packages/exception-reporting/spec/reporter-spec.js
@@ -28,7 +28,7 @@ describe('Reporter', () => {
     });
     requests = [];
     mockActivePackages = [];
-    spyOn(atom.packages, 'getActivePackages').andCallFake(
+    spyOn(core.packages, 'getActivePackages').andCallFake(
       () => mockActivePackages
     );
 
@@ -101,8 +101,8 @@ describe('Reporter', () => {
             severity: 'error',
             user: {},
             app: {
-              version: atom.getVersion(),
-              releaseStage: getReleaseChannel(atom.getVersion())
+              version: core.getVersion(),
+              releaseStage: getReleaseChannel(core.getVersion())
             },
             device: {
               osVersion: osVersion
@@ -162,8 +162,8 @@ describe('Reporter', () => {
             severity: 'error',
             user: {},
             app: {
-              version: atom.getVersion(),
-              releaseStage: getReleaseChannel(atom.getVersion())
+              version: core.getVersion(),
+              releaseStage: getReleaseChannel(core.getVersion())
             },
             device: {
               osVersion: osVersion
@@ -177,8 +177,8 @@ describe('Reporter', () => {
       let [error, notification] = [];
 
       beforeEach(() => {
-        atom.notifications.clear();
-        spyOn(atom.notifications, 'addInfo').andCallThrough();
+        core.notifications.clear();
+        spyOn(core.notifications, 'addInfo').andCallThrough();
 
         error = new Error();
         Error.captureStackTrace(error);
@@ -190,7 +190,7 @@ describe('Reporter', () => {
 
       it('posts a notification asking for consent', () => {
         reporter.reportUncaughtException(error);
-        expect(atom.notifications.addInfo).toHaveBeenCalled();
+        expect(core.notifications.addInfo).toHaveBeenCalled();
       });
 
       it('submits the error with the private metadata if the user consents', () => {
@@ -198,9 +198,9 @@ describe('Reporter', () => {
         reporter.reportUncaughtException(error);
         reporter.reportUncaughtException.reset();
 
-        notification = atom.notifications.getNotifications()[0];
+        notification = core.notifications.getNotifications()[0];
 
-        let notificationOptions = atom.notifications.addInfo.argsForCall[0][1];
+        let notificationOptions = core.notifications.addInfo.argsForCall[0][1];
         expect(notificationOptions.buttons[1].text).toMatch(/Yes/);
 
         notificationOptions.buttons[1].onDidClick();
@@ -218,9 +218,9 @@ describe('Reporter', () => {
         reporter.reportUncaughtException(error);
         reporter.reportUncaughtException.reset();
 
-        notification = atom.notifications.getNotifications()[0];
+        notification = core.notifications.getNotifications()[0];
 
-        let notificationOptions = atom.notifications.addInfo.argsForCall[0][1];
+        let notificationOptions = core.notifications.addInfo.argsForCall[0][1];
         expect(notificationOptions.buttons[0].text).toMatch(/No/);
 
         notificationOptions.buttons[0].onDidClick();
@@ -238,7 +238,7 @@ describe('Reporter', () => {
         reporter.reportUncaughtException(error);
         reporter.reportUncaughtException.reset();
 
-        notification = atom.notifications.getNotifications()[0];
+        notification = core.notifications.getNotifications()[0];
         notification.dismiss();
 
         expect(reporter.reportUncaughtException).toHaveBeenCalledWith(error);
@@ -249,7 +249,7 @@ describe('Reporter', () => {
       });
     });
 
-    it('treats packages located in atom.packages.getPackageDirPaths as user packages', () => {
+    it('treats packages located in core.packages.getPackageDirPaths as user packages', () => {
       mockActivePackages = [
         {
           name: 'user-1',
@@ -277,7 +277,7 @@ describe('Reporter', () => {
 
       const packageDirPaths = ['/Users/user/.atom/packages'];
 
-      spyOn(atom.packages, 'getPackageDirPaths').andReturn(packageDirPaths);
+      spyOn(core.packages, 'getPackageDirPaths').andReturn(packageDirPaths);
 
       let error = new Error();
       Error.captureStackTrace(error);
@@ -368,8 +368,8 @@ describe('Reporter', () => {
             severity: 'warning',
             user: {},
             app: {
-              version: atom.getVersion(),
-              releaseStage: getReleaseChannel(atom.getVersion())
+              version: core.getVersion(),
+              releaseStage: getReleaseChannel(core.getVersion())
             },
             device: {
               osVersion: osVersion
@@ -383,8 +383,8 @@ describe('Reporter', () => {
       let [error, notification] = [];
 
       beforeEach(() => {
-        atom.notifications.clear();
-        spyOn(atom.notifications, 'addInfo').andCallThrough();
+        core.notifications.clear();
+        spyOn(core.notifications, 'addInfo').andCallThrough();
 
         error = new Error();
         Error.captureStackTrace(error);
@@ -396,7 +396,7 @@ describe('Reporter', () => {
 
       it('posts a notification asking for consent', () => {
         reporter.reportFailedAssertion(error);
-        expect(atom.notifications.addInfo).toHaveBeenCalled();
+        expect(core.notifications.addInfo).toHaveBeenCalled();
       });
 
       it('submits the error with the private metadata if the user consents', () => {
@@ -404,9 +404,9 @@ describe('Reporter', () => {
         reporter.reportFailedAssertion(error);
         reporter.reportFailedAssertion.reset();
 
-        notification = atom.notifications.getNotifications()[0];
+        notification = core.notifications.getNotifications()[0];
 
-        let notificationOptions = atom.notifications.addInfo.argsForCall[0][1];
+        let notificationOptions = core.notifications.addInfo.argsForCall[0][1];
         expect(notificationOptions.buttons[1].text).toMatch(/Yes/);
 
         notificationOptions.buttons[1].onDidClick();
@@ -424,9 +424,9 @@ describe('Reporter', () => {
         reporter.reportFailedAssertion(error);
         reporter.reportFailedAssertion.reset();
 
-        notification = atom.notifications.getNotifications()[0];
+        notification = core.notifications.getNotifications()[0];
 
-        let notificationOptions = atom.notifications.addInfo.argsForCall[0][1];
+        let notificationOptions = core.notifications.addInfo.argsForCall[0][1];
         expect(notificationOptions.buttons[0].text).toMatch(/No/);
 
         notificationOptions.buttons[0].onDidClick();
@@ -444,7 +444,7 @@ describe('Reporter', () => {
         reporter.reportFailedAssertion(error);
         reporter.reportFailedAssertion.reset();
 
-        notification = atom.notifications.getNotifications()[0];
+        notification = core.notifications.getNotifications()[0];
         notification.dismiss();
 
         expect(reporter.reportFailedAssertion).toHaveBeenCalledWith(error);
@@ -466,11 +466,11 @@ describe('Reporter', () => {
         error.privateMetadataRequestName = 'foo';
 
         reporter.reportFailedAssertion(error);
-        expect(atom.notifications.addInfo).toHaveBeenCalled();
-        atom.notifications.addInfo.reset();
+        expect(core.notifications.addInfo).toHaveBeenCalled();
+        core.notifications.addInfo.reset();
 
         reporter.reportFailedAssertion(error);
-        expect(atom.notifications.addInfo).not.toHaveBeenCalled();
+        expect(core.notifications.addInfo).not.toHaveBeenCalled();
 
         let error2 = new Error();
         Error.captureStackTrace(error2);
@@ -479,11 +479,11 @@ describe('Reporter', () => {
         error2.privateMetadataRequestName = 'bar';
 
         reporter.reportFailedAssertion(error2);
-        expect(atom.notifications.addInfo).toHaveBeenCalled();
+        expect(core.notifications.addInfo).toHaveBeenCalled();
       });
     });
 
-    it('treats packages located in atom.packages.getPackageDirPaths as user packages', () => {
+    it('treats packages located in core.packages.getPackageDirPaths as user packages', () => {
       mockActivePackages = [
         {
           name: 'user-1',
@@ -511,7 +511,7 @@ describe('Reporter', () => {
 
       const packageDirPaths = ['/Users/user/.atom/packages'];
 
-      spyOn(atom.packages, 'getPackageDirPaths').andReturn(packageDirPaths);
+      spyOn(core.packages, 'getPackageDirPaths').andReturn(packageDirPaths);
 
       let error = new Error();
       Error.captureStackTrace(error);

--- a/packages/git-diff/lib/diff-list-view.js
+++ b/packages/git-diff/lib/diff-list-view.js
@@ -40,7 +40,7 @@ export default class DiffListView {
       }
     });
     this.selectListView.element.classList.add('diff-list-view');
-    this.panel = atom.workspace.addModalPanel({
+    this.panel = core.workspace.addModalPanel({
       item: this.selectListView,
       visible: false
     });
@@ -68,7 +68,7 @@ export default class DiffListView {
   }
 
   async toggle() {
-    const editor = atom.workspace.getActiveTextEditor();
+    const editor = core.workspace.getActiveTextEditor();
     if (this.panel.isVisible()) {
       this.cancel();
     } else if (editor) {

--- a/packages/git-diff/lib/git-diff-view.js
+++ b/packages/git-diff/lib/git-diff-view.js
@@ -31,7 +31,7 @@ export default class GitDiffView {
     subscribeToRepository();
 
     this.subscriptions.add(
-      atom.project.onDidChangePaths(subscribeToRepository)
+      core.project.onDidChangePaths(subscribeToRepository)
     );
   }
 
@@ -108,21 +108,21 @@ export default class GitDiffView {
           this.buffer = this.editor.getBuffer();
           scheduleUpdate();
         }),
-        atom.commands.add(
+        core.commands.add(
           this.editorElement,
           'git-diff:move-to-next-diff',
           this.moveToNextDiff.bind(this)
         ),
-        atom.commands.add(
+        core.commands.add(
           this.editorElement,
           'git-diff:move-to-previous-diff',
           this.moveToPreviousDiff.bind(this)
         ),
-        atom.config.onDidChange(
+        core.config.onDidChange(
           'git-diff.showIconsInEditorGutter',
           updateIconDecoration
         ),
-        atom.config.onDidChange('editor.showLineNumbers', updateIconDecoration),
+        core.config.onDidChange('editor.showLineNumbers', updateIconDecoration),
         this.editorElement.onDidAttach(updateIconDecoration)
       );
 
@@ -156,7 +156,7 @@ export default class GitDiffView {
 
     // Wrap around to the first diff in the file
     if (
-      atom.config.get('git-diff.wrapAroundOnMoveToDiff') &&
+      core.config.get('git-diff.wrapAroundOnMoveToDiff') &&
       nextDiffLineNumber == null
     ) {
       nextDiffLineNumber = firstDiffLineNumber;
@@ -178,7 +178,7 @@ export default class GitDiffView {
 
     // Wrap around to the last diff in the file
     if (
-      atom.config.get('git-diff.wrapAroundOnMoveToDiff') &&
+      core.config.get('git-diff.wrapAroundOnMoveToDiff') &&
       previousDiffLineNumber === null
     ) {
       previousDiffLineNumber = lastDiffLineNumber;
@@ -191,8 +191,8 @@ export default class GitDiffView {
     const gutter = this.editorElement.querySelector('.gutter');
     if (gutter) {
       if (
-        atom.config.get('editor.showLineNumbers') &&
-        atom.config.get('git-diff.showIconsInEditorGutter')
+        core.config.get('editor.showLineNumbers') &&
+        core.config.get('git-diff.showIconsInEditorGutter')
       ) {
         gutter.classList.add('git-diff-icon');
       } else {

--- a/packages/git-diff/lib/helpers.js
+++ b/packages/git-diff/lib/helpers.js
@@ -3,7 +3,7 @@ import { Directory } from 'atom';
 
 export default async function(goalPath) {
   if (goalPath) {
-    return atom.project.repositoryForDirectory(new Directory(goalPath));
+    return core.project.repositoryForDirectory(new Directory(goalPath));
   }
   return null;
 }

--- a/packages/git-diff/lib/main.js
+++ b/packages/git-diff/lib/main.js
@@ -13,15 +13,15 @@ export default {
     subscriptions = new CompositeDisposable();
 
     subscriptions.add(
-      atom.workspace.observeTextEditors(editor => {
-        const editorElement = atom.views.getView(editor);
+      core.workspace.observeTextEditors(editor => {
+        const editorElement = core.views.getView(editor);
         const diffView = new GitDiffView(editor, editorElement);
 
         diffViews.add(diffView);
 
         const listViewCommand = 'git-diff:toggle-diff-list';
         const editorSubs = new CompositeDisposable(
-          atom.commands.add(editorElement, listViewCommand, () => {
+          core.commands.add(editorElement, listViewCommand, () => {
             if (diffListView == null) diffListView = new DiffListView();
 
             diffListView.toggle();

--- a/packages/git-diff/spec/diff-list-view-spec.js
+++ b/packages/git-diff/spec/diff-list-view-spec.js
@@ -12,19 +12,19 @@ describe('git-diff:toggle-diff-list', () => {
       path.join(projectPath, 'git.git'),
       path.join(projectPath, '.git')
     );
-    atom.project.setPaths([projectPath]);
+    core.project.setPaths([projectPath]);
 
-    jasmine.attachToDOM(atom.workspace.getElement());
+    jasmine.attachToDOM(core.workspace.getElement());
 
-    waitsForPromise(() => atom.packages.activatePackage('git-diff'));
+    waitsForPromise(() => core.packages.activatePackage('git-diff'));
 
-    waitsForPromise(() => atom.workspace.open('sample.js'));
+    waitsForPromise(() => core.workspace.open('sample.js'));
 
     runs(() => {
-      editor = atom.workspace.getActiveTextEditor();
+      editor = core.workspace.getActiveTextEditor();
       editor.setCursorBufferPosition([8, 30]);
       editor.insertText('a');
-      atom.commands.dispatch(editor.getElement(), 'git-diff:toggle-diff-list');
+      core.commands.dispatch(editor.getElement(), 'git-diff:toggle-diff-list');
     });
 
     waitsFor(() => {
@@ -42,7 +42,7 @@ describe('git-diff:toggle-diff-list', () => {
 
   it('moves the cursor to the selected hunk', () => {
     editor.setCursorBufferPosition([0, 0]);
-    atom.commands.dispatch(
+    core.commands.dispatch(
       document.querySelector('.diff-list-view'),
       'core:confirm'
     );

--- a/packages/git-diff/spec/git-diff-spec.js
+++ b/packages/git-diff/spec/git-diff-spec.js
@@ -21,18 +21,18 @@ describe('GitDiff package', () => {
       path.join(projectPath, 'git.git'),
       path.join(projectPath, '.git')
     );
-    atom.project.setPaths([otherPath, projectPath]);
+    core.project.setPaths([otherPath, projectPath]);
 
-    jasmine.attachToDOM(atom.workspace.getElement());
+    jasmine.attachToDOM(core.workspace.getElement());
 
     waitsForPromise(async () => {
-      await atom.workspace.open(path.join(projectPath, 'sample.js'));
-      await atom.packages.activatePackage('git-diff');
+      await core.workspace.open(path.join(projectPath, 'sample.js'));
+      await core.packages.activatePackage('git-diff');
     });
 
     runs(() => {
-      editor = atom.workspace.getActiveTextEditor();
-      editorElement = atom.views.getView(editor);
+      editor = core.workspace.getActiveTextEditor();
+      editorElement = core.views.getView(editor);
     });
   });
 
@@ -161,11 +161,11 @@ describe('GitDiff package', () => {
       );
 
       waitsForPromise(() =>
-        atom.workspace.open(path.join(projectPath, 'sample.txt'))
+        core.workspace.open(path.join(projectPath, 'sample.txt'))
       );
 
       runs(() => {
-        editor = atom.workspace.getActiveTextEditor();
+        editor = core.workspace.getActiveTextEditor();
         editorElement = editor.getElement();
       });
 
@@ -186,7 +186,7 @@ describe('GitDiff package', () => {
   describe('when the project paths change', () => {
     it("doesn't try to use the destroyed git repository", () => {
       editor.deleteLine();
-      atom.project.setPaths([temp.mkdirSync('no-repository')]);
+      core.project.setPaths([temp.mkdirSync('no-repository')]);
       advanceClock(editor.getBuffer().stoppedChangingDelay);
       waitsFor(() => editor.getMarkers().length === 0);
       runs(() => {
@@ -205,10 +205,10 @@ describe('GitDiff package', () => {
         advanceClock(editor.getBuffer().stoppedChangingDelay);
 
         editor.setCursorBufferPosition([0]);
-        atom.commands.dispatch(editorElement, 'git-diff:move-to-next-diff');
+        core.commands.dispatch(editorElement, 'git-diff:move-to-next-diff');
         expect(editor.getCursorBufferPosition()).toEqual([4, 4]);
 
-        atom.commands.dispatch(editorElement, 'git-diff:move-to-previous-diff');
+        core.commands.dispatch(editorElement, 'git-diff:move-to-previous-diff');
         expect(editor.getCursorBufferPosition()).toEqual([0, 0]);
       });
     });
@@ -222,20 +222,20 @@ describe('GitDiff package', () => {
         advanceClock(editor.getBuffer().stoppedChangingDelay);
 
         editor.setCursorBufferPosition([0]);
-        atom.commands.dispatch(editorElement, 'git-diff:move-to-next-diff');
+        core.commands.dispatch(editorElement, 'git-diff:move-to-next-diff');
         expect(editor.getCursorBufferPosition().toArray()).toEqual([4, 4]);
 
-        atom.commands.dispatch(editorElement, 'git-diff:move-to-next-diff');
+        core.commands.dispatch(editorElement, 'git-diff:move-to-next-diff');
         expect(editor.getCursorBufferPosition().toArray()).toEqual([0, 0]);
 
-        atom.commands.dispatch(editorElement, 'git-diff:move-to-previous-diff');
+        core.commands.dispatch(editorElement, 'git-diff:move-to-previous-diff');
         expect(editor.getCursorBufferPosition().toArray()).toEqual([4, 4]);
       });
     });
 
     describe('when the wrapAroundOnMoveToDiff config option is false', () => {
       beforeEach(() =>
-        atom.config.set('git-diff.wrapAroundOnMoveToDiff', false)
+        core.config.set('git-diff.wrapAroundOnMoveToDiff', false)
       );
 
       it('does not wraps around to the first/last diff in the file', () => {
@@ -247,19 +247,19 @@ describe('GitDiff package', () => {
 
         runs(() => {
           editor.setCursorBufferPosition([0]);
-          atom.commands.dispatch(editorElement, 'git-diff:move-to-next-diff');
+          core.commands.dispatch(editorElement, 'git-diff:move-to-next-diff');
           expect(editor.getCursorBufferPosition()).toEqual([4, 4]);
 
-          atom.commands.dispatch(editorElement, 'git-diff:move-to-next-diff');
+          core.commands.dispatch(editorElement, 'git-diff:move-to-next-diff');
           expect(editor.getCursorBufferPosition()).toEqual([4, 4]);
 
-          atom.commands.dispatch(
+          core.commands.dispatch(
             editorElement,
             'git-diff:move-to-previous-diff'
           );
           expect(editor.getCursorBufferPosition()).toEqual([0, 0]);
 
-          atom.commands.dispatch(
+          core.commands.dispatch(
             editorElement,
             'git-diff:move-to-previous-diff'
           );
@@ -271,7 +271,7 @@ describe('GitDiff package', () => {
 
   describe('when the showIconsInEditorGutter config option is true', () => {
     beforeEach(() => {
-      atom.config.set('git-diff.showIconsInEditorGutter', true);
+      core.config.set('git-diff.showIconsInEditorGutter', true);
     });
 
     it('the gutter has a git-diff-icon class', () => {
@@ -287,12 +287,12 @@ describe('GitDiff package', () => {
       waitsFor(() => screenUpdates > 0);
 
       runs(() => {
-        atom.config.set('editor.showLineNumbers', false);
+        core.config.set('editor.showLineNumbers', false);
         expect(editorElement.querySelector('.gutter')).not.toHaveClass(
           'git-diff-icon'
         );
 
-        atom.config.set('editor.showLineNumbers', true);
+        core.config.set('editor.showLineNumbers', true);
         expect(editorElement.querySelector('.gutter')).toHaveClass(
           'git-diff-icon'
         );
@@ -303,7 +303,7 @@ describe('GitDiff package', () => {
       waitsFor(() => screenUpdates > 0);
 
       runs(() => {
-        atom.config.set('git-diff.showIconsInEditorGutter', false);
+        core.config.set('git-diff.showIconsInEditorGutter', false);
         expect(editorElement.querySelector('.gutter')).not.toHaveClass(
           'git-diff-icon'
         );

--- a/packages/git-diff/spec/git-diff-subfolder-spec.js
+++ b/packages/git-diff/spec/git-diff-subfolder-spec.js
@@ -31,18 +31,18 @@ describe('GitDiff when targeting nested repository', () => {
       path.join(nestedPath, '.git')
     );
 
-    atom.project.setPaths([projectPath]);
+    core.project.setPaths([projectPath]);
 
-    jasmine.attachToDOM(atom.workspace.getElement());
+    jasmine.attachToDOM(core.workspace.getElement());
 
     waitsForPromise(async () => {
-      await atom.workspace.open(path.join(nestedPath, 'sample.js'));
-      await atom.packages.activatePackage('git-diff');
+      await core.workspace.open(path.join(nestedPath, 'sample.js'));
+      await core.packages.activatePackage('git-diff');
     });
 
     runs(() => {
-      editor = atom.workspace.getActiveTextEditor();
-      editorElement = atom.views.getView(editor);
+      editor = core.workspace.getActiveTextEditor();
+      editorElement = core.views.getView(editor);
     });
   });
 

--- a/packages/git-diff/spec/init-spec.js
+++ b/packages/git-diff/spec/init-spec.js
@@ -18,27 +18,27 @@ describe('git-diff', () => {
       path.join(projectPath, 'git.git'),
       path.join(projectPath, '.git')
     );
-    atom.project.setPaths([projectPath]);
+    core.project.setPaths([projectPath]);
 
-    jasmine.attachToDOM(atom.workspace.getElement());
+    jasmine.attachToDOM(core.workspace.getElement());
 
-    waitsForPromise(() => atom.workspace.open('sample.js'));
+    waitsForPromise(() => core.workspace.open('sample.js'));
 
     runs(() => {
-      editor = atom.workspace.getActiveTextEditor();
-      element = atom.views.getView(editor);
+      editor = core.workspace.getActiveTextEditor();
+      element = core.views.getView(editor);
     });
   });
 
   describe('When the module is deactivated', () => {
     it('removes all registered command hooks after deactivation.', () => {
-      waitsForPromise(() => atom.packages.activatePackage('git-diff'));
-      waitsForPromise(() => atom.packages.deactivatePackage('git-diff'));
+      waitsForPromise(() => core.packages.activatePackage('git-diff'));
+      waitsForPromise(() => core.packages.deactivatePackage('git-diff'));
       runs(() => {
         // NOTE: don't use enable and disable from the Public API.
-        expect(atom.packages.isPackageActive('git-diff')).toBe(false);
+        expect(core.packages.isPackageActive('git-diff')).toBe(false);
 
-        atom.commands
+        core.commands
           .findCommands({ target: element })
           .filter(({ name }) => commands.includes(name))
           .forEach(command => expect(commands).not.toContain(command.name));

--- a/packages/go-to-line/lib/go-to-line-view.js
+++ b/packages/go-to-line/lib/go-to-line-view.js
@@ -15,18 +15,18 @@ class GoToLineView {
     this.element.appendChild(this.miniEditor.element);
     this.element.appendChild(this.message);
 
-    this.panel = atom.workspace.addModalPanel({
+    this.panel = core.workspace.addModalPanel({
       item: this,
       visible: false
     });
-    atom.commands.add('atom-text-editor', 'go-to-line:toggle', () => {
+    core.commands.add('atom-text-editor', 'go-to-line:toggle', () => {
       this.toggle();
       return false;
     });
-    atom.commands.add(this.miniEditor.element, 'core:confirm', () => {
+    core.commands.add(this.miniEditor.element, 'core:confirm', () => {
       this.navigate();
     });
-    atom.commands.add(this.miniEditor.element, 'core:cancel', () => {
+    core.commands.add(this.miniEditor.element, 'core:cancel', () => {
       this.close();
     });
     this.miniEditor.onWillInsertText(arg => {
@@ -54,7 +54,7 @@ class GoToLineView {
 
   navigate(options = {}) {
     const lineNumber = this.miniEditor.getText();
-    const editor = atom.workspace.getActiveTextEditor();
+    const editor = core.workspace.getActiveTextEditor();
     if (!options.keepOpen) {
       this.close();
     }
@@ -91,11 +91,11 @@ class GoToLineView {
     ) {
       return this.previouslyFocusedElement.focus();
     }
-    atom.views.getView(atom.workspace).focus();
+    core.views.getView(core.workspace).focus();
   }
 
   open() {
-    if (this.panel.isVisible() || !atom.workspace.getActiveTextEditor()) return;
+    if (this.panel.isVisible() || !core.workspace.getActiveTextEditor()) return;
     this.storeFocusedElement();
     this.panel.show();
     this.message.textContent =

--- a/packages/go-to-line/spec/go-to-line-spec.js
+++ b/packages/go-to-line/spec/go-to-line-spec.js
@@ -11,16 +11,16 @@ describe('GoToLine', () => {
 
   beforeEach(() => {
     waitsForPromise(() => {
-      return atom.workspace.open('sample.js');
+      return core.workspace.open('sample.js');
     });
 
     runs(() => {
-      const workspaceElement = atom.views.getView(atom.workspace);
+      const workspaceElement = core.views.getView(core.workspace);
       workspaceElement.style.height = '200px';
       workspaceElement.style.width = '1000px';
       jasmine.attachToDOM(workspaceElement);
-      editor = atom.workspace.getActiveTextEditor();
-      editorView = atom.views.getView(editor);
+      editor = core.workspace.getActiveTextEditor();
+      editorView = core.views.getView(editor);
       goToLine = GoToLineView.activate();
       editor.setCursorBufferPosition([1, 0]);
     });
@@ -29,7 +29,7 @@ describe('GoToLine', () => {
   describe('when go-to-line:toggle is triggered', () => {
     it('adds a modal panel', () => {
       expect(goToLine.panel.isVisible()).toBeFalsy();
-      atom.commands.dispatch(editorView, 'go-to-line:toggle');
+      core.commands.dispatch(editorView, 'go-to-line:toggle');
       expect(goToLine.panel.isVisible()).toBeTruthy();
     });
   });
@@ -67,13 +67,13 @@ describe('GoToLine', () => {
     it('moves the cursor to the column number of the line specified', () => {
       expect(goToLine.miniEditor.getText()).toBe('');
       goToLine.miniEditor.insertText('3:14');
-      atom.commands.dispatch(goToLine.miniEditor.element, 'core:confirm');
+      core.commands.dispatch(goToLine.miniEditor.element, 'core:confirm');
       expect(editor.getCursorBufferPosition()).toEqual([2, 13]);
     });
 
     it('centers the selected line', () => {
       goToLine.miniEditor.insertText('45:4');
-      atom.commands.dispatch(goToLine.miniEditor.element, 'core:confirm');
+      core.commands.dispatch(goToLine.miniEditor.element, 'core:confirm');
       const rowsPerPage = editor.getRowsPerPage();
       const currentRow = editor.getCursorBufferPosition().row;
       expect(editor.getFirstVisibleScreenRow()).toBe(
@@ -87,11 +87,11 @@ describe('GoToLine', () => {
 
   describe('when entering a line number greater than the number of rows in the buffer', () => {
     it('moves the cursor position to the first character of the last line', () => {
-      atom.commands.dispatch(editorView, 'go-to-line:toggle');
+      core.commands.dispatch(editorView, 'go-to-line:toggle');
       expect(goToLine.panel.isVisible()).toBeTruthy();
       expect(goToLine.miniEditor.getText()).toBe('');
       goToLine.miniEditor.insertText('78');
-      atom.commands.dispatch(goToLine.miniEditor.element, 'core:confirm');
+      core.commands.dispatch(goToLine.miniEditor.element, 'core:confirm');
       expect(goToLine.panel.isVisible()).toBeFalsy();
       expect(editor.getCursorBufferPosition()).toEqual([77, 0]);
     });
@@ -99,11 +99,11 @@ describe('GoToLine', () => {
 
   describe('when entering a column number greater than the number in the specified line', () => {
     it('moves the cursor position to the last character of the specified line', () => {
-      atom.commands.dispatch(editorView, 'go-to-line:toggle');
+      core.commands.dispatch(editorView, 'go-to-line:toggle');
       expect(goToLine.panel.isVisible()).toBeTruthy();
       expect(goToLine.miniEditor.getText()).toBe('');
       goToLine.miniEditor.insertText('3:43');
-      atom.commands.dispatch(goToLine.miniEditor.element, 'core:confirm');
+      core.commands.dispatch(goToLine.miniEditor.element, 'core:confirm');
       expect(goToLine.panel.isVisible()).toBeFalsy();
       expect(editor.getCursorBufferPosition()).toEqual([2, 39]);
     });
@@ -113,7 +113,7 @@ describe('GoToLine', () => {
     describe('when a line number has been entered', () => {
       it('moves the cursor to the first character of the line', () => {
         goToLine.miniEditor.insertText('3');
-        atom.commands.dispatch(goToLine.miniEditor.element, 'core:confirm');
+        core.commands.dispatch(goToLine.miniEditor.element, 'core:confirm');
         expect(editor.getCursorBufferPosition()).toEqual([2, 4]);
       });
     });
@@ -124,7 +124,7 @@ describe('GoToLine', () => {
         editor.foldAll();
         expect(editor.screenRowForBufferRow(9)).toEqual(0);
         goToLine.miniEditor.insertText('10');
-        atom.commands.dispatch(goToLine.miniEditor.element, 'core:confirm');
+        core.commands.dispatch(goToLine.miniEditor.element, 'core:confirm');
         expect(editor.getCursorBufferPosition()).toEqual([9, 6]);
       });
     });
@@ -132,9 +132,9 @@ describe('GoToLine', () => {
 
   describe('when no line number has been entered', () => {
     it('closes the view and does not update the cursor position', () => {
-      atom.commands.dispatch(editorView, 'go-to-line:toggle');
+      core.commands.dispatch(editorView, 'go-to-line:toggle');
       expect(goToLine.panel.isVisible()).toBeTruthy();
-      atom.commands.dispatch(goToLine.miniEditor.element, 'core:confirm');
+      core.commands.dispatch(goToLine.miniEditor.element, 'core:confirm');
       expect(goToLine.panel.isVisible()).toBeFalsy();
       expect(editor.getCursorBufferPosition()).toEqual([1, 0]);
     });
@@ -142,16 +142,16 @@ describe('GoToLine', () => {
 
   describe('when no line number has been entered, but a column number has been entered', () => {
     it('navigates to the column of the current line', () => {
-      atom.commands.dispatch(editorView, 'go-to-line:toggle');
+      core.commands.dispatch(editorView, 'go-to-line:toggle');
       expect(goToLine.panel.isVisible()).toBeTruthy();
       goToLine.miniEditor.insertText('4:1');
-      atom.commands.dispatch(goToLine.miniEditor.element, 'core:confirm');
+      core.commands.dispatch(goToLine.miniEditor.element, 'core:confirm');
       expect(goToLine.panel.isVisible()).toBeFalsy();
       expect(editor.getCursorBufferPosition()).toEqual([3, 0]);
-      atom.commands.dispatch(editorView, 'go-to-line:toggle');
+      core.commands.dispatch(editorView, 'go-to-line:toggle');
       expect(goToLine.panel.isVisible()).toBeTruthy();
       goToLine.miniEditor.insertText(':19');
-      atom.commands.dispatch(goToLine.miniEditor.element, 'core:confirm');
+      core.commands.dispatch(goToLine.miniEditor.element, 'core:confirm');
       expect(goToLine.panel.isVisible()).toBeFalsy();
       expect(editor.getCursorBufferPosition()).toEqual([3, 18]);
     });
@@ -159,9 +159,9 @@ describe('GoToLine', () => {
 
   describe('when core:cancel is triggered', () => {
     it('closes the view and does not update the cursor position', () => {
-      atom.commands.dispatch(editorView, 'go-to-line:toggle');
+      core.commands.dispatch(editorView, 'go-to-line:toggle');
       expect(goToLine.panel.isVisible()).toBeTruthy();
-      atom.commands.dispatch(goToLine.miniEditor.element, 'core:cancel');
+      core.commands.dispatch(goToLine.miniEditor.element, 'core:cancel');
       expect(goToLine.panel.isVisible()).toBeFalsy();
       expect(editor.getCursorBufferPosition()).toEqual([1, 0]);
     });

--- a/packages/grammar-selector/lib/grammar-list-view.js
+++ b/packages/grammar-selector/lib/grammar-list-view.js
@@ -47,9 +47,9 @@ module.exports = class GrammarListView {
       didConfirmSelection: grammar => {
         this.cancel();
         if (grammar === this.autoDetect) {
-          atom.textEditors.clearGrammarOverride(this.editor);
+          core.textEditors.clearGrammarOverride(this.editor);
         } else {
-          atom.grammars.assignGrammar(this.editor, grammar);
+          core.grammars.assignGrammar(this.editor, grammar);
         }
       },
       didCancelSelection: () => {
@@ -79,7 +79,7 @@ module.exports = class GrammarListView {
   attach() {
     this.previouslyFocusedElement = document.activeElement;
     if (this.panel == null) {
-      this.panel = atom.workspace.addModalPanel({ item: this.selectListView });
+      this.panel = core.workspace.addModalPanel({ item: this.selectListView });
     }
     this.selectListView.focus();
     this.selectListView.reset();
@@ -91,21 +91,21 @@ module.exports = class GrammarListView {
       return;
     }
 
-    const editor = atom.workspace.getActiveTextEditor();
+    const editor = core.workspace.getActiveTextEditor();
     if (editor) {
       this.editor = editor;
       this.currentGrammar = this.editor.getGrammar();
-      if (this.currentGrammar === atom.grammars.nullGrammar) {
+      if (this.currentGrammar === core.grammars.nullGrammar) {
         this.currentGrammar = this.autoDetect;
       }
 
-      let grammars = atom.grammars
+      let grammars = core.grammars
         .getGrammars({ includeTreeSitter: true })
         .filter(grammar => {
-          return grammar !== atom.grammars.nullGrammar && grammar.name;
+          return grammar !== core.grammars.nullGrammar && grammar.name;
         });
 
-      if (atom.config.get('grammar-selector.hideDuplicateTextMateGrammars')) {
+      if (core.config.get('grammar-selector.hideDuplicateTextMateGrammars')) {
         const blacklist = new Set();
         grammars.forEach(grammar => {
           if (isTreeSitter(grammar)) {

--- a/packages/grammar-selector/lib/grammar-status-view.js
+++ b/packages/grammar-selector/lib/grammar-status-view.js
@@ -9,18 +9,18 @@ module.exports = class GrammarStatusView {
     this.grammarLink.classList.add('inline-block');
     this.element.appendChild(this.grammarLink);
 
-    this.activeItemSubscription = atom.workspace.observeActiveTextEditor(
+    this.activeItemSubscription = core.workspace.observeActiveTextEditor(
       this.subscribeToActiveTextEditor.bind(this)
     );
 
-    this.configSubscription = atom.config.observe(
+    this.configSubscription = core.config.observe(
       'grammar-selector.showOnRightSideOfStatusBar',
       this.attach.bind(this)
     );
     const clickHandler = event => {
       event.preventDefault();
-      atom.commands.dispatch(
-        atom.views.getView(atom.workspace.getActiveTextEditor()),
+      core.commands.dispatch(
+        core.views.getView(core.workspace.getActiveTextEditor()),
         'grammar-selector:show'
       );
     };
@@ -35,7 +35,7 @@ module.exports = class GrammarStatusView {
       this.tile.destroy();
     }
 
-    this.tile = atom.config.get('grammar-selector.showOnRightSideOfStatusBar')
+    this.tile = core.config.get('grammar-selector.showOnRightSideOfStatusBar')
       ? this.statusBar.addRightTile({ item: this.element, priority: 10 })
       : this.statusBar.addLeftTile({ item: this.element, priority: 10 });
   }
@@ -72,7 +72,7 @@ module.exports = class GrammarStatusView {
       this.grammarSubscription = null;
     }
 
-    const editor = atom.workspace.getActiveTextEditor();
+    const editor = core.workspace.getActiveTextEditor();
     if (editor) {
       this.grammarSubscription = editor.onDidChangeGrammar(
         this.updateGrammarText.bind(this)
@@ -82,8 +82,8 @@ module.exports = class GrammarStatusView {
   }
 
   updateGrammarText() {
-    atom.views.updateDocument(() => {
-      const editor = atom.workspace.getActiveTextEditor();
+    core.views.updateDocument(() => {
+      const editor = core.workspace.getActiveTextEditor();
       const grammar = editor ? editor.getGrammar() : null;
 
       if (this.tooltip) {
@@ -93,7 +93,7 @@ module.exports = class GrammarStatusView {
 
       if (grammar) {
         let grammarName = null;
-        if (grammar === atom.grammars.nullGrammar) {
+        if (grammar === core.grammars.nullGrammar) {
           grammarName = 'Plain Text';
         } else {
           grammarName = grammar.name || grammar.scopeName;
@@ -103,7 +103,7 @@ module.exports = class GrammarStatusView {
         this.grammarLink.dataset.grammar = grammarName;
         this.element.style.display = '';
 
-        this.tooltip = atom.tooltips.add(this.element, {
+        this.tooltip = core.tooltips.add(this.element, {
           title: `File uses the ${grammarName} grammar`
         });
       } else {

--- a/packages/grammar-selector/lib/main.js
+++ b/packages/grammar-selector/lib/main.js
@@ -7,7 +7,7 @@ let grammarStatusView = null;
 
 module.exports = {
   activate() {
-    commandDisposable = atom.commands.add(
+    commandDisposable = core.commands.add(
       'atom-text-editor',
       'grammar-selector:show',
       () => {

--- a/packages/grammar-selector/spec/grammar-selector-spec.js
+++ b/packages/grammar-selector/spec/grammar-selector-spec.js
@@ -5,23 +5,23 @@ describe('GrammarSelector', () => {
   let [editor, textGrammar, jsGrammar] = [];
 
   beforeEach(async () => {
-    jasmine.attachToDOM(atom.views.getView(atom.workspace));
-    atom.config.set('grammar-selector.showOnRightSideOfStatusBar', false);
-    atom.config.set('grammar-selector.hideDuplicateTextMateGrammars', false);
+    jasmine.attachToDOM(core.views.getView(core.workspace));
+    core.config.set('grammar-selector.showOnRightSideOfStatusBar', false);
+    core.config.set('grammar-selector.hideDuplicateTextMateGrammars', false);
 
-    await atom.packages.activatePackage('status-bar');
-    await atom.packages.activatePackage('grammar-selector');
-    await atom.packages.activatePackage('language-text');
-    await atom.packages.activatePackage('language-javascript');
-    await atom.packages.activatePackage(
+    await core.packages.activatePackage('status-bar');
+    await core.packages.activatePackage('grammar-selector');
+    await core.packages.activatePackage('language-text');
+    await core.packages.activatePackage('language-javascript');
+    await core.packages.activatePackage(
       path.join(__dirname, 'fixtures', 'language-with-no-name')
     );
 
-    editor = await atom.workspace.open('sample.js');
+    editor = await core.workspace.open('sample.js');
 
-    textGrammar = atom.grammars.grammarForScopeName('text.plain');
+    textGrammar = core.grammars.grammarForScopeName('text.plain');
     expect(textGrammar).toBeTruthy();
-    jsGrammar = atom.grammars.grammarForScopeName('source.js');
+    jsGrammar = core.grammars.grammarForScopeName('source.js');
     expect(jsGrammar).toBeTruthy();
     expect(editor.getGrammar()).toBe(jsGrammar);
   });
@@ -33,7 +33,7 @@ describe('GrammarSelector', () => {
       // -1 for removing nullGrammar, +1 for adding "Auto Detect"
       // Tree-sitter names the regex and JSDoc grammars
       expect(grammarView.querySelectorAll('li').length).toBe(
-        atom.grammars
+        core.grammars
           .getGrammars({ includeTreeSitter: true })
           .filter(g => g.name).length
       );
@@ -44,7 +44,7 @@ describe('GrammarSelector', () => {
       grammarView
         .querySelectorAll('li')
         .forEach(li =>
-          expect(li.textContent).not.toBe(atom.grammars.nullGrammar.name)
+          expect(li.textContent).not.toBe(core.grammars.nullGrammar.name)
         );
       expect(grammarView.textContent.includes('Tree-sitter')).toBe(true); // check we are showing and labelling Tree-sitter grammars
     }));
@@ -69,7 +69,7 @@ describe('GrammarSelector', () => {
 
   describe("when the editor's current grammar is the null grammar", () =>
     it('displays Auto Detect as the selected grammar', async () => {
-      editor.setGrammar(atom.grammars.nullGrammar);
+      editor.setGrammar(core.grammars.nullGrammar);
       const grammarView = (await getGrammarView(editor)).element;
       expect(grammarView.querySelector('li.active').textContent).toBe(
         'Auto Detect'
@@ -78,7 +78,7 @@ describe('GrammarSelector', () => {
 
   describe('when editor is untitled', () =>
     it('sets the new grammar on the editor', async () => {
-      editor = await atom.workspace.open();
+      editor = await core.workspace.open();
       expect(editor.getGrammar()).not.toBe(jsGrammar);
 
       const grammarView = await getGrammarView(editor);
@@ -96,7 +96,7 @@ describe('GrammarSelector', () => {
 
       // Wait for status bar service hook to fire
       while (!grammarStatus || !grammarStatus.textContent) {
-        await atom.views.getNextUpdatePromise();
+        await core.views.getNextUpdatePromise();
         grammarStatus = document.querySelector('.grammar-status');
       }
     });
@@ -109,8 +109,8 @@ describe('GrammarSelector', () => {
     });
 
     it('displays Plain Text when the current grammar is the null grammar', async () => {
-      editor.setGrammar(atom.grammars.nullGrammar);
-      await atom.views.getNextUpdatePromise();
+      editor.setGrammar(core.grammars.nullGrammar);
+      await core.views.getNextUpdatePromise();
 
       expect(grammarStatus.querySelector('a').textContent).toBe('Plain Text');
       expect(grammarStatus).toBeVisible();
@@ -118,8 +118,8 @@ describe('GrammarSelector', () => {
         'File uses the Plain Text grammar'
       );
 
-      editor.setGrammar(atom.grammars.grammarForScopeName('source.js'));
-      await atom.views.getNextUpdatePromise();
+      editor.setGrammar(core.grammars.grammarForScopeName('source.js'));
+      await core.views.getNextUpdatePromise();
 
       expect(grammarStatus.querySelector('a').textContent).toBe('JavaScript');
       expect(grammarStatus).toBeVisible();
@@ -128,8 +128,8 @@ describe('GrammarSelector', () => {
     it('hides the label when the current grammar is null', async () => {
       jasmine.attachToDOM(editor.getElement());
       spyOn(editor, 'getGrammar').andReturn(null);
-      editor.setGrammar(atom.grammars.nullGrammar);
-      await atom.views.getNextUpdatePromise();
+      editor.setGrammar(core.grammars.nullGrammar);
+      await core.views.getNextUpdatePromise();
       expect(grammarStatus.offsetHeight).toBe(0);
     });
 
@@ -142,7 +142,7 @@ describe('GrammarSelector', () => {
           statusBar.getRightTiles().map(tile => tile.getItem())
         ).not.toContain(grammarStatus);
 
-        atom.config.set('grammar-selector.showOnRightSideOfStatusBar', true);
+        core.config.set('grammar-selector.showOnRightSideOfStatusBar', true);
 
         expect(
           statusBar.getLeftTiles().map(tile => tile.getItem())
@@ -151,7 +151,7 @@ describe('GrammarSelector', () => {
           grammarStatus
         );
 
-        atom.config.set('grammar-selector.showOnRightSideOfStatusBar', false);
+        core.config.set('grammar-selector.showOnRightSideOfStatusBar', false);
 
         expect(statusBar.getLeftTiles().map(tile => tile.getItem())).toContain(
           grammarStatus
@@ -163,16 +163,16 @@ describe('GrammarSelector', () => {
 
     describe("when the editor's grammar changes", () =>
       it('displays the new grammar of the editor', async () => {
-        editor.setGrammar(atom.grammars.grammarForScopeName('text.plain'));
-        await atom.views.getNextUpdatePromise();
+        editor.setGrammar(core.grammars.grammarForScopeName('text.plain'));
+        await core.views.getNextUpdatePromise();
 
         expect(grammarStatus.querySelector('a').textContent).toBe('Plain Text');
         expect(getTooltipText(grammarStatus)).toBe(
           'File uses the Plain Text grammar'
         );
 
-        editor.setGrammar(atom.grammars.grammarForScopeName('source.a'));
-        await atom.views.getNextUpdatePromise();
+        editor.setGrammar(core.grammars.grammarForScopeName('source.a'));
+        await core.views.getNextUpdatePromise();
 
         expect(grammarStatus.querySelector('a').textContent).toBe('source.a');
         expect(getTooltipText(grammarStatus)).toBe(
@@ -183,7 +183,7 @@ describe('GrammarSelector', () => {
     describe('when toggling hideDuplicateTextMateGrammars', () => {
       it('shows only the Tree-sitter if true and both exist', async () => {
         // the main JS grammar has both a TextMate and Tree-sitter implementation
-        atom.config.set('grammar-selector.hideDuplicateTextMateGrammars', true);
+        core.config.set('grammar-selector.hideDuplicateTextMateGrammars', true);
         const grammarView = await getGrammarView(editor);
         const observedNames = new Set();
         grammarView.element.querySelectorAll('li').forEach(li => {
@@ -193,7 +193,7 @@ describe('GrammarSelector', () => {
         });
 
         // check the seen JS is actually the Tree-sitter one
-        const list = atom.workspace.getModalPanels()[0].item;
+        const list = core.workspace.getModalPanels()[0].item;
         for (const item of list.items) {
           if (item.name === 'JavaScript') {
             expect(item.constructor.name === 'TreeSitterGrammar');
@@ -202,15 +202,15 @@ describe('GrammarSelector', () => {
       });
 
       it('shows both if false', async () => {
-        await atom.packages.activatePackage('language-c'); // punctuation making it sort wrong
-        atom.config.set(
+        await core.packages.activatePackage('language-c'); // punctuation making it sort wrong
+        core.config.set(
           'grammar-selector.hideDuplicateTextMateGrammars',
           false
         );
         await getGrammarView(editor);
         let cppCount = 0;
 
-        const listItems = atom.workspace.getModalPanels()[0].item.items;
+        const listItems = core.workspace.getModalPanels()[0].item.items;
         for (let i = 0; i < listItems.length; i++) {
           const grammar = listItems[i];
           const name = grammar.name;
@@ -234,7 +234,7 @@ describe('GrammarSelector', () => {
       it('adds a label to identify it as Tree-sitter', async () => {
         const grammarView = await getGrammarView(editor);
         const elements = grammarView.element.querySelectorAll('li');
-        const listItems = atom.workspace.getModalPanels()[0].item.items;
+        const listItems = core.workspace.getModalPanels()[0].item.items;
         for (let i = 0; i < listItems.length; i++) {
           if (listItems[i].constructor.name === 'TreeSitterGrammar') {
             expect(
@@ -250,7 +250,7 @@ describe('GrammarSelector', () => {
     describe('when clicked', () =>
       it('shows the grammar selector modal', () => {
         const eventHandler = jasmine.createSpy('eventHandler');
-        atom.commands.add(
+        core.commands.add(
           editor.getElement(),
           'grammar-selector:show',
           eventHandler
@@ -262,19 +262,19 @@ describe('GrammarSelector', () => {
     describe('when the package is deactivated', () =>
       it('removes the view', () => {
         spyOn(grammarTile, 'destroy');
-        atom.packages.deactivatePackage('grammar-selector');
+        core.packages.deactivatePackage('grammar-selector');
         expect(grammarTile.destroy).toHaveBeenCalled();
       }));
   });
 });
 
 function getTooltipText(element) {
-  const [tooltip] = atom.tooltips.findTooltips(element);
+  const [tooltip] = core.tooltips.findTooltips(element);
   return tooltip.getTitle();
 }
 
 async function getGrammarView(editor) {
-  atom.commands.dispatch(editor.getElement(), 'grammar-selector:show');
+  core.commands.dispatch(editor.getElement(), 'grammar-selector:show');
   await SelectListView.getScheduler().getNextUpdatePromise();
-  return atom.workspace.getModalPanels()[0].getItem();
+  return core.workspace.getModalPanels()[0].getItem();
 }

--- a/packages/incompatible-packages/lib/incompatible-packages-component.js
+++ b/packages/incompatible-packages/lib/incompatible-packages-component.js
@@ -28,9 +28,9 @@ export default class IncompatiblePackagesComponent {
       if (event.target === this.refs.rebuildButton) {
         this.rebuildIncompatiblePackages();
       } else if (event.target === this.refs.reloadButton) {
-        atom.reload();
+        core.reload();
       } else if (event.target.classList.contains('view-settings')) {
-        atom.workspace.open(
+        core.workspace.open(
           `atom://config/packages/${event.target.package.name}`
         );
       }

--- a/packages/incompatible-packages/lib/main.js
+++ b/packages/incompatible-packages/lib/main.js
@@ -9,7 +9,7 @@ export function activate() {
   disposables = new CompositeDisposable();
 
   disposables.add(
-    atom.workspace.addOpener(uri => {
+    core.workspace.addOpener(uri => {
       if (uri === VIEW_URI) {
         return deserializeIncompatiblePackagesComponent();
       }
@@ -17,9 +17,9 @@ export function activate() {
   );
 
   disposables.add(
-    atom.commands.add('atom-workspace', {
+    core.commands.add('atom-workspace', {
       'incompatible-packages:view': () => {
-        atom.workspace.open(VIEW_URI);
+        core.workspace.open(VIEW_URI);
       }
     })
   );
@@ -31,7 +31,7 @@ export function deactivate() {
 
 export function consumeStatusBar(statusBar) {
   let incompatibleCount = 0;
-  for (let pack of atom.packages.getLoadedPackages()) {
+  for (let pack of core.packages.getLoadedPackages()) {
     if (!pack.isCompatible()) incompatibleCount++;
   }
 
@@ -39,7 +39,7 @@ export function consumeStatusBar(statusBar) {
     let icon = createIcon(incompatibleCount);
     let tile = statusBar.addRightTile({ item: icon, priority: 200 });
     icon.element.addEventListener('click', () => {
-      atom.commands.dispatch(icon.element, 'incompatible-packages:view');
+      core.commands.dispatch(icon.element, 'incompatible-packages:view');
     });
     disposables.add(new Disposable(() => tile.destroy()));
   }
@@ -47,7 +47,7 @@ export function consumeStatusBar(statusBar) {
 
 export function deserializeIncompatiblePackagesComponent() {
   const IncompatiblePackagesComponent = require('./incompatible-packages-component');
-  return new IncompatiblePackagesComponent(atom.packages);
+  return new IncompatiblePackagesComponent(core.packages);
 }
 
 function createIcon(count) {

--- a/packages/incompatible-packages/spec/incompatible-packages-component-spec.js
+++ b/packages/incompatible-packages/spec/incompatible-packages-component-spec.js
@@ -248,11 +248,11 @@ describe('IncompatiblePackagesComponent', () => {
           expect(component.refs.reloadButton).toBeDefined();
           expect(element.querySelector('.alert').textContent).toMatch(/2 of 2/);
 
-          spyOn(atom, 'reload');
+          spyOn(core, 'reload');
           component.refs.reloadButton.dispatchEvent(
             new CustomEvent('click', { bubbles: true })
           );
-          expect(atom.reload).toHaveBeenCalled();
+          expect(core.reload).toHaveBeenCalled();
         });
       });
     });
@@ -269,11 +269,11 @@ describe('IncompatiblePackagesComponent', () => {
 
           await etchScheduler.getNextUpdatePromise();
 
-          spyOn(atom.workspace, 'open');
+          spyOn(core.workspace, 'open');
           element
             .querySelector('.incompatible-package:nth-child(2) button')
             .dispatchEvent(new CustomEvent('click', { bubbles: true }));
-          expect(atom.workspace.open).toHaveBeenCalledWith(
+          expect(core.workspace.open).toHaveBeenCalledWith(
             'atom://config/packages/incompatible-2'
           );
         });

--- a/packages/incompatible-packages/spec/incompatible-packages-spec.js
+++ b/packages/incompatible-packages/spec/incompatible-packages-spec.js
@@ -6,23 +6,23 @@ import StatusIconComponent from '../lib/status-icon-component';
 
 // This exists only so that CI passes on both Atom 1.6 and Atom 1.8+.
 function findStatusBar() {
-  if (typeof atom.workspace.getFooterPanels === 'function') {
-    const footerPanels = atom.workspace.getFooterPanels();
+  if (typeof core.workspace.getFooterPanels === 'function') {
+    const footerPanels = core.workspace.getFooterPanels();
     if (footerPanels.length > 0) {
       return footerPanels[0].getItem();
     }
   }
 
-  return atom.workspace.getBottomPanels()[0].getItem();
+  return core.workspace.getBottomPanels()[0].getItem();
 }
 
 describe('Incompatible packages', () => {
   let statusBar;
 
   beforeEach(() => {
-    atom.views.getView(atom.workspace);
+    core.views.getView(core.workspace);
 
-    waitsForPromise(() => atom.packages.activatePackage('status-bar'));
+    waitsForPromise(() => core.packages.activatePackage('status-bar'));
 
     runs(() => {
       statusBar = findStatusBar();
@@ -31,13 +31,13 @@ describe('Incompatible packages', () => {
 
   describe('when there are packages with incompatible native modules', () => {
     beforeEach(() => {
-      let incompatiblePackage = atom.packages.loadPackage(
+      let incompatiblePackage = core.packages.loadPackage(
         path.join(__dirname, 'fixtures', 'incompatible-package')
       );
       spyOn(incompatiblePackage, 'isCompatible').andReturn(false);
       incompatiblePackage.incompatibleModules = [];
       waitsForPromise(() =>
-        atom.packages.activatePackage('incompatible-packages')
+        core.packages.activatePackage('incompatible-packages')
       );
 
       waits(1);
@@ -54,7 +54,7 @@ describe('Incompatible packages', () => {
         statusBarIcon.element.dispatchEvent(new MouseEvent('click'));
 
         let activePaneItem;
-        waitsFor(() => (activePaneItem = atom.workspace.getActivePaneItem()));
+        waitsFor(() => (activePaneItem = core.workspace.getActivePaneItem()));
 
         runs(() => {
           expect(activePaneItem.constructor).toBe(
@@ -68,7 +68,7 @@ describe('Incompatible packages', () => {
   describe('when there are no packages with incompatible native modules', () => {
     beforeEach(() => {
       waitsForPromise(() =>
-        atom.packages.activatePackage('incompatible-packages')
+        core.packages.activatePackage('incompatible-packages')
       );
     });
 

--- a/packages/language-c/lib/main.js
+++ b/packages/language-c/lib/main.js
@@ -2,7 +2,7 @@ exports.activate = function() {
   // Highlight macro bodies as C/C++
   for (const language of ['c', 'cpp']) {
     for (const nodeType of ['preproc_def', 'preproc_function_def']) {
-      atom.grammars.addInjectionPoint(`source.${language}`, {
+      core.grammars.addInjectionPoint(`source.${language}`, {
         type: nodeType,
         language(node) {
           return language;

--- a/packages/language-c/spec/c-spec.coffee
+++ b/packages/language-c/spec/c-spec.coffee
@@ -1,7 +1,7 @@
 TextEditor = null
 buildTextEditor = (params) ->
-  if atom.workspace.buildTextEditor?
-    atom.workspace.buildTextEditor(params)
+  if core.workspace.buildTextEditor?
+    core.workspace.buildTextEditor(params)
   else
     TextEditor ?= require('atom').TextEditor
     new TextEditor(params)
@@ -10,14 +10,14 @@ describe "Language-C", ->
   grammar = null
 
   beforeEach ->
-    atom.config.set('core.useTreeSitterParsers', false)
+    core.config.set('core.useTreeSitterParsers', false)
 
     waitsForPromise ->
-      atom.packages.activatePackage('language-c')
+      core.packages.activatePackage('language-c')
 
   describe "C", ->
     beforeEach ->
-      grammar = atom.grammars.grammarForScopeName('source.c')
+      grammar = core.grammars.grammarForScopeName('source.c')
 
     it "parses the grammar", ->
       expect(grammar).toBeTruthy()
@@ -939,7 +939,7 @@ describe "Language-C", ->
 
   describe "C++", ->
     beforeEach ->
-      grammar = atom.grammars.grammarForScopeName('source.cpp')
+      grammar = core.grammars.grammarForScopeName('source.cpp')
 
     it "parses the grammar", ->
       expect(grammar).toBeTruthy()

--- a/packages/language-clojure/spec/clojure-spec.coffee
+++ b/packages/language-clojure/spec/clojure-spec.coffee
@@ -3,10 +3,10 @@ describe "Clojure grammar", ->
 
   beforeEach ->
     waitsForPromise ->
-      atom.packages.activatePackage("language-clojure")
+      core.packages.activatePackage("language-clojure")
 
     runs ->
-      grammar = atom.grammars.grammarForScopeName("source.clojure")
+      grammar = core.grammars.grammarForScopeName("source.clojure")
 
   it "parses the grammar", ->
     expect(grammar).toBeDefined()

--- a/packages/language-coffee-script/spec/coffee-script-literate-spec.coffee
+++ b/packages/language-coffee-script/spec/coffee-script-literate-spec.coffee
@@ -3,10 +3,10 @@ describe "CoffeeScript (Literate) grammar", ->
 
   beforeEach ->
     waitsForPromise ->
-      atom.packages.activatePackage("language-coffee-script")
+      core.packages.activatePackage("language-coffee-script")
 
     runs ->
-      grammar = atom.grammars.grammarForScopeName("source.litcoffee")
+      grammar = core.grammars.grammarForScopeName("source.litcoffee")
 
   it "parses the grammar", ->
     expect(grammar).toBeTruthy()

--- a/packages/language-coffee-script/spec/coffee-script-spec.coffee
+++ b/packages/language-coffee-script/spec/coffee-script-spec.coffee
@@ -6,10 +6,10 @@ describe "CoffeeScript grammar", ->
 
   beforeEach ->
     waitsForPromise ->
-      atom.packages.activatePackage("language-coffee-script")
+      core.packages.activatePackage("language-coffee-script")
 
     runs ->
-      grammar = atom.grammars.grammarForScopeName("source.coffee")
+      grammar = core.grammars.grammarForScopeName("source.coffee")
 
   it "parses the grammar", ->
     expect(grammar).toBeTruthy()
@@ -591,7 +591,7 @@ describe "CoffeeScript grammar", ->
 
   it "tokenizes embedded JavaScript", ->
     waitsForPromise ->
-      atom.packages.activatePackage("language-javascript")
+      core.packages.activatePackage("language-javascript")
 
     runs ->
       {tokens} = grammar.tokenizeLine("`;`")
@@ -1124,7 +1124,7 @@ describe "CoffeeScript grammar", ->
   describe "regular expressions", ->
     beforeEach ->
       waitsForPromise ->
-        atom.packages.activatePackage("language-javascript") # Provides the regexp subgrammar
+        core.packages.activatePackage("language-javascript") # Provides the regexp subgrammar
 
     it "tokenizes regular expressions", ->
       {tokens} = grammar.tokenizeLine("/test/")

--- a/packages/language-csharp/spec/grammar-spec.coffee
+++ b/packages/language-csharp/spec/grammar-spec.coffee
@@ -2,16 +2,16 @@ describe "Language C# package", ->
 
   beforeEach ->
     waitsForPromise ->
-      atom.packages.activatePackage("language-csharp")
+      core.packages.activatePackage("language-csharp")
 
   describe "C# Script grammar", ->
     it "parses the grammar", ->
-      grammar = atom.grammars.grammarForScopeName("source.csx")
+      grammar = core.grammars.grammarForScopeName("source.csx")
       expect(grammar).toBeDefined()
       expect(grammar.scopeName).toBe "source.csx"
 
   describe "C# Cake grammar", ->
     it "parses the grammar", ->
-      grammar = atom.grammars.grammarForScopeName("source.cake")
+      grammar = core.grammars.grammarForScopeName("source.cake")
       expect(grammar).toBeDefined()
       expect(grammar.scopeName).toBe "source.cake"

--- a/packages/language-css/spec/css-spec.coffee
+++ b/packages/language-css/spec/css-spec.coffee
@@ -2,13 +2,13 @@ describe 'CSS grammar', ->
   grammar = null
 
   beforeEach ->
-    atom.config.set('core.useTreeSitterParsers', false)
+    core.config.set('core.useTreeSitterParsers', false)
 
     waitsForPromise ->
-      atom.packages.activatePackage('language-css')
+      core.packages.activatePackage('language-css')
 
     runs ->
-      grammar = atom.grammars.grammarForScopeName('source.css')
+      grammar = core.grammars.grammarForScopeName('source.css')
 
   it 'parses the grammar', ->
     expect(grammar).toBeTruthy()
@@ -3476,7 +3476,7 @@ describe 'CSS grammar', ->
 
   describe "performance regressions", ->
     it "does not hang when tokenizing invalid input preceding an equals sign", ->
-      grammar = atom.grammars.grammarForScopeName('source.css')
+      grammar = core.grammars.grammarForScopeName('source.css')
       start = Date.now()
       grammar.tokenizeLine('<![CDATA[啊啊啊啊啊啊啊啊啊啊啊啊啊啊啊啊啊啊啊啊啊啊啊啊啊啊啊啊"=')
       expect(Date.now() - start).toBeLessThan(5000)

--- a/packages/language-gfm/spec/gfm-spec.coffee
+++ b/packages/language-gfm/spec/gfm-spec.coffee
@@ -3,10 +3,10 @@ describe "GitHub Flavored Markdown grammar", ->
 
   beforeEach ->
     waitsForPromise ->
-      atom.packages.activatePackage("language-gfm")
+      core.packages.activatePackage("language-gfm")
 
     runs ->
-      grammar = atom.grammars.grammarForScopeName("source.gfm")
+      grammar = core.grammars.grammarForScopeName("source.gfm")
 
   it "parses the grammar", ->
     expect(grammar).toBeDefined()

--- a/packages/language-git/spec/git-spec.coffee
+++ b/packages/language-git/spec/git-spec.coffee
@@ -3,11 +3,11 @@ describe "Git grammars", ->
 
   beforeEach ->
     waitsForPromise ->
-      atom.packages.activatePackage("language-git")
+      core.packages.activatePackage("language-git")
 
   describe "Git configs", ->
     beforeEach ->
-      grammar = atom.grammars.grammarForScopeName("source.git-config")
+      grammar = core.grammars.grammarForScopeName("source.git-config")
 
     it "parses the Git config grammar", ->
       expect(grammar).toBeTruthy()
@@ -27,7 +27,7 @@ describe "Git grammars", ->
     scopeLineOver72 = ['text.git-commit', 'meta.scope.message.git-commit', 'invalid.illegal.line-too-long.git-commit']
 
     beforeEach ->
-      grammar = atom.grammars.grammarForScopeName("text.git-commit")
+      grammar = core.grammars.grammarForScopeName("text.git-commit")
 
     it "parses the Git commit message grammar", ->
       expect(grammar).toBeTruthy()
@@ -159,7 +159,7 @@ describe "Git grammars", ->
 
   describe "Git rebases", ->
     beforeEach ->
-      grammar = atom.grammars.grammarForScopeName("text.git-rebase")
+      grammar = core.grammars.grammarForScopeName("text.git-rebase")
 
     it "parses the Git rebase message grammar", ->
       expect(grammar).toBeTruthy()
@@ -186,7 +186,7 @@ describe "Git grammars", ->
 
     it "includes language-shellscript highlighting when using the exec command", ->
       waitsForPromise ->
-        atom.packages.activatePackage("language-shellscript")
+        core.packages.activatePackage("language-shellscript")
 
       runs ->
         {tokens} = grammar.tokenizeLine "exec echo 'Hello World'"

--- a/packages/language-go/spec/go-spec.coffee
+++ b/packages/language-go/spec/go-spec.coffee
@@ -2,13 +2,13 @@ describe 'Go grammar', ->
   grammar = null
 
   beforeEach ->
-    atom.config.set('core.useTreeSitterParsers', false)
+    core.config.set('core.useTreeSitterParsers', false)
 
     waitsForPromise ->
-      atom.packages.activatePackage('language-go')
+      core.packages.activatePackage('language-go')
 
     runs ->
-      grammar = atom.grammars.grammarForScopeName('source.go')
+      grammar = core.grammars.grammarForScopeName('source.go')
 
   it 'parses the grammar', ->
     expect(grammar).toBeTruthy()

--- a/packages/language-go/spec/language-go-spec.coffee
+++ b/packages/language-go/spec/language-go-spec.coffee
@@ -5,15 +5,15 @@ describe 'Go settings', ->
     editor.destroy()
 
   beforeEach ->
-    atom.config.set('core.useTreeSitterParsers', false)
+    core.config.set('core.useTreeSitterParsers', false)
 
     waitsForPromise ->
-      atom.workspace.open().then (o) ->
+      core.workspace.open().then (o) ->
         editor = o
         languageMode = editor.languageMode
 
     waitsForPromise ->
-      atom.packages.activatePackage('language-go')
+      core.packages.activatePackage('language-go')
 
   it 'matches lines correctly using the increaseIndentPattern', ->
     increaseIndentRegex = languageMode.increaseIndentRegexForScopeDescriptor(['source.go'])

--- a/packages/language-html/lib/main.js
+++ b/packages/language-html/lib/main.js
@@ -1,5 +1,5 @@
 exports.activate = function() {
-  atom.grammars.addInjectionPoint('text.html.basic', {
+  core.grammars.addInjectionPoint('text.html.basic', {
     type: 'script_element',
     language() {
       return 'javascript';
@@ -9,7 +9,7 @@ exports.activate = function() {
     }
   });
 
-  atom.grammars.addInjectionPoint('text.html.basic', {
+  core.grammars.addInjectionPoint('text.html.basic', {
     type: 'style_element',
     language() {
       return 'css';
@@ -19,7 +19,7 @@ exports.activate = function() {
     }
   });
 
-  atom.grammars.addInjectionPoint('text.html.ejs', {
+  core.grammars.addInjectionPoint('text.html.ejs', {
     type: 'template',
     language(node) {
       return 'javascript';
@@ -30,7 +30,7 @@ exports.activate = function() {
     newlinesBetween: true
   });
 
-  atom.grammars.addInjectionPoint('text.html.ejs', {
+  core.grammars.addInjectionPoint('text.html.ejs', {
     type: 'template',
     language(node) {
       return 'html';
@@ -40,7 +40,7 @@ exports.activate = function() {
     }
   });
 
-  atom.grammars.addInjectionPoint('text.html.erb', {
+  core.grammars.addInjectionPoint('text.html.erb', {
     type: 'template',
     language(node) {
       return 'ruby';
@@ -51,7 +51,7 @@ exports.activate = function() {
     newlinesBetween: true
   });
 
-  atom.grammars.addInjectionPoint('text.html.erb', {
+  core.grammars.addInjectionPoint('text.html.erb', {
     type: 'template',
     language(node) {
       return 'html';

--- a/packages/language-html/spec/html-spec.coffee
+++ b/packages/language-html/spec/html-spec.coffee
@@ -5,13 +5,13 @@ describe 'TextMate HTML grammar', ->
   grammar = null
 
   beforeEach ->
-    atom.config.set('core.useTreeSitterParsers', false)
+    core.config.set('core.useTreeSitterParsers', false)
 
     waitsForPromise ->
-      atom.packages.activatePackage('language-html')
+      core.packages.activatePackage('language-html')
 
     runs ->
-      grammar = atom.grammars.grammarForScopeName('text.html.basic')
+      grammar = core.grammars.grammarForScopeName('text.html.basic')
 
   it 'parses the grammar', ->
     expect(grammar).toBeTruthy()
@@ -20,7 +20,7 @@ describe 'TextMate HTML grammar', ->
   describe 'style tags', ->
     beforeEach ->
       waitsForPromise ->
-        atom.packages.activatePackage('language-css')
+        core.packages.activatePackage('language-css')
 
     it 'tokenizes the tag attributes', ->
       lines = grammar.tokenizeLines '''
@@ -170,7 +170,7 @@ describe 'TextMate HTML grammar', ->
   describe 'CoffeeScript script tags', ->
     beforeEach ->
       waitsForPromise ->
-        atom.packages.activatePackage('language-coffee-script')
+        core.packages.activatePackage('language-coffee-script')
 
     it 'tokenizes the content inside the tag as CoffeeScript', ->
       lines = grammar.tokenizeLines '''
@@ -182,7 +182,7 @@ describe 'TextMate HTML grammar', ->
       expect(lines[0][0]).toEqual value: '<', scopes: ['text.html.basic', 'meta.tag.script.html', 'punctuation.definition.tag.html']
       expect(lines[1][0]).toEqual value: '  ', scopes: ['text.html.basic', 'meta.tag.script.html', 'source.coffee.embedded.html']
       # TODO: Remove when Atom 1.21 reaches stable
-      if parseFloat(atom.getVersion()) <= 1.20
+      if parseFloat(core.getVersion()) <= 1.20
         expect(lines[1][1]).toEqual value: '->', scopes: ['text.html.basic', 'meta.tag.script.html', 'source.coffee.embedded.html', 'storage.type.function.coffee']
       else
         expect(lines[1][1]).toEqual value: '->', scopes: ['text.html.basic', 'meta.tag.script.html', 'source.coffee.embedded.html', 'meta.function.inline.coffee', 'storage.type.function.coffee']
@@ -198,7 +198,7 @@ describe 'TextMate HTML grammar', ->
 
       expect(lines[0][0]).toEqual value: '<', scopes: ['text.html.basic', 'meta.tag.script.html', 'punctuation.definition.tag.html']
       # TODO: Remove when Atom 1.21 reaches stable
-      if parseFloat(atom.getVersion()) <= 1.20
+      if parseFloat(core.getVersion()) <= 1.20
         expect(lines[2][1]).toEqual value: '->', scopes: ['text.html.basic', 'meta.tag.script.html', 'source.coffee.embedded.html', 'storage.type.function.coffee']
       else
         expect(lines[2][1]).toEqual value: '->', scopes: ['text.html.basic', 'meta.tag.script.html', 'source.coffee.embedded.html', 'meta.function.inline.coffee', 'storage.type.function.coffee']
@@ -226,7 +226,7 @@ describe 'TextMate HTML grammar', ->
 
   describe 'JavaScript script tags', ->
     beforeEach ->
-      waitsForPromise -> atom.packages.activatePackage('language-javascript')
+      waitsForPromise -> core.packages.activatePackage('language-javascript')
 
     it 'tokenizes the content inside the tag as JavaScript', ->
       lines = grammar.tokenizeLines '''
@@ -401,7 +401,7 @@ describe 'TextMate HTML grammar', ->
     describe "the 'style' attribute", ->
       beforeEach ->
         waitsForPromise ->
-          atom.packages.activatePackage('language-css')
+          core.packages.activatePackage('language-css')
 
       quotes =
         '"': 'double'
@@ -811,12 +811,12 @@ describe 'TextMate HTML grammar', ->
     snippetsModule = null
 
     beforeEach ->
-      # FIXME: This should just be atom.packages.loadPackage('snippets'),
+      # FIXME: This should just be core.packages.loadPackage('snippets'),
       # but a bug in PackageManager::resolvePackagePath where it finds language-html's
       # `snippets` directory before the actual package necessitates passing an absolute path
       # See https://github.com/atom/atom/issues/15953
-      snippetsPath = path.join(atom.packages.resourcePath, 'node_modules', 'snippets')
-      snippetsModule = require(atom.packages.loadPackage(snippetsPath).getMainModulePath())
+      snippetsPath = path.join(core.packages.resourcePath, 'node_modules', 'snippets')
+      snippetsModule = require(core.packages.loadPackage(snippetsPath).getMainModulePath())
 
       # Disable loading of user snippets before the package is activated
       spyOn(snippetsModule, 'loadUserSnippets').andCallFake (callback) -> callback({})

--- a/packages/language-html/spec/tree-sitter-spec.js
+++ b/packages/language-html/spec/tree-sitter-spec.js
@@ -2,12 +2,12 @@ const dedent = require('dedent');
 
 describe('Tree-sitter HTML grammar', () => {
   beforeEach(async () => {
-    atom.config.set('core.useTreeSitterParsers', true);
-    await atom.packages.activatePackage('language-html');
+    core.config.set('core.useTreeSitterParsers', true);
+    await core.packages.activatePackage('language-html');
   });
 
   it('tokenizes punctuation in HTML tags and attributes', async () => {
-    const editor = await atom.workspace.open(`test.html`);
+    const editor = await core.workspace.open(`test.html`);
 
     editor.setText(dedent`
       <html lang="en">

--- a/packages/language-hyperlink/spec/hyperlink-spec.coffee
+++ b/packages/language-hyperlink/spec/hyperlink-spec.coffee
@@ -5,17 +5,17 @@ describe 'Hyperlink grammar', ->
 
   beforeEach ->
     waitsForPromise ->
-      atom.packages.activatePackage('language-hyperlink')
+      core.packages.activatePackage('language-hyperlink')
 
     runs ->
-      grammar = atom.grammars.grammarForScopeName('text.hyperlink')
+      grammar = core.grammars.grammarForScopeName('text.hyperlink')
 
   it 'parses the grammar', ->
     expect(grammar).toBeTruthy()
     expect(grammar.scopeName).toBe 'text.hyperlink'
 
   it 'parses http: and https: links', ->
-    plainGrammar = atom.grammars.selectGrammar()
+    plainGrammar = core.grammars.selectGrammar()
 
     {tokens} = plainGrammar.tokenizeLine 'http://github.com'
     expect(tokens[0]).toEqual value: 'http://github.com', scopes: ['text.plain.null-grammar', 'markup.underline.link.http.hyperlink']
@@ -30,13 +30,13 @@ describe 'Hyperlink grammar', ->
     expect(tokens[0]).toEqual value: 'https://github.com/atom/brightray_example', scopes: ['text.plain.null-grammar', 'markup.underline.link.https.hyperlink']
 
   it 'parses http: and https: links that contains unicode characters', ->
-    plainGrammar = atom.grammars.selectGrammar()
+    plainGrammar = core.grammars.selectGrammar()
 
     {tokens} = plainGrammar.tokenizeLine 'https://sv.wikipedia.org/wiki/Mañana'
     expect(tokens[0]).toEqual value: 'https://sv.wikipedia.org/wiki/Mañana', scopes: ['text.plain.null-grammar', 'markup.underline.link.https.hyperlink']
 
   it 'parses other links', ->
-    plainGrammar = atom.grammars.selectGrammar()
+    plainGrammar = core.grammars.selectGrammar()
 
     {tokens} = plainGrammar.tokenizeLine 'mailto:noreply@example.com'
     expect(tokens[0]).toEqual value: 'mailto:noreply@example.com', scopes: ['text.plain.null-grammar', 'markup.underline.link.mailto.hyperlink']
@@ -48,7 +48,7 @@ describe 'Hyperlink grammar', ->
     expect(tokens[0]).toEqual value: 'atom://core/open/file?filename=urlEncodedFileName&line=n&column=n', scopes: ['text.plain.null-grammar', 'markup.underline.link.atom.hyperlink']
 
   it 'does not parse links in a regex string', ->
-    testGrammar = atom.grammars.loadGrammarSync(path.join(__dirname, 'fixtures', 'test-grammar.cson'))
+    testGrammar = core.grammars.loadGrammarSync(path.join(__dirname, 'fixtures', 'test-grammar.cson'))
 
     {tokens} = testGrammar.tokenizeLine 'regexp:http://github.com'
     expect(tokens[1]).toEqual value: 'http://github.com', scopes: ['source.test', 'string.regexp.test']
@@ -61,32 +61,32 @@ describe 'Hyperlink grammar', ->
       # https://github.com/atom/language-php/issues/219
 
       waitsForPromise ->
-        atom.packages.activatePackage('language-php')
+        core.packages.activatePackage('language-php')
 
       runs ->
-        phpGrammar = atom.grammars.grammarForScopeName('text.html.php')
+        phpGrammar = core.grammars.grammarForScopeName('text.html.php')
 
         {tokens} = phpGrammar.tokenizeLine '<?php "/mailto:/" ?>'
         expect(tokens[3]).toEqual value: 'mailto:', scopes: ['text.html.php', 'meta.embedded.line.php', 'source.php', 'string.regexp.double-quoted.php']
 
   describe 'parsing cfml strings', ->
     it 'does not include anything between (and including) pound signs', ->
-      plainGrammar = atom.grammars.selectGrammar()
+      plainGrammar = core.grammars.selectGrammar()
       {tokens} = plainGrammar.tokenizeLine 'http://github.com/#username#'
       expect(tokens[0]).toEqual value: 'http://github.com/', scopes: ['text.plain.null-grammar', 'markup.underline.link.http.hyperlink']
 
     it 'still includes single pound signs', ->
-      plainGrammar = atom.grammars.selectGrammar()
+      plainGrammar = core.grammars.selectGrammar()
       {tokens} = plainGrammar.tokenizeLine 'http://github.com/atom/#start-of-content'
       expect(tokens[0]).toEqual value: 'http://github.com/atom/#start-of-content', scopes: ['text.plain.null-grammar', 'markup.underline.link.http.hyperlink']
 
   describe 'parsing matching parentheses', ->
     it 'still includes matching parentheses', ->
-      plainGrammar = atom.grammars.selectGrammar()
+      plainGrammar = core.grammars.selectGrammar()
       {tokens} = plainGrammar.tokenizeLine 'https://en.wikipedia.org/wiki/Atom_(text_editor)'
       expect(tokens[0]).toEqual value: 'https://en.wikipedia.org/wiki/Atom_(text_editor)', scopes: ['text.plain.null-grammar', 'markup.underline.link.https.hyperlink']
 
     it 'does not include wrapping parentheses', ->
-      plainGrammar = atom.grammars.selectGrammar()
+      plainGrammar = core.grammars.selectGrammar()
       {tokens} = plainGrammar.tokenizeLine '(https://en.wikipedia.org/wiki/Atom_(text_editor))'
       expect(tokens[1]).toEqual value: 'https://en.wikipedia.org/wiki/Atom_(text_editor)', scopes: ['text.plain.null-grammar', 'markup.underline.link.https.hyperlink']

--- a/packages/language-java/spec/java-spec.coffee
+++ b/packages/language-java/spec/java-spec.coffee
@@ -2,12 +2,12 @@ describe 'Java grammar', ->
   grammar = null
 
   beforeEach ->
-    atom.config.set('core.useTreeSitterParsers', false)
+    core.config.set('core.useTreeSitterParsers', false)
     waitsForPromise ->
-      atom.packages.activatePackage('language-java')
+      core.packages.activatePackage('language-java')
 
     runs ->
-      grammar = atom.grammars.grammarForScopeName('source.java')
+      grammar = core.grammars.grammarForScopeName('source.java')
 
   it 'parses the grammar', ->
     expect(grammar).toBeTruthy()

--- a/packages/language-java/spec/tree-sitter-java-spec.coffee
+++ b/packages/language-java/spec/tree-sitter-java-spec.coffee
@@ -6,14 +6,14 @@ describe 'Tree-sitter based Java grammar', ->
   buffer = null
 
   beforeEach ->
-    atom.config.set('core.useTreeSitterParsers', true)
+    core.config.set('core.useTreeSitterParsers', true)
 
     waitsForPromise ->
-      atom.packages.activatePackage('language-java')
+      core.packages.activatePackage('language-java')
 
     runs ->
       editor = new TextEditor()
-      grammar = atom.grammars.grammarForScopeName('source.java')
+      grammar = core.grammars.grammarForScopeName('source.java')
       editor.setGrammar(grammar)
       buffer = editor.getBuffer()
 

--- a/packages/language-java/spec/unified-el-spec.coffee
+++ b/packages/language-java/spec/unified-el-spec.coffee
@@ -2,12 +2,12 @@ describe 'Unified expression language grammar', ->
   grammar = null
 
   beforeEach ->
-    atom.config.set('core.useTreeSitterParsers', false)
+    core.config.set('core.useTreeSitterParsers', false)
     waitsForPromise ->
-      atom.packages.activatePackage('language-java')
+      core.packages.activatePackage('language-java')
 
     runs ->
-      grammar = atom.grammars.grammarForScopeName('source.java.el')
+      grammar = core.grammars.grammarForScopeName('source.java.el')
 
   it 'parses the grammar', ->
     expect(grammar).toBeTruthy()

--- a/packages/language-javascript/lib/main.js
+++ b/packages/language-javascript/lib/main.js
@@ -1,7 +1,7 @@
 exports.activate = function() {
-  if (!atom.grammars.addInjectionPoint) return;
+  if (!core.grammars.addInjectionPoint) return;
 
-  atom.grammars.addInjectionPoint('source.js', {
+  core.grammars.addInjectionPoint('source.js', {
     type: 'call_expression',
 
     language(callExpression) {
@@ -26,7 +26,7 @@ exports.activate = function() {
     }
   });
 
-  atom.grammars.addInjectionPoint('source.js', {
+  core.grammars.addInjectionPoint('source.js', {
     type: 'assignment_expression',
 
     language(callExpression) {
@@ -46,7 +46,7 @@ exports.activate = function() {
     }
   });
 
-  atom.grammars.addInjectionPoint('source.js', {
+  core.grammars.addInjectionPoint('source.js', {
     type: 'regex_pattern',
     language(regex) {
       return 'regex';
@@ -57,7 +57,7 @@ exports.activate = function() {
   });
 
   for (const scopeName of ['source.js', 'source.flow', 'source.ts']) {
-    atom.grammars.addInjectionPoint(scopeName, {
+    core.grammars.addInjectionPoint(scopeName, {
       type: 'comment',
       language(comment) {
         if (comment.text.startsWith('/**')) return 'jsdoc';

--- a/packages/language-javascript/spec/javascript-spec.coffee
+++ b/packages/language-javascript/spec/javascript-spec.coffee
@@ -2,8 +2,8 @@ fs = require 'fs'
 path = require 'path'
 TextEditor = null
 buildTextEditor = (params) ->
-  if atom.workspace.buildTextEditor?
-    atom.workspace.buildTextEditor(params)
+  if core.workspace.buildTextEditor?
+    core.workspace.buildTextEditor(params)
   else
     TextEditor ?= require('atom').TextEditor
     new TextEditor(params)
@@ -12,13 +12,13 @@ describe "JavaScript grammar", ->
   grammar = null
 
   beforeEach ->
-    atom.config.set('core.useTreeSitterParsers', false)
+    core.config.set('core.useTreeSitterParsers', false)
 
     waitsForPromise ->
-      atom.packages.activatePackage("language-javascript")
+      core.packages.activatePackage("language-javascript")
 
     runs ->
-      grammar = atom.grammars.grammarForScopeName("source.js")
+      grammar = core.grammars.grammarForScopeName("source.js")
 
   it "parses the grammar", ->
     expect(grammar).toBeTruthy()
@@ -840,7 +840,7 @@ describe "JavaScript grammar", ->
   describe "HTML template strings", ->
     # TODO: Remove after Atom 1.21 is released
     [tagScope, entityScope] = []
-    if parseFloat(atom.getVersion()) <= 1.21
+    if parseFloat(core.getVersion()) <= 1.21
       tagScope = 'meta.tag.inline.any.html'
       entityScope = 'entity.name.tag.inline.any.html'
     else
@@ -849,7 +849,7 @@ describe "JavaScript grammar", ->
 
     beforeEach ->
       waitsForPromise ->
-        atom.packages.activatePackage("language-html")
+        core.packages.activatePackage("language-html")
 
     it "tokenizes ES6 tagged HTML string templates", ->
       {tokens} = grammar.tokenizeLine('html`hey <b>${name}</b>`')

--- a/packages/language-javascript/spec/jsdoc-spec.coffee
+++ b/packages/language-javascript/spec/jsdoc-spec.coffee
@@ -2,13 +2,13 @@ describe "JSDoc grammar", ->
   grammar = null
 
   beforeEach ->
-    atom.config.set('core.useTreeSitterParsers', false)
+    core.config.set('core.useTreeSitterParsers', false)
 
     waitsForPromise ->
-      atom.packages.activatePackage("language-javascript")
+      core.packages.activatePackage("language-javascript")
 
     runs ->
-      grammar = atom.grammars.grammarForScopeName("source.js")
+      grammar = core.grammars.grammarForScopeName("source.js")
 
   describe "inline tags", ->
     it "tokenises tags without descriptions", ->

--- a/packages/language-javascript/spec/regular-expression-replacement-spec.coffee
+++ b/packages/language-javascript/spec/regular-expression-replacement-spec.coffee
@@ -2,13 +2,13 @@ describe "Regular Expression Replacement grammar", ->
   grammar = null
 
   beforeEach ->
-    atom.config.set('core.useTreeSitterParsers', false)
+    core.config.set('core.useTreeSitterParsers', false)
 
     waitsForPromise ->
-      atom.packages.activatePackage("language-javascript")
+      core.packages.activatePackage("language-javascript")
 
     runs ->
-      grammar = atom.grammars.grammarForScopeName("source.js.regexp.replacement")
+      grammar = core.grammars.grammarForScopeName("source.js.regexp.replacement")
 
   it "parses the grammar", ->
     expect(grammar).toBeTruthy()

--- a/packages/language-json/spec/json-spec.coffee
+++ b/packages/language-json/spec/json-spec.coffee
@@ -2,13 +2,13 @@ describe "JSON grammar", ->
   grammar = null
 
   beforeEach ->
-    atom.config.set('core.useTreeSitterParsers', false)
+    core.config.set('core.useTreeSitterParsers', false)
 
     waitsForPromise ->
-      atom.packages.activatePackage('language-json')
+      core.packages.activatePackage('language-json')
 
     runs ->
-      grammar = atom.grammars.grammarForScopeName('source.json')
+      grammar = core.grammars.grammarForScopeName('source.json')
 
   it "parses the grammar", ->
     expect(grammar).toBeDefined()

--- a/packages/language-less/spec/less-spec.coffee
+++ b/packages/language-less/spec/less-spec.coffee
@@ -3,13 +3,13 @@ describe "Less grammar", ->
 
   beforeEach ->
     waitsForPromise ->
-      atom.packages.activatePackage("language-css")
+      core.packages.activatePackage("language-css")
 
     waitsForPromise ->
-      atom.packages.activatePackage("language-less")
+      core.packages.activatePackage("language-less")
 
     runs ->
-      grammar = atom.grammars.grammarForScopeName("source.css.less")
+      grammar = core.grammars.grammarForScopeName("source.css.less")
 
   it "parses the grammar", ->
     expect(grammar).toBeDefined()

--- a/packages/language-make/spec/make-spec.coffee
+++ b/packages/language-make/spec/make-spec.coffee
@@ -7,17 +7,17 @@ describe "Makefile grammar", ->
 
   beforeEach ->
     waitsForPromise ->
-      atom.packages.activatePackage("language-make")
+      core.packages.activatePackage("language-make")
 
     runs ->
-      grammar = atom.grammars.grammarForScopeName("source.makefile")
+      grammar = core.grammars.grammarForScopeName("source.makefile")
 
   it "parses the grammar", ->
     expect(grammar).toBeTruthy()
     expect(grammar.scopeName).toBe "source.makefile"
 
   it "selects the Makefile grammar for files that start with a hashbang make -f command", ->
-    expect(atom.grammars.selectGrammar('', '#!/usr/bin/make -f')).toBe grammar
+    expect(core.grammars.selectGrammar('', '#!/usr/bin/make -f')).toBe grammar
 
   it "parses comments correctly", ->
     lines = grammar.tokenizeLines '#foo\n\t#bar\n#foo\\\nbar'
@@ -41,7 +41,7 @@ describe "Makefile grammar", ->
 
   it "parses recipes", ->
     waitsForPromise ->
-      atom.packages.activatePackage("language-shellscript")
+      core.packages.activatePackage("language-shellscript")
 
     runs ->
       lines = grammar.tokenizeLines 'all: foo.bar\n\ttest\n\nclean: foo\n\trm -fr foo.bar'
@@ -168,7 +168,7 @@ describe "Makefile grammar", ->
 
   it "continues matching prerequisites after reaching a line continuation character", ->
     waitsForPromise ->
-      atom.packages.activatePackage("language-shellscript")
+      core.packages.activatePackage("language-shellscript")
 
     runs ->
       lines = grammar.tokenizeLines 'hello: a b c \\\n d e f\n\techo "test"'
@@ -179,7 +179,7 @@ describe "Makefile grammar", ->
 
   it "parses nested interpolated strings and function calls correctly", ->
     waitsForPromise ->
-      atom.packages.activatePackage("language-shellscript")
+      core.packages.activatePackage("language-shellscript")
 
     runs ->
       lines = grammar.tokenizeLines 'default:\n\t$(eval MESSAGE=$(shell node -pe "decodeURIComponent(process.argv.pop())" "${MSG}"))'
@@ -203,7 +203,7 @@ describe "Makefile grammar", ->
 
   it "parses `origin` correctly", ->
     waitsForPromise ->
-      atom.packages.activatePackage("language-shellscript")
+      core.packages.activatePackage("language-shellscript")
 
     runs ->
       lines = grammar.tokenizeLines 'default:\n\t$(origin 1)'
@@ -215,7 +215,7 @@ describe "Makefile grammar", ->
 
   it "parses `flavor` correctly", ->
     waitsForPromise ->
-      atom.packages.activatePackage("language-shellscript")
+      core.packages.activatePackage("language-shellscript")
 
     runs ->
       lines = grammar.tokenizeLines 'default:\n\t$(flavor 1)'

--- a/packages/language-mustache/spec/mustache-spec.coffee
+++ b/packages/language-mustache/spec/mustache-spec.coffee
@@ -3,13 +3,13 @@ describe 'Mustache grammar', ->
 
   beforeEach ->
     waitsForPromise ->
-      atom.packages.activatePackage('language-html')
+      core.packages.activatePackage('language-html')
 
     waitsForPromise ->
-      atom.packages.activatePackage('language-mustache')
+      core.packages.activatePackage('language-mustache')
 
     runs ->
-      grammar = atom.grammars.grammarForScopeName('text.html.mustache')
+      grammar = core.grammars.grammarForScopeName('text.html.mustache')
 
   it 'parses the grammar', ->
     expect(grammar).toBeTruthy()

--- a/packages/language-objective-c/spec/objective-c-spec.coffee
+++ b/packages/language-objective-c/spec/objective-c-spec.coffee
@@ -3,14 +3,14 @@ describe 'Language-Objective-C', ->
 
   beforeEach ->
     waitsForPromise ->
-      atom.packages.activatePackage('language-objective-c')
+      core.packages.activatePackage('language-objective-c')
 
     waitsForPromise ->
-      atom.packages.activatePackage('language-c')
+      core.packages.activatePackage('language-c')
 
   describe "Objective-C", ->
     beforeEach ->
-      grammar = atom.grammars.grammarForScopeName('source.objc')
+      grammar = core.grammars.grammarForScopeName('source.objc')
 
     it 'parses the grammar', ->
       expect(grammar).toBeTruthy()
@@ -28,7 +28,7 @@ describe 'Language-Objective-C', ->
 
   describe "Objective-C++", ->
     beforeEach ->
-      grammar = atom.grammars.grammarForScopeName('source.objcpp')
+      grammar = core.grammars.grammarForScopeName('source.objcpp')
 
     it 'parses the grammar', ->
       expect(grammar).toBeTruthy()

--- a/packages/language-perl/spec/grammar-perl6-spec.coffee
+++ b/packages/language-perl/spec/grammar-perl6-spec.coffee
@@ -3,10 +3,10 @@ describe "Perl 6 grammar", ->
 
   beforeEach ->
     waitsForPromise ->
-      atom.packages.activatePackage("language-perl")
+      core.packages.activatePackage("language-perl")
 
     runs ->
-      grammar = atom.grammars.grammarForScopeName("source.perl6")
+      grammar = core.grammars.grammarForScopeName("source.perl6")
 
   it "parses the grammar", ->
     expect(grammar).toBeDefined()

--- a/packages/language-perl/spec/grammar-spec.coffee
+++ b/packages/language-perl/spec/grammar-spec.coffee
@@ -3,10 +3,10 @@ describe "Perl grammar", ->
 
   beforeEach ->
     waitsForPromise ->
-      atom.packages.activatePackage("language-perl")
+      core.packages.activatePackage("language-perl")
 
     runs ->
-      grammar = atom.grammars.grammarForScopeName("source.perl")
+      grammar = core.grammars.grammarForScopeName("source.perl")
 
   it "parses the grammar", ->
     expect(grammar).toBeDefined()

--- a/packages/language-php/spec/html-spec.coffee
+++ b/packages/language-php/spec/html-spec.coffee
@@ -3,15 +3,15 @@ describe 'PHP in HTML', ->
 
   beforeEach ->
     waitsForPromise ->
-      atom.packages.activatePackage 'language-php'
+      core.packages.activatePackage 'language-php'
 
     waitsForPromise ->
       # While not used explicitly in any tests, we still activate language-html
       # to mirror how language-php behaves outside of specs
-      atom.packages.activatePackage 'language-html'
+      core.packages.activatePackage 'language-html'
 
     runs ->
-      grammar = atom.grammars.grammarForScopeName 'text.html.php'
+      grammar = core.grammars.grammarForScopeName 'text.html.php'
 
   it 'parses the grammar', ->
     expect(grammar).toBeTruthy()

--- a/packages/language-php/spec/php-spec.coffee
+++ b/packages/language-php/spec/php-spec.coffee
@@ -3,10 +3,10 @@ describe 'PHP grammar', ->
 
   beforeEach ->
     waitsForPromise ->
-      atom.packages.activatePackage 'language-php'
+      core.packages.activatePackage 'language-php'
 
     runs ->
-      grammar = atom.grammars.grammarForScopeName 'source.php'
+      grammar = core.grammars.grammarForScopeName 'source.php'
       @addMatchers
         toContainAll: (arr) ->
           arr.every (el) =>
@@ -3119,7 +3119,7 @@ describe 'PHP grammar', ->
 
   it 'should tokenize embedded SQL in a string', ->
     waitsForPromise ->
-      atom.packages.activatePackage('language-sql')
+      core.packages.activatePackage('language-sql')
 
     runs ->
       delimsByScope =
@@ -3410,7 +3410,7 @@ describe 'PHP grammar', ->
 
   it 'should tokenize a heredoc with embedded HTML and interpolation correctly', ->
     waitsForPromise ->
-      atom.packages.activatePackage('language-html')
+      core.packages.activatePackage('language-html')
 
     runs ->
       lines = grammar.tokenizeLines '''
@@ -3456,7 +3456,7 @@ describe 'PHP grammar', ->
 
   it 'should tokenize a nowdoc with embedded HTML and interpolation correctly', ->
     waitsForPromise ->
-      atom.packages.activatePackage('language-html')
+      core.packages.activatePackage('language-html')
 
     runs ->
       lines = grammar.tokenizeLines '''
@@ -3514,7 +3514,7 @@ describe 'PHP grammar', ->
 
   it 'should tokenize a heredoc with embedded XML correctly', ->
     waitsForPromise ->
-      atom.packages.activatePackage('language-xml')
+      core.packages.activatePackage('language-xml')
 
     runs ->
       lines = grammar.tokenizeLines '''
@@ -3541,7 +3541,7 @@ describe 'PHP grammar', ->
 
   it 'should tokenize a nowdoc with embedded XML correctly', ->
     waitsForPromise ->
-      atom.packages.activatePackage('language-xml')
+      core.packages.activatePackage('language-xml')
 
     runs ->
       lines = grammar.tokenizeLines '''
@@ -3570,7 +3570,7 @@ describe 'PHP grammar', ->
 
   it 'should tokenize a heredoc with embedded SQL correctly', ->
     waitsForPromise ->
-      atom.packages.activatePackage('language-sql')
+      core.packages.activatePackage('language-sql')
 
     runs ->
       lines = grammar.tokenizeLines '''
@@ -3603,7 +3603,7 @@ describe 'PHP grammar', ->
 
   it 'should tokenize a nowdoc with embedded SQL correctly', ->
     waitsForPromise ->
-      atom.packages.activatePackage('language-sql')
+      core.packages.activatePackage('language-sql')
 
     runs ->
       lines = grammar.tokenizeLines '''
@@ -3638,7 +3638,7 @@ describe 'PHP grammar', ->
 
   it 'should tokenize a heredoc with embedded DQL correctly', ->
     waitsForPromise ->
-      atom.packages.activatePackage('language-sql')
+      core.packages.activatePackage('language-sql')
 
     runs ->
       lines = grammar.tokenizeLines '''
@@ -3671,7 +3671,7 @@ describe 'PHP grammar', ->
 
   it 'should tokenize a nowdoc with embedded DQL correctly', ->
     waitsForPromise ->
-      atom.packages.activatePackage('language-sql')
+      core.packages.activatePackage('language-sql')
 
     runs ->
       lines = grammar.tokenizeLines '''
@@ -3706,7 +3706,7 @@ describe 'PHP grammar', ->
 
   it 'should tokenize a heredoc with embedded javascript correctly', ->
     waitsForPromise ->
-      atom.packages.activatePackage('language-javascript')
+      core.packages.activatePackage('language-javascript')
 
     runs ->
       lines = grammar.tokenizeLines '''
@@ -3765,7 +3765,7 @@ describe 'PHP grammar', ->
 
   it 'should tokenize a nowdoc with embedded javascript correctly', ->
     waitsForPromise ->
-      atom.packages.activatePackage('language-javascript')
+      core.packages.activatePackage('language-javascript')
 
     runs ->
       lines = grammar.tokenizeLines '''
@@ -3828,7 +3828,7 @@ describe 'PHP grammar', ->
 
   it 'should tokenize a heredoc with embedded json correctly', ->
     waitsForPromise ->
-      atom.packages.activatePackage('language-json')
+      core.packages.activatePackage('language-json')
 
     runs ->
       lines = grammar.tokenizeLines '''
@@ -3867,7 +3867,7 @@ describe 'PHP grammar', ->
 
   it 'should tokenize a nowdoc with embedded json correctly', ->
     waitsForPromise ->
-      atom.packages.activatePackage('language-json')
+      core.packages.activatePackage('language-json')
 
     runs ->
       lines = grammar.tokenizeLines '''
@@ -3908,7 +3908,7 @@ describe 'PHP grammar', ->
 
   it 'should tokenize a heredoc with embedded css correctly', ->
     waitsForPromise ->
-      atom.packages.activatePackage('language-css')
+      core.packages.activatePackage('language-css')
 
     runs ->
       lines = grammar.tokenizeLines '''
@@ -3935,7 +3935,7 @@ describe 'PHP grammar', ->
 
   it 'should tokenize a nowdoc with embedded css correctly', ->
     waitsForPromise ->
-      atom.packages.activatePackage('language-css')
+      core.packages.activatePackage('language-css')
 
     runs ->
       lines = grammar.tokenizeLines '''

--- a/packages/language-python/spec/language-python-spec.coffee
+++ b/packages/language-python/spec/language-python-spec.coffee
@@ -5,15 +5,15 @@ describe 'Python settings', ->
     editor.destroy()
 
   beforeEach ->
-    atom.config.set('core.useTreeSitterParsers', false)
+    core.config.set('core.useTreeSitterParsers', false)
 
     waitsForPromise ->
-      atom.workspace.open().then (o) ->
+      core.workspace.open().then (o) ->
         editor = o
         languageMode = editor.languageMode
 
     waitsForPromise ->
-      atom.packages.activatePackage('language-python')
+      core.packages.activatePackage('language-python')
 
   it 'matches lines correctly using the increaseIndentPattern', ->
     increaseIndentRegex = languageMode.increaseIndentRegexForScopeDescriptor(['source.python'])

--- a/packages/language-python/spec/python-regex-spec.coffee
+++ b/packages/language-python/spec/python-regex-spec.coffee
@@ -2,13 +2,13 @@ describe 'Python regular expression grammar', ->
   grammar = null
 
   beforeEach ->
-    atom.config.set('core.useTreeSitterParsers', false)
+    core.config.set('core.useTreeSitterParsers', false)
 
     waitsForPromise ->
-      atom.packages.activatePackage('language-python')
+      core.packages.activatePackage('language-python')
 
     runs ->
-      grammar = atom.grammars.grammarForScopeName('source.regexp.python')
+      grammar = core.grammars.grammarForScopeName('source.regexp.python')
 
   describe 'character classes', ->
     it 'does not recursively match character classes', ->

--- a/packages/language-python/spec/python-spec.coffee
+++ b/packages/language-python/spec/python-spec.coffee
@@ -5,13 +5,13 @@ describe "Python grammar", ->
   grammar = null
 
   beforeEach ->
-    atom.config.set('core.useTreeSitterParsers', false)
+    core.config.set('core.useTreeSitterParsers', false)
 
     waitsForPromise ->
-      atom.packages.activatePackage("language-python")
+      core.packages.activatePackage("language-python")
 
     runs ->
-      grammar = atom.grammars.grammarForScopeName("source.python")
+      grammar = core.grammars.grammarForScopeName("source.python")
 
   it "recognises shebang on firstline", ->
     expect(grammar.firstLineRegex.scanner.findNextMatchSync("#!/usr/bin/env python")).not.toBeNull()
@@ -654,7 +654,7 @@ describe "Python grammar", ->
   describe "SQL highlighting", ->
     beforeEach ->
       waitsForPromise ->
-        atom.packages.activatePackage('language-sql')
+        core.packages.activatePackage('language-sql')
 
     it "tokenizes SQL inline highlighting on blocks", ->
       delimsByScope =

--- a/packages/language-ruby-on-rails/spec/grammar-spec.coffee
+++ b/packages/language-ruby-on-rails/spec/grammar-spec.coffee
@@ -1,29 +1,29 @@
 describe "Ruby on Rails package", ->
   beforeEach ->
     waitsForPromise ->
-      atom.packages.activatePackage("language-ruby-on-rails")
+      core.packages.activatePackage("language-ruby-on-rails")
 
   it "parses the HTML grammar", ->
-    grammar = atom.grammars.grammarForScopeName("text.html.ruby")
+    grammar = core.grammars.grammarForScopeName("text.html.ruby")
     expect(grammar).toBeDefined()
     expect(grammar.scopeName).toBe "text.html.ruby"
 
   it "parses the JavaScript grammar", ->
-    grammar = atom.grammars.grammarForScopeName("source.js.rails source.js.jquery")
+    grammar = core.grammars.grammarForScopeName("source.js.rails source.js.jquery")
     expect(grammar).toBeDefined()
     expect(grammar.scopeName).toBe "source.js.rails source.js.jquery"
 
   it "parses the RJS grammar", ->
-    grammar = atom.grammars.grammarForScopeName("source.ruby.rails.rjs")
+    grammar = core.grammars.grammarForScopeName("source.ruby.rails.rjs")
     expect(grammar).toBeDefined()
     expect(grammar.scopeName).toBe "source.ruby.rails.rjs"
 
   it "parses the Rails grammar", ->
-    grammar = atom.grammars.grammarForScopeName("source.ruby.rails")
+    grammar = core.grammars.grammarForScopeName("source.ruby.rails")
     expect(grammar).toBeDefined()
     expect(grammar.scopeName).toBe "source.ruby.rails"
 
   it "parses the SQL grammar", ->
-    grammar = atom.grammars.grammarForScopeName("source.sql.ruby")
+    grammar = core.grammars.grammarForScopeName("source.sql.ruby")
     expect(grammar).toBeDefined()
     expect(grammar.scopeName).toBe "source.sql.ruby"

--- a/packages/language-ruby-on-rails/spec/snippets-spec.coffee
+++ b/packages/language-ruby-on-rails/spec/snippets-spec.coffee
@@ -3,10 +3,10 @@ describe "Ruby on Rails snippets", ->
 
   beforeEach ->
     waitsForPromise ->
-      atom.packages.activatePackage("language-ruby-on-rails")
+      core.packages.activatePackage("language-ruby-on-rails")
 
     runs ->
-      grammar = atom.grammars.grammarForScopeName("source.ruby.rails")
+      grammar = core.grammars.grammarForScopeName("source.ruby.rails")
 
   it "tokenizes ActionMailer::Base", ->
     railsMailer = 'class RailsMailer < ActionMailer::Base'

--- a/packages/language-ruby/lib/main.js
+++ b/packages/language-ruby/lib/main.js
@@ -1,7 +1,7 @@
 exports.activate = function() {
-  if (!atom.grammars.addInjectionPoint) return;
+  if (!core.grammars.addInjectionPoint) return;
 
-  atom.grammars.addInjectionPoint('source.ruby', {
+  core.grammars.addInjectionPoint('source.ruby', {
     type: 'heredoc_body',
     language(node) {
       return node.lastChild.text;
@@ -11,7 +11,7 @@ exports.activate = function() {
     }
   });
 
-  atom.grammars.addInjectionPoint('source.ruby', {
+  core.grammars.addInjectionPoint('source.ruby', {
     type: 'regex',
     language() {
       return 'regex';

--- a/packages/language-ruby/spec/erb-spec.coffee
+++ b/packages/language-ruby/spec/erb-spec.coffee
@@ -2,13 +2,13 @@ describe "TextMate HTML (Ruby - ERB) grammar", ->
   grammar = null
 
   beforeEach ->
-    atom.config.set('core.useTreeSitterParsers', false)
+    core.config.set('core.useTreeSitterParsers', false)
 
     waitsForPromise ->
-      atom.packages.activatePackage("language-ruby")
+      core.packages.activatePackage("language-ruby")
 
     runs ->
-      grammar = atom.grammars.grammarForScopeName("text.html.erb")
+      grammar = core.grammars.grammarForScopeName("text.html.erb")
 
   it "parses the grammar", ->
     expect(grammar).toBeTruthy()

--- a/packages/language-ruby/spec/gemfile-spec.coffee
+++ b/packages/language-ruby/spec/gemfile-spec.coffee
@@ -2,13 +2,13 @@ describe "TextMate Gemfile grammar", ->
   grammar = null
 
   beforeEach ->
-    atom.config.set('core.useTreeSitterParsers', false)
+    core.config.set('core.useTreeSitterParsers', false)
 
     waitsForPromise ->
-      atom.packages.activatePackage("language-ruby")
+      core.packages.activatePackage("language-ruby")
 
     runs ->
-      grammar = atom.grammars.grammarForScopeName("source.ruby.gemfile")
+      grammar = core.grammars.grammarForScopeName("source.ruby.gemfile")
 
   it "parses the grammar", ->
     expect(grammar).toBeTruthy()

--- a/packages/language-ruby/spec/ruby-spec.coffee
+++ b/packages/language-ruby/spec/ruby-spec.coffee
@@ -2,13 +2,13 @@ describe "TextMate Ruby grammar", ->
   grammar = null
 
   beforeEach ->
-    atom.config.set('core.useTreeSitterParsers', false)
+    core.config.set('core.useTreeSitterParsers', false)
 
     waitsForPromise ->
-      atom.packages.activatePackage("language-ruby")
+      core.packages.activatePackage("language-ruby")
 
     runs ->
-      grammar = atom.grammars.grammarForScopeName("source.ruby")
+      grammar = core.grammars.grammarForScopeName("source.ruby")
 
   it "parses the grammar", ->
     expect(grammar).toBeTruthy()

--- a/packages/language-ruby/spec/tree-sitter-spec.js
+++ b/packages/language-ruby/spec/tree-sitter-spec.js
@@ -2,12 +2,12 @@ const dedent = require('dedent');
 
 describe('Tree-sitter Ruby grammar', () => {
   beforeEach(async () => {
-    atom.config.set('core.useTreeSitterParsers', true);
-    await atom.packages.activatePackage('language-ruby');
+    core.config.set('core.useTreeSitterParsers', true);
+    await core.packages.activatePackage('language-ruby');
   });
 
   it('tokenizes symbols', async () => {
-    const editor = await atom.workspace.open('foo.rb');
+    const editor = await core.workspace.open('foo.rb');
 
     editor.setText(dedent`
       :foo
@@ -24,7 +24,7 @@ describe('Tree-sitter Ruby grammar', () => {
   });
 
   it('tokenizes visibility modifiers', async () => {
-    const editor = await atom.workspace.open('foo.rb');
+    const editor = await core.workspace.open('foo.rb');
 
     editor.setText(dedent`
       public
@@ -57,7 +57,7 @@ describe('Tree-sitter Ruby grammar', () => {
   });
 
   it('tokenizes keyword predicates', async () => {
-    const editor = await atom.workspace.open('foo.rb');
+    const editor = await core.workspace.open('foo.rb');
 
     editor.setText(dedent`
       defined?(:thing)
@@ -77,7 +77,7 @@ describe('Tree-sitter Ruby grammar', () => {
   });
 
   it('tokenizes alias definitions', async () => {
-    const editor = await atom.workspace.open('foo.rb');
+    const editor = await core.workspace.open('foo.rb');
 
     editor.setText(dedent`
       alias_method :name, :full_name
@@ -93,7 +93,7 @@ describe('Tree-sitter Ruby grammar', () => {
   });
 
   it('tokenizes keywords', async () => {
-    const editor = await atom.workspace.open('foo.rb');
+    const editor = await core.workspace.open('foo.rb');
 
     editor.setText(dedent`
       super
@@ -110,7 +110,7 @@ describe('Tree-sitter Ruby grammar', () => {
   });
 
   it('tokenizes variable in assignment expressions', async () => {
-    const editor = await atom.workspace.open('foo.rb');
+    const editor = await core.workspace.open('foo.rb');
     editor.setText(dedent`
       a = 10
     `);
@@ -121,7 +121,7 @@ describe('Tree-sitter Ruby grammar', () => {
   });
 
   it('does not tokenizes method call in assignment expressions', async () => {
-    const editor = await atom.workspace.open('foo.rb');
+    const editor = await core.workspace.open('foo.rb');
     editor.setText(dedent`
       foo() = 10
     `);

--- a/packages/language-rust-bundled/lib/main.js
+++ b/packages/language-rust-bundled/lib/main.js
@@ -1,6 +1,6 @@
 exports.activate = function() {
   for (const nodeType of ['macro_invocation', 'macro_rule']) {
-    atom.grammars.addInjectionPoint('source.rust', {
+    core.grammars.addInjectionPoint('source.rust', {
       type: nodeType,
       language() {
         return 'rust';

--- a/packages/language-sass/spec/sass-spec.coffee
+++ b/packages/language-sass/spec/sass-spec.coffee
@@ -3,13 +3,13 @@ describe 'Sass grammar', ->
 
   beforeEach ->
     waitsForPromise ->
-      atom.packages.activatePackage('language-css')
+      core.packages.activatePackage('language-css')
 
     waitsForPromise ->
-      atom.packages.activatePackage('language-sass')
+      core.packages.activatePackage('language-sass')
 
     runs ->
-      grammar = atom.grammars.grammarForScopeName('source.sass')
+      grammar = core.grammars.grammarForScopeName('source.sass')
 
   it 'parses the grammar', ->
     expect(grammar).toBeTruthy()

--- a/packages/language-sass/spec/sassdoc-spec.coffee
+++ b/packages/language-sass/spec/sassdoc-spec.coffee
@@ -3,10 +3,10 @@ describe 'SassDoc grammar', ->
 
   beforeEach ->
     waitsForPromise ->
-      atom.packages.activatePackage('language-sass')
+      core.packages.activatePackage('language-sass')
 
     runs ->
-      grammar = atom.grammars.grammarForScopeName('source.css.scss')
+      grammar = core.grammars.grammarForScopeName('source.css.scss')
 
   describe 'block tags', ->
     it 'tokenises simple tags', ->

--- a/packages/language-sass/spec/scss-spec.coffee
+++ b/packages/language-sass/spec/scss-spec.coffee
@@ -3,13 +3,13 @@ describe 'SCSS grammar', ->
 
   beforeEach ->
     waitsForPromise ->
-      atom.packages.activatePackage('language-css')
+      core.packages.activatePackage('language-css')
 
     waitsForPromise ->
-      atom.packages.activatePackage('language-sass')
+      core.packages.activatePackage('language-sass')
 
     runs ->
-      grammar = atom.grammars.grammarForScopeName('source.css.scss')
+      grammar = core.grammars.grammarForScopeName('source.css.scss')
 
   it 'parses the grammar', ->
     expect(grammar).toBeTruthy()

--- a/packages/language-sass/spec/scss-spec.js
+++ b/packages/language-sass/spec/scss-spec.js
@@ -2,12 +2,12 @@ const dedent = require('dedent');
 
 describe('Language sass', () => {
   beforeEach(async () => {
-    atom.config.set('core.useTreeSitterParsers', false);
-    await atom.packages.activatePackage('language-sass');
+    core.config.set('core.useTreeSitterParsers', false);
+    await core.packages.activatePackage('language-sass');
   });
 
   it('Should tokenize - as selector', async () => {
-    const editor = await atom.workspace.open('foo.scss');
+    const editor = await core.workspace.open('foo.scss');
 
     editor.setText(dedent`
       .foo {

--- a/packages/language-shellscript/spec/shell-session-spec.coffee
+++ b/packages/language-shellscript/spec/shell-session-spec.coffee
@@ -2,13 +2,13 @@ describe "Shell session grammar", ->
   grammar = null
 
   beforeEach ->
-    atom.config.set('core.useTreeSitterParsers', false)
+    core.config.set('core.useTreeSitterParsers', false)
 
     waitsForPromise ->
-      atom.packages.activatePackage("language-shellscript")
+      core.packages.activatePackage("language-shellscript")
 
     runs ->
-      grammar = atom.grammars.grammarForScopeName("text.shell-session")
+      grammar = core.grammars.grammarForScopeName("text.shell-session")
 
   it "parses the grammar", ->
     expect(grammar).toBeDefined()

--- a/packages/language-shellscript/spec/shell-unix-bash-spec.coffee
+++ b/packages/language-shellscript/spec/shell-unix-bash-spec.coffee
@@ -1,7 +1,7 @@
 TextEditor = null
 buildTextEditor = (params) ->
-  if atom.workspace.buildTextEditor?
-    atom.workspace.buildTextEditor(params)
+  if core.workspace.buildTextEditor?
+    core.workspace.buildTextEditor(params)
   else
     TextEditor ?= require('atom').TextEditor
     new TextEditor(params)
@@ -10,13 +10,13 @@ describe "Shell script grammar", ->
   grammar = null
 
   beforeEach ->
-    atom.config.set('core.useTreeSitterParsers', false)
+    core.config.set('core.useTreeSitterParsers', false)
 
     waitsForPromise ->
-      atom.packages.activatePackage("language-shellscript")
+      core.packages.activatePackage("language-shellscript")
 
     runs ->
-      grammar = atom.grammars.grammarForScopeName("source.shell")
+      grammar = core.grammars.grammarForScopeName("source.shell")
 
   it "parses the grammar", ->
     expect(grammar).toBeDefined()

--- a/packages/language-sql/spec/grammar-spec.coffee
+++ b/packages/language-sql/spec/grammar-spec.coffee
@@ -3,10 +3,10 @@ describe "SQL grammar", ->
 
   beforeEach ->
     waitsForPromise ->
-      atom.packages.activatePackage("language-sql")
+      core.packages.activatePackage("language-sql")
 
     runs ->
-      grammar = atom.grammars.grammarForScopeName("source.sql")
+      grammar = core.grammars.grammarForScopeName("source.sql")
 
   it "parses the grammar", ->
     expect(grammar).toBeDefined()

--- a/packages/language-text/spec/plain-text-spec.coffee
+++ b/packages/language-text/spec/plain-text-spec.coffee
@@ -3,10 +3,10 @@ describe "Plain Text grammar", ->
 
   beforeEach ->
     waitsForPromise ->
-      atom.packages.activatePackage("language-text")
+      core.packages.activatePackage("language-text")
 
     runs ->
-      grammar = atom.grammars.grammarForScopeName("text.plain")
+      grammar = core.grammars.grammarForScopeName("text.plain")
 
   it "parses the grammar", ->
     expect(grammar).toBeTruthy()

--- a/packages/language-todo/spec/todo-spec.coffee
+++ b/packages/language-todo/spec/todo-spec.coffee
@@ -3,10 +3,10 @@ describe "TODO grammar", ->
 
   beforeEach ->
     waitsForPromise ->
-      atom.packages.activatePackage("language-todo")
+      core.packages.activatePackage("language-todo")
 
     runs ->
-      grammar = atom.grammars.grammarForScopeName("text.todo")
+      grammar = core.grammars.grammarForScopeName("text.todo")
 
   it "parses the grammar", ->
     expect(grammar).toBeTruthy()

--- a/packages/language-toml/spec/toml-spec.coffee
+++ b/packages/language-toml/spec/toml-spec.coffee
@@ -3,10 +3,10 @@ describe "TOML grammar", ->
 
   beforeEach ->
     waitsForPromise ->
-      atom.packages.activatePackage("language-toml")
+      core.packages.activatePackage("language-toml")
 
     runs ->
-      grammar = atom.grammars.grammarForScopeName('source.toml')
+      grammar = core.grammars.grammarForScopeName('source.toml')
 
   it "parses the grammar", ->
     expect(grammar).toBeTruthy()

--- a/packages/language-typescript/lib/main.js
+++ b/packages/language-typescript/lib/main.js
@@ -1,6 +1,6 @@
 exports.activate = function() {
   for (const scopeName of ['source.ts', 'source.flow']) {
-    atom.grammars.addInjectionPoint(scopeName, {
+    core.grammars.addInjectionPoint(scopeName, {
       type: 'call_expression',
 
       language(callExpression) {
@@ -23,7 +23,7 @@ exports.activate = function() {
       }
     });
 
-    atom.grammars.addInjectionPoint(scopeName, {
+    core.grammars.addInjectionPoint(scopeName, {
       type: 'assignment_expression',
 
       language(callExpression) {
@@ -43,7 +43,7 @@ exports.activate = function() {
       }
     });
 
-    atom.grammars.addInjectionPoint(scopeName, {
+    core.grammars.addInjectionPoint(scopeName, {
       type: 'regex_pattern',
       language(regex) {
         return 'regex';

--- a/packages/language-xml/spec/xml-spec.coffee
+++ b/packages/language-xml/spec/xml-spec.coffee
@@ -3,10 +3,10 @@ describe "XML grammar", ->
 
   beforeEach ->
     waitsForPromise ->
-      atom.packages.activatePackage("language-xml")
+      core.packages.activatePackage("language-xml")
 
     runs ->
-      grammar = atom.grammars.grammarForScopeName("text.xml")
+      grammar = core.grammars.grammarForScopeName("text.xml")
 
   it "parses the grammar", ->
     expect(grammar).toBeTruthy()

--- a/packages/language-yaml/spec/yaml-spec.coffee
+++ b/packages/language-yaml/spec/yaml-spec.coffee
@@ -3,10 +3,10 @@ describe "YAML grammar", ->
 
   beforeEach ->
     waitsForPromise ->
-      atom.packages.activatePackage("language-yaml")
+      core.packages.activatePackage("language-yaml")
 
     runs ->
-      grammar = atom.grammars.grammarForScopeName('source.yaml')
+      grammar = core.grammars.grammarForScopeName('source.yaml')
 
   it "parses the grammar", ->
     expect(grammar).toBeTruthy()
@@ -14,10 +14,10 @@ describe "YAML grammar", ->
 
   it "selects the grammar for cloud config files", ->
     waitsForPromise ->
-      atom.workspace.open('cloud.config')
+      core.workspace.open('cloud.config')
 
     runs ->
-      expect(atom.workspace.getActiveTextEditor().getGrammar()).toBe grammar
+      expect(core.workspace.getActiveTextEditor().getGrammar()).toBe grammar
 
   describe "strings", ->
     describe "double quoted", ->

--- a/packages/line-ending-selector/lib/main.js
+++ b/packages/line-ending-selector/lib/main.js
@@ -23,7 +23,7 @@ export function activate() {
   let selector;
 
   disposables.add(
-    atom.commands.add('atom-text-editor', {
+    core.commands.add('atom-text-editor', {
       'line-ending-selector:show': () => {
         // Initiating Selector object - called only once when `line-ending-selector:show` is called
         if (!selectorDisposable) {
@@ -74,7 +74,7 @@ export function consumeStatusBar(statusBar) {
   }, 0);
 
   disposables.add(
-    atom.workspace.observeActiveTextEditor(editor => {
+    core.workspace.observeActiveTextEditor(editor => {
       if (currentBufferDisposable) currentBufferDisposable.dispose();
 
       if (editor && editor.getBuffer) {
@@ -102,7 +102,7 @@ export function consumeStatusBar(statusBar) {
         disposables.remove(tooltipDisposable);
         tooltipDisposable.dispose();
       }
-      tooltipDisposable = atom.tooltips.add(statusBarItem.element, {
+      tooltipDisposable = core.tooltips.add(statusBarItem.element, {
         title() {
           return `File uses ${statusBarItem.description()} line endings`;
         }
@@ -118,9 +118,9 @@ export function consumeStatusBar(statusBar) {
   );
 
   statusBarItem.onClick(() => {
-    const editor = atom.workspace.getActiveTextEditor();
-    atom.commands.dispatch(
-      atom.views.getView(editor),
+    const editor = core.workspace.getActiveTextEditor();
+    core.commands.dispatch(
+      core.views.getView(editor),
       'line-ending-selector:show'
     );
   });
@@ -130,7 +130,7 @@ export function consumeStatusBar(statusBar) {
 }
 
 function getDefaultLineEnding() {
-  switch (atom.config.get('line-ending-selector.defaultLineEnding')) {
+  switch (core.config.get('line-ending-selector.defaultLineEnding')) {
     case 'LF':
       return '\n';
     case 'CRLF':

--- a/packages/line-ending-selector/lib/selector.js
+++ b/packages/line-ending-selector/lib/selector.js
@@ -31,7 +31,7 @@ export class Selector {
 
       // called when the user clicks or presses Enter on an item. // use `=>` for `this`
       didConfirmSelection: lineEnding => {
-        const editor = atom.workspace.getActiveTextEditor();
+        const editor = core.workspace.getActiveTextEditor();
         if (editor instanceof TextEditor) {
           setLineEnding(editor, lineEnding.value);
         }
@@ -45,14 +45,14 @@ export class Selector {
     });
 
     // Adding SelectListView to panel
-    this.modalPanel = atom.workspace.addModalPanel({
+    this.modalPanel = core.workspace.addModalPanel({
       item: this.lineEndingListView
     });
   }
 
   // Show a selector object
   show() {
-    this.previousActivePane = atom.workspace.getActivePane();
+    this.previousActivePane = core.workspace.getActivePane();
 
     // Show selector
     this.lineEndingListView.reset();

--- a/packages/line-ending-selector/spec/line-ending-selector-spec.js
+++ b/packages/line-ending-selector/spec/line-ending-selector-spec.js
@@ -8,17 +8,17 @@ describe('line ending selector', () => {
     jasmine.useRealClock();
 
     waitsForPromise(() => {
-      return atom.packages.activatePackage('status-bar');
+      return core.packages.activatePackage('status-bar');
     });
 
     waitsForPromise(() => {
-      return atom.packages.activatePackage('line-ending-selector');
+      return core.packages.activatePackage('line-ending-selector');
     });
 
     waits(1);
 
     runs(() => {
-      const statusBar = atom.workspace.getFooterPanels()[0].getItem();
+      const statusBar = core.workspace.getFooterPanels()[0].getItem();
       lineEndingTile = statusBar.getRightTiles()[0].getItem();
       expect(lineEndingTile.element.className).toMatch(/line-ending-tile/);
       expect(lineEndingTile.element.textContent).toBe('');
@@ -30,9 +30,9 @@ describe('line ending selector', () => {
 
     beforeEach(() => {
       waitsForPromise(() => {
-        return atom.workspace.open('mixed-endings.md').then(e => {
+        return core.workspace.open('mixed-endings.md').then(e => {
           editor = e;
-          editorElement = atom.views.getView(editor);
+          editorElement = core.views.getView(editor);
           jasmine.attachToDOM(editorElement);
         });
       });
@@ -41,7 +41,7 @@ describe('line ending selector', () => {
     describe('When "line-ending-selector:convert-to-LF" is run', () => {
       it('converts the file to LF line endings', () => {
         editorElement.focus();
-        atom.commands.dispatch(
+        core.commands.dispatch(
           document.activeElement,
           'line-ending-selector:convert-to-LF'
         );
@@ -52,7 +52,7 @@ describe('line ending selector', () => {
     describe('When "line-ending-selector:convert-to-LF" is run', () => {
       it('converts the file to CRLF line endings', () => {
         editorElement.focus();
-        atom.commands.dispatch(
+        core.commands.dispatch(
           document.activeElement,
           'line-ending-selector:convert-to-CRLF'
         );
@@ -67,7 +67,7 @@ describe('line ending selector', () => {
         waitsFor(done => {
           spyOn(helpers, 'getProcessPlatform').andReturn('win32');
 
-          atom.workspace.open('').then(editor => {
+          core.workspace.open('').then(editor => {
             const subscription = lineEndingTile.onDidChange(() => {
               subscription.dispose();
               expect(lineEndingTile.element.textContent).toBe('CRLF');
@@ -84,7 +84,7 @@ describe('line ending selector', () => {
         waitsFor(done => {
           helpers.getProcessPlatform.andReturn('darwin');
 
-          atom.workspace.open('').then(editor => {
+          core.workspace.open('').then(editor => {
             const subscription = lineEndingTile.onDidChange(() => {
               subscription.dispose();
               expect(lineEndingTile.element.textContent).toBe('LF');
@@ -101,14 +101,14 @@ describe('line ending selector', () => {
 
       describe('when the "defaultLineEnding" setting is set to "LF"', () => {
         beforeEach(() => {
-          atom.config.set('line-ending-selector.defaultLineEnding', 'LF');
+          core.config.set('line-ending-selector.defaultLineEnding', 'LF');
         });
 
         it('uses LF line endings, regardless of the platform', () => {
           waitsFor(done => {
             spyOn(helpers, 'getProcessPlatform').andReturn('win32');
 
-            atom.workspace.open('').then(editor => {
+            core.workspace.open('').then(editor => {
               lineEndingTile.onDidChange(() => {
                 expect(lineEndingTile.element.textContent).toBe('LF');
                 expect(editor.getBuffer().getPreferredLineEnding()).toBe('\n');
@@ -121,12 +121,12 @@ describe('line ending selector', () => {
 
       describe('when the "defaultLineEnding" setting is set to "CRLF"', () => {
         beforeEach(() => {
-          atom.config.set('line-ending-selector.defaultLineEnding', 'CRLF');
+          core.config.set('line-ending-selector.defaultLineEnding', 'CRLF');
         });
 
         it('uses CRLF line endings, regardless of the platform', () => {
           waitsFor(done => {
-            atom.workspace.open('').then(editor => {
+            core.workspace.open('').then(editor => {
               lineEndingTile.onDidChange(() => {
                 expect(lineEndingTile.element.textContent).toBe('CRLF');
                 expect(editor.getBuffer().getPreferredLineEnding()).toBe(
@@ -143,7 +143,7 @@ describe('line ending selector', () => {
     describe('when a file is opened that contains only CRLF line endings', () => {
       it('displays "CRLF" as the line ending', () => {
         waitsFor(done => {
-          atom.workspace.open('windows-endings.md').then(() => {
+          core.workspace.open('windows-endings.md').then(() => {
             lineEndingTile.onDidChange(() => {
               expect(lineEndingTile.element.textContent).toBe('CRLF');
               done();
@@ -156,7 +156,7 @@ describe('line ending selector', () => {
     describe('when a file is opened that contains only LF line endings', () => {
       it('displays "LF" as the line ending', () => {
         waitsFor(done => {
-          atom.workspace.open('unix-endings.md').then(editor => {
+          core.workspace.open('unix-endings.md').then(editor => {
             lineEndingTile.onDidChange(() => {
               expect(lineEndingTile.element.textContent).toBe('LF');
               expect(editor.getBuffer().getPreferredLineEnding()).toBe(null);
@@ -170,7 +170,7 @@ describe('line ending selector', () => {
     describe('when a file is opened that contains mixed line endings', () => {
       it('displays "Mixed" as the line ending', () => {
         waitsFor(done => {
-          atom.workspace.open('mixed-endings.md').then(() => {
+          core.workspace.open('mixed-endings.md').then(() => {
             lineEndingTile.onDidChange(() => {
               expect(lineEndingTile.element.textContent).toBe('Mixed');
               done();
@@ -184,10 +184,10 @@ describe('line ending selector', () => {
       let lineEndingModal, lineEndingSelector;
 
       beforeEach(() => {
-        jasmine.attachToDOM(atom.views.getView(atom.workspace));
+        jasmine.attachToDOM(core.views.getView(core.workspace));
 
         waitsFor(done =>
-          atom.workspace
+          core.workspace
             .open('unix-endings.md')
             .then(() => lineEndingTile.onDidChange(done))
         );
@@ -195,14 +195,14 @@ describe('line ending selector', () => {
 
       describe('when the text editor has focus', () => {
         it('opens the line ending selector modal for the text editor', () => {
-          atom.workspace.getCenter().activate();
-          const item = atom.workspace.getActivePaneItem();
+          core.workspace.getCenter().activate();
+          const item = core.workspace.getActivePaneItem();
           expect(item.getFileName && item.getFileName()).toBe(
             'unix-endings.md'
           );
 
           lineEndingTile.element.dispatchEvent(new MouseEvent('click', {}));
-          lineEndingModal = atom.workspace.getModalPanels()[0];
+          lineEndingModal = core.workspace.getModalPanels()[0];
           lineEndingSelector = lineEndingModal.getItem();
 
           expect(lineEndingModal.isVisible()).toBe(true);
@@ -217,12 +217,12 @@ describe('line ending selector', () => {
 
       describe('when the text editor does not have focus', () => {
         it('opens the line ending selector modal for the active text editor', () => {
-          atom.workspace.getLeftDock().activate();
-          const item = atom.workspace.getActivePaneItem();
+          core.workspace.getLeftDock().activate();
+          const item = core.workspace.getActivePaneItem();
           expect(item instanceof TextEditor).toBe(false);
 
           lineEndingTile.element.dispatchEvent(new MouseEvent('click', {}));
-          lineEndingModal = atom.workspace.getModalPanels()[0];
+          lineEndingModal = core.workspace.getModalPanels()[0];
           lineEndingSelector = lineEndingModal.getItem();
 
           expect(lineEndingModal.isVisible()).toBe(true);
@@ -238,13 +238,13 @@ describe('line ending selector', () => {
       describe('when selecting a different line ending for the file', () => {
         it('changes the line endings in the buffer', () => {
           lineEndingTile.element.dispatchEvent(new MouseEvent('click', {}));
-          lineEndingModal = atom.workspace.getModalPanels()[0];
+          lineEndingModal = core.workspace.getModalPanels()[0];
           lineEndingSelector = lineEndingModal.getItem();
 
           const lineEndingChangedPromise = new Promise(resolve => {
             lineEndingTile.onDidChange(() => {
               expect(lineEndingTile.element.textContent).toBe('CRLF');
-              const editor = atom.workspace.getActiveTextEditor();
+              const editor = core.workspace.getActiveTextEditor();
               expect(editor.getText()).toBe('Hello\r\nGoodbye\r\nUnix\r\n');
               expect(editor.getBuffer().getPreferredLineEnding()).toBe('\r\n');
               resolve();
@@ -262,7 +262,7 @@ describe('line ending selector', () => {
       describe('when modal is exited', () => {
         it('leaves the tile selection as-is', () => {
           lineEndingTile.element.dispatchEvent(new MouseEvent('click', {}));
-          lineEndingModal = atom.workspace.getModalPanels()[0];
+          lineEndingModal = core.workspace.getModalPanels()[0];
           lineEndingSelector = lineEndingModal.getItem();
 
           lineEndingSelector.cancelSelection();
@@ -274,8 +274,8 @@ describe('line ending selector', () => {
     describe('closing the last text editor', () => {
       it('displays no line ending in the status bar', () => {
         waitsForPromise(() => {
-          return atom.workspace.open('unix-endings.md').then(() => {
-            atom.workspace.getActivePane().destroy();
+          return core.workspace.open('unix-endings.md').then(() => {
+            core.workspace.getActivePane().destroy();
             expect(lineEndingTile.element.textContent).toBe('');
           });
         });
@@ -287,7 +287,7 @@ describe('line ending selector', () => {
 
       beforeEach(() => {
         waitsFor(done => {
-          atom.workspace.open('unix-endings.md').then(e => {
+          core.workspace.open('unix-endings.md').then(e => {
             editor = e;
             lineEndingTile.onDidChange(done);
           });
@@ -330,7 +330,7 @@ describe('line ending selector', () => {
         });
 
         waitsFor(done => {
-          atom.commands.dispatch(
+          core.commands.dispatch(
             editor.getElement(),
             'line-ending-selector:convert-to-CRLF'
           );
@@ -346,7 +346,7 @@ describe('line ending selector', () => {
         });
 
         waitsFor(done => {
-          atom.commands.dispatch(
+          core.commands.dispatch(
             editor.getElement(),
             'line-ending-selector:convert-to-LF'
           );
@@ -373,6 +373,6 @@ describe('line ending selector', () => {
 });
 
 function getTooltipText(element) {
-  const [tooltip] = atom.tooltips.findTooltips(element);
+  const [tooltip] = core.tooltips.findTooltips(element);
   return tooltip.getTitle();
 }

--- a/packages/link/lib/link.js
+++ b/packages/link/lib/link.js
@@ -6,7 +6,7 @@ const LINK_SCOPE_REGEX = /markup\.underline\.link/;
 
 module.exports = {
   activate() {
-    this.commandDisposable = atom.commands.add(
+    this.commandDisposable = core.commands.add(
       'atom-text-editor',
       'link:open',
       () => this.openLink()
@@ -18,7 +18,7 @@ module.exports = {
   },
 
   openLink() {
-    const editor = atom.workspace.getActiveTextEditor();
+    const editor = core.workspace.getActiveTextEditor();
     if (editor == null) return;
 
     let link = this.linkUnderCursor(editor);

--- a/packages/link/spec/link-spec.js
+++ b/packages/link/spec/link-spec.js
@@ -2,41 +2,41 @@ const { shell } = require('electron');
 
 describe('link package', () => {
   beforeEach(async () => {
-    await atom.packages.activatePackage('language-gfm');
-    await atom.packages.activatePackage('language-hyperlink');
+    await core.packages.activatePackage('language-gfm');
+    await core.packages.activatePackage('language-hyperlink');
 
-    const activationPromise = atom.packages.activatePackage('link');
-    atom.commands.dispatch(atom.views.getView(atom.workspace), 'link:open');
+    const activationPromise = core.packages.activatePackage('link');
+    core.commands.dispatch(core.views.getView(core.workspace), 'link:open');
     await activationPromise;
   });
 
   describe('when the cursor is on a link', () => {
     it("opens the link using the 'open' command", async () => {
-      await atom.workspace.open('sample.md');
+      await core.workspace.open('sample.md');
 
-      const editor = atom.workspace.getActiveTextEditor();
+      const editor = core.workspace.getActiveTextEditor();
       editor.setText('// "http://github.com"');
 
       spyOn(shell, 'openExternal');
-      atom.commands.dispatch(atom.views.getView(editor), 'link:open');
+      core.commands.dispatch(core.views.getView(editor), 'link:open');
       expect(shell.openExternal).not.toHaveBeenCalled();
 
       editor.setCursorBufferPosition([0, 4]);
-      atom.commands.dispatch(atom.views.getView(editor), 'link:open');
+      core.commands.dispatch(core.views.getView(editor), 'link:open');
 
       expect(shell.openExternal).toHaveBeenCalled();
       expect(shell.openExternal.argsForCall[0][0]).toBe('http://github.com');
 
       shell.openExternal.reset();
       editor.setCursorBufferPosition([0, 8]);
-      atom.commands.dispatch(atom.views.getView(editor), 'link:open');
+      core.commands.dispatch(core.views.getView(editor), 'link:open');
 
       expect(shell.openExternal).toHaveBeenCalled();
       expect(shell.openExternal.argsForCall[0][0]).toBe('http://github.com');
 
       shell.openExternal.reset();
       editor.setCursorBufferPosition([0, 21]);
-      atom.commands.dispatch(atom.views.getView(editor), 'link:open');
+      core.commands.dispatch(core.views.getView(editor), 'link:open');
 
       expect(shell.openExternal).toHaveBeenCalled();
       expect(shell.openExternal.argsForCall[0][0]).toBe('http://github.com');
@@ -44,23 +44,23 @@ describe('link package', () => {
 
     // only works in Atom >= 1.33.0
     // https://github.com/atom/link/pull/33#issuecomment-419643655
-    const atomVersion = atom.getVersion().split('.');
+    const atomVersion = core.getVersion().split('.');
     console.error('atomVersion', atomVersion);
     if (+atomVersion[0] > 1 || +atomVersion[1] >= 33) {
       it("opens an 'atom:' link", async () => {
-        await atom.workspace.open('sample.md');
+        await core.workspace.open('sample.md');
 
-        const editor = atom.workspace.getActiveTextEditor();
+        const editor = core.workspace.getActiveTextEditor();
         editor.setText(
           '// "atom://core/open/file?filename=sample.js&line=1&column=2"'
         );
 
         spyOn(shell, 'openExternal');
-        atom.commands.dispatch(atom.views.getView(editor), 'link:open');
+        core.commands.dispatch(core.views.getView(editor), 'link:open');
         expect(shell.openExternal).not.toHaveBeenCalled();
 
         editor.setCursorBufferPosition([0, 4]);
-        atom.commands.dispatch(atom.views.getView(editor), 'link:open');
+        core.commands.dispatch(core.views.getView(editor), 'link:open');
 
         expect(shell.openExternal).toHaveBeenCalled();
         expect(shell.openExternal.argsForCall[0][0]).toBe(
@@ -69,7 +69,7 @@ describe('link package', () => {
 
         shell.openExternal.reset();
         editor.setCursorBufferPosition([0, 8]);
-        atom.commands.dispatch(atom.views.getView(editor), 'link:open');
+        core.commands.dispatch(core.views.getView(editor), 'link:open');
 
         expect(shell.openExternal).toHaveBeenCalled();
         expect(shell.openExternal.argsForCall[0][0]).toBe(
@@ -78,7 +78,7 @@ describe('link package', () => {
 
         shell.openExternal.reset();
         editor.setCursorBufferPosition([0, 60]);
-        atom.commands.dispatch(atom.views.getView(editor), 'link:open');
+        core.commands.dispatch(core.views.getView(editor), 'link:open');
 
         expect(shell.openExternal).toHaveBeenCalled();
         expect(shell.openExternal.argsForCall[0][0]).toBe(
@@ -89,9 +89,9 @@ describe('link package', () => {
 
     describe('when the cursor is on a [name][url-name] style markdown link', () =>
       it('opens the named url', async () => {
-        await atom.workspace.open('README.md');
+        await core.workspace.open('README.md');
 
-        const editor = atom.workspace.getActiveTextEditor();
+        const editor = core.workspace.getActiveTextEditor();
         editor.setText(`\
 you should [click][here]
 you should not [click][her]
@@ -101,34 +101,34 @@ you should not [click][her]
 
         spyOn(shell, 'openExternal');
         editor.setCursorBufferPosition([0, 0]);
-        atom.commands.dispatch(atom.views.getView(editor), 'link:open');
+        core.commands.dispatch(core.views.getView(editor), 'link:open');
         expect(shell.openExternal).not.toHaveBeenCalled();
 
         editor.setCursorBufferPosition([0, 20]);
-        atom.commands.dispatch(atom.views.getView(editor), 'link:open');
+        core.commands.dispatch(core.views.getView(editor), 'link:open');
 
         expect(shell.openExternal).toHaveBeenCalled();
         expect(shell.openExternal.argsForCall[0][0]).toBe('http://github.com');
 
         shell.openExternal.reset();
         editor.setCursorBufferPosition([1, 24]);
-        atom.commands.dispatch(atom.views.getView(editor), 'link:open');
+        core.commands.dispatch(core.views.getView(editor), 'link:open');
 
         expect(shell.openExternal).not.toHaveBeenCalled();
       }));
 
     it('does not open non http/https/atom links', async () => {
-      await atom.workspace.open('sample.md');
+      await core.workspace.open('sample.md');
 
-      const editor = atom.workspace.getActiveTextEditor();
+      const editor = core.workspace.getActiveTextEditor();
       editor.setText('// ftp://github.com\n');
 
       spyOn(shell, 'openExternal');
-      atom.commands.dispatch(atom.views.getView(editor), 'link:open');
+      core.commands.dispatch(core.views.getView(editor), 'link:open');
       expect(shell.openExternal).not.toHaveBeenCalled();
 
       editor.setCursorBufferPosition([0, 5]);
-      atom.commands.dispatch(atom.views.getView(editor), 'link:open');
+      core.commands.dispatch(core.views.getView(editor), 'link:open');
 
       expect(shell.openExternal).not.toHaveBeenCalled();
     });

--- a/packages/one-dark-ui/lib/main.js
+++ b/packages/one-dark-ui/lib/main.js
@@ -3,11 +3,11 @@ const themeName = 'one-dark-ui';
 
 module.exports = {
   activate(state) {
-    atom.config.observe(`${themeName}.fontSize`, setFontSize);
-    atom.config.observe(`${themeName}.tabSizing`, setTabSizing);
-    atom.config.observe(`${themeName}.tabCloseButton`, setTabCloseButton);
-    atom.config.observe(`${themeName}.hideDockButtons`, setHideDockButtons);
-    atom.config.observe(`${themeName}.stickyHeaders`, setStickyHeaders);
+    core.config.observe(`${themeName}.fontSize`, setFontSize);
+    core.config.observe(`${themeName}.tabSizing`, setTabSizing);
+    core.config.observe(`${themeName}.tabCloseButton`, setTabCloseButton);
+    core.config.observe(`${themeName}.hideDockButtons`, setHideDockButtons);
+    core.config.observe(`${themeName}.stickyHeaders`, setStickyHeaders);
   },
 
   deactivate() {

--- a/packages/one-dark-ui/spec/theme-spec.js
+++ b/packages/one-dark-ui/spec/theme-spec.js
@@ -2,32 +2,32 @@ const themeName = 'one-dark-ui';
 
 describe(`${themeName} theme`, () => {
   beforeEach(() => {
-    waitsForPromise(() => atom.packages.activatePackage(themeName));
+    waitsForPromise(() => core.packages.activatePackage(themeName));
   });
 
   it('allows the font size to be set via config', () => {
     expect(document.documentElement.style.fontSize).toBe('12px');
 
-    atom.config.set(`${themeName}.fontSize`, '10');
+    core.config.set(`${themeName}.fontSize`, '10');
     expect(document.documentElement.style.fontSize).toBe('10px');
   });
 
   it('allows the tab sizing to be set via config', () => {
-    atom.config.set(`${themeName}.tabSizing`, 'Maximum');
+    core.config.set(`${themeName}.tabSizing`, 'Maximum');
     expect(
       document.documentElement.getAttribute(`theme-${themeName}-tabsizing`)
     ).toBe('maximum');
   });
 
   it('allows the tab sizing to be set via config', () => {
-    atom.config.set(`${themeName}.tabSizing`, 'Minimum');
+    core.config.set(`${themeName}.tabSizing`, 'Minimum');
     expect(
       document.documentElement.getAttribute(`theme-${themeName}-tabsizing`)
     ).toBe('minimum');
   });
 
   it('allows the tab close button to be shown on the left via config', () => {
-    atom.config.set(`${themeName}.tabCloseButton`, 'Left');
+    core.config.set(`${themeName}.tabCloseButton`, 'Left');
     expect(
       document.documentElement.getAttribute(
         `theme-${themeName}-tab-close-button`
@@ -36,21 +36,21 @@ describe(`${themeName} theme`, () => {
   });
 
   it('allows the dock toggle buttons to be hidden via config', () => {
-    atom.config.set(`${themeName}.hideDockButtons`, true);
+    core.config.set(`${themeName}.hideDockButtons`, true);
     expect(
       document.documentElement.getAttribute(`theme-${themeName}-dock-buttons`)
     ).toBe('hidden');
   });
 
   it('allows the tree-view headers to be sticky via config', () => {
-    atom.config.set(`${themeName}.stickyHeaders`, true);
+    core.config.set(`${themeName}.stickyHeaders`, true);
     expect(
       document.documentElement.getAttribute(`theme-${themeName}-sticky-headers`)
     ).toBe('sticky');
   });
 
   it('allows the tree-view headers to not be sticky via config', () => {
-    atom.config.set(`${themeName}.stickyHeaders`, false);
+    core.config.set(`${themeName}.stickyHeaders`, false);
     expect(
       document.documentElement.getAttribute(`theme-${themeName}-sticky-headers`)
     ).toBe(null);

--- a/packages/one-light-ui/lib/main.js
+++ b/packages/one-light-ui/lib/main.js
@@ -3,11 +3,11 @@ const themeName = 'one-light-ui';
 
 module.exports = {
   activate(state) {
-    atom.config.observe(`${themeName}.fontSize`, setFontSize);
-    atom.config.observe(`${themeName}.tabSizing`, setTabSizing);
-    atom.config.observe(`${themeName}.tabCloseButton`, setTabCloseButton);
-    atom.config.observe(`${themeName}.hideDockButtons`, setHideDockButtons);
-    atom.config.observe(`${themeName}.stickyHeaders`, setStickyHeaders);
+    core.config.observe(`${themeName}.fontSize`, setFontSize);
+    core.config.observe(`${themeName}.tabSizing`, setTabSizing);
+    core.config.observe(`${themeName}.tabCloseButton`, setTabCloseButton);
+    core.config.observe(`${themeName}.hideDockButtons`, setHideDockButtons);
+    core.config.observe(`${themeName}.stickyHeaders`, setStickyHeaders);
   },
 
   deactivate() {

--- a/packages/one-light-ui/spec/theme-spec.js
+++ b/packages/one-light-ui/spec/theme-spec.js
@@ -2,32 +2,32 @@ const themeName = 'one-light-ui';
 
 describe(`${themeName} theme`, () => {
   beforeEach(() => {
-    waitsForPromise(() => atom.packages.activatePackage(themeName));
+    waitsForPromise(() => core.packages.activatePackage(themeName));
   });
 
   it('allows the font size to be set via config', () => {
     expect(document.documentElement.style.fontSize).toBe('12px');
 
-    atom.config.set(`${themeName}.fontSize`, '10');
+    core.config.set(`${themeName}.fontSize`, '10');
     expect(document.documentElement.style.fontSize).toBe('10px');
   });
 
   it('allows the tab sizing to be set via config', () => {
-    atom.config.set(`${themeName}.tabSizing`, 'Maximum');
+    core.config.set(`${themeName}.tabSizing`, 'Maximum');
     expect(
       document.documentElement.getAttribute(`theme-${themeName}-tabsizing`)
     ).toBe('maximum');
   });
 
   it('allows the tab sizing to be set via config', () => {
-    atom.config.set(`${themeName}.tabSizing`, 'Minimum');
+    core.config.set(`${themeName}.tabSizing`, 'Minimum');
     expect(
       document.documentElement.getAttribute(`theme-${themeName}-tabsizing`)
     ).toBe('minimum');
   });
 
   it('allows the tab close button to be shown on the left via config', () => {
-    atom.config.set(`${themeName}.tabCloseButton`, 'Left');
+    core.config.set(`${themeName}.tabCloseButton`, 'Left');
     expect(
       document.documentElement.getAttribute(
         `theme-${themeName}-tab-close-button`
@@ -36,21 +36,21 @@ describe(`${themeName} theme`, () => {
   });
 
   it('allows the dock toggle buttons to be hidden via config', () => {
-    atom.config.set(`${themeName}.hideDockButtons`, true);
+    core.config.set(`${themeName}.hideDockButtons`, true);
     expect(
       document.documentElement.getAttribute(`theme-${themeName}-dock-buttons`)
     ).toBe('hidden');
   });
 
   it('allows the tree-view headers to be sticky via config', () => {
-    atom.config.set(`${themeName}.stickyHeaders`, true);
+    core.config.set(`${themeName}.stickyHeaders`, true);
     expect(
       document.documentElement.getAttribute(`theme-${themeName}-sticky-headers`)
     ).toBe('sticky');
   });
 
   it('allows the tree-view headers to not be sticky via config', () => {
-    atom.config.set(`${themeName}.stickyHeaders`, false);
+    core.config.set(`${themeName}.stickyHeaders`, false);
     expect(
       document.documentElement.getAttribute(`theme-${themeName}-sticky-headers`)
     ).toBe(null);

--- a/packages/update-package-dependencies/lib/update-package-dependencies-status-view.js
+++ b/packages/update-package-dependencies/lib/update-package-dependencies-status-view.js
@@ -18,7 +18,7 @@ module.exports = class UpdatePackageDependenciesStatusView {
 
   attach() {
     this.tile = this.statusBar.addRightTile({ item: this.element });
-    this.tooltip = atom.tooltips.add(this.element, {
+    this.tooltip = core.tooltips.add(this.element, {
       title: 'Updating package dependencies\u2026'
     });
   }

--- a/packages/update-package-dependencies/lib/update-package-dependencies.js
+++ b/packages/update-package-dependencies/lib/update-package-dependencies.js
@@ -3,7 +3,7 @@ const UpdatePackageDependenciesStatusView = require('./update-package-dependenci
 
 module.exports = {
   activate() {
-    this.subscription = atom.commands.add(
+    this.subscription = core.commands.add(
       'atom-workspace',
       'update-package-dependencies:update',
       () => this.update()
@@ -31,7 +31,7 @@ module.exports = {
 
     let errorOutput = '';
 
-    const command = atom.packages.getApmPath();
+    const command = core.packages.getApmPath();
     const args = ['install', '--no-color'];
     const stderr = output => {
       errorOutput += output;
@@ -47,9 +47,9 @@ module.exports = {
         this.updatePackageDependenciesStatusView.detach();
 
       if (code === 0) {
-        atom.notifications.addSuccess('Package dependencies updated');
+        core.notifications.addSuccess('Package dependencies updated');
       } else {
-        atom.notifications.addError('Failed to update package dependencies', {
+        core.notifications.addError('Failed to update package dependencies', {
           detail: errorOutput,
           dismissable: true
         });
@@ -71,11 +71,11 @@ module.exports = {
   },
 
   getActiveProjectPath() {
-    const activeItem = atom.workspace.getActivePaneItem();
+    const activeItem = core.workspace.getActivePaneItem();
     if (activeItem && typeof activeItem.getPath === 'function') {
-      return atom.project.relativizePath(activeItem.getPath())[0];
+      return core.project.relativizePath(activeItem.getPath())[0];
     } else {
-      return atom.project.getPaths()[0];
+      return core.project.getPaths()[0];
     }
   }
 };

--- a/packages/update-package-dependencies/spec/update-package-dependencies-spec.js
+++ b/packages/update-package-dependencies/spec/update-package-dependencies-spec.js
@@ -7,7 +7,7 @@ describe('Update Package Dependencies', () => {
 
   beforeEach(() => {
     projectPath = __dirname;
-    atom.project.setPaths([projectPath]);
+    core.project.setPaths([projectPath]);
   });
 
   describe('updating package dependencies', () => {
@@ -58,13 +58,13 @@ describe('Update Package Dependencies', () => {
     });
 
     it('adds a status bar tile', async () => {
-      const statusBar = await atom.packages.activatePackage('status-bar');
+      const statusBar = await core.packages.activatePackage('status-bar');
 
-      const activationPromise = atom.packages.activatePackage(
+      const activationPromise = core.packages.activatePackage(
         'update-package-dependencies'
       );
-      atom.commands.dispatch(
-        atom.views.getView(atom.workspace),
+      core.commands.dispatch(
+        core.views.getView(core.workspace),
         'update-package-dependencies:update'
       );
       const { mainModule } = await activationPromise;
@@ -88,10 +88,10 @@ describe('Update Package Dependencies', () => {
     });
 
     describe('when there are multiple project paths', () => {
-      beforeEach(() => atom.project.setPaths([os.tmpdir(), projectPath]));
+      beforeEach(() => core.project.setPaths([os.tmpdir(), projectPath]));
 
       it('uses the currently active one', async () => {
-        await atom.workspace.open(path.join(projectPath, 'package.json'));
+        await core.workspace.open(path.join(projectPath, 'package.json'));
 
         updatePackageDependencies.update();
         expect(options.cwd).toEqual(projectPath);
@@ -105,7 +105,7 @@ describe('Update Package Dependencies', () => {
       });
 
       it('shows a success notification message', () => {
-        const notification = atom.notifications.getNotifications()[0];
+        const notification = core.notifications.getNotifications()[0];
         expect(notification.getType()).toEqual('success');
         expect(notification.getMessage()).toEqual(
           'Package dependencies updated'
@@ -121,7 +121,7 @@ describe('Update Package Dependencies', () => {
       });
 
       it('shows a failure notification', () => {
-        const notification = atom.notifications.getNotifications()[0];
+        const notification = core.notifications.getNotifications()[0];
         expect(notification.getType()).toEqual('error');
         expect(notification.getMessage()).toEqual(
           'Failed to update package dependencies'
@@ -136,11 +136,11 @@ describe('Update Package Dependencies', () => {
     beforeEach(() => spyOn(updatePackageDependencies, 'update'));
 
     it('activates the package and updates package dependencies', async () => {
-      const activationPromise = atom.packages.activatePackage(
+      const activationPromise = core.packages.activatePackage(
         'update-package-dependencies'
       );
-      atom.commands.dispatch(
-        atom.views.getView(atom.workspace),
+      core.commands.dispatch(
+        core.views.getView(core.workspace),
         'update-package-dependencies:update'
       );
       const { mainModule } = await activationPromise;

--- a/packages/welcome/lib/guide-view.js
+++ b/packages/welcome/lib/guide-view.js
@@ -6,7 +6,7 @@ import etch from 'etch';
 export default class GuideView {
   constructor(props) {
     this.props = props;
-    this.brand = atom.branding.name;
+    this.brand = core.branding.name;
     this.didClickProjectButton = this.didClickProjectButton.bind(this);
     this.didClickGitButton = this.didClickGitButton.bind(this);
     this.didClickGitHubButton = this.didClickGitHubButton.bind(this);
@@ -416,56 +416,56 @@ export default class GuideView {
 
   didClickProjectButton() {
     this.props.reporterProxy.sendEvent('clicked-project-cta');
-    atom.commands.dispatch(
-      atom.views.getView(atom.workspace),
+    core.commands.dispatch(
+      core.views.getView(core.workspace),
       'application:open'
     );
   }
 
   didClickGitButton() {
     this.props.reporterProxy.sendEvent('clicked-git-cta');
-    atom.commands.dispatch(
-      atom.views.getView(atom.workspace),
+    core.commands.dispatch(
+      core.views.getView(core.workspace),
       'github:toggle-git-tab'
     );
   }
 
   didClickGitHubButton() {
     this.props.reporterProxy.sendEvent('clicked-github-cta');
-    atom.commands.dispatch(
-      atom.views.getView(atom.workspace),
+    core.commands.dispatch(
+      core.views.getView(core.workspace),
       'github:toggle-github-tab'
     );
   }
 
   didClickPackagesButton() {
     this.props.reporterProxy.sendEvent('clicked-packages-cta');
-    atom.workspace.open('atom://config/install', { split: 'left' });
+    core.workspace.open('atom://config/install', { split: 'left' });
   }
 
   didClickThemesButton() {
     this.props.reporterProxy.sendEvent('clicked-themes-cta');
-    atom.workspace.open('atom://config/themes', { split: 'left' });
+    core.workspace.open('atom://config/themes', { split: 'left' });
   }
 
   didClickStylingButton() {
     this.props.reporterProxy.sendEvent('clicked-styling-cta');
-    atom.workspace.open('atom://.pulsar/stylesheet', { split: 'left' });
+    core.workspace.open('atom://.pulsar/stylesheet', { split: 'left' });
   }
 
   didClickInitScriptButton() {
     this.props.reporterProxy.sendEvent('clicked-init-script-cta');
-    atom.workspace.open('atom://.pulsar/init-script', { split: 'left' });
+    core.workspace.open('atom://.pulsar/init-script', { split: 'left' });
   }
 
   didClickSnippetsButton() {
     this.props.reporterProxy.sendEvent('clicked-snippets-cta');
-    atom.workspace.open('atom://.pulsar/snippets', { split: 'left' });
+    core.workspace.open('atom://.pulsar/snippets', { split: 'left' });
   }
 
   didClickTeletypeButton() {
     this.props.reporterProxy.sendEvent('clicked-teletype-cta');
-    atom.workspace.open('atom://config/packages/teletype', { split: 'left' });
+    core.workspace.open('atom://config/packages/teletype', { split: 'left' });
   }
 
   didExpandOrCollapseSection(event) {

--- a/packages/welcome/lib/welcome-package.js
+++ b/packages/welcome/lib/welcome-package.js
@@ -17,7 +17,7 @@ export default class WelcomePackage {
     this.subscriptions = new CompositeDisposable();
 
     this.subscriptions.add(
-      atom.workspace.addOpener(filePath => {
+      core.workspace.addOpener(filePath => {
         if (filePath === WELCOME_URI) {
           return this.createWelcomeView({ uri: WELCOME_URI });
         }
@@ -25,7 +25,7 @@ export default class WelcomePackage {
     );
 
     this.subscriptions.add(
-      atom.workspace.addOpener(filePath => {
+      core.workspace.addOpener(filePath => {
         if (filePath === GUIDE_URI) {
           return this.createGuideView({ uri: GUIDE_URI });
         }
@@ -33,10 +33,10 @@ export default class WelcomePackage {
     );
 
     this.subscriptions.add(
-      atom.commands.add('atom-workspace', 'welcome:show', () => this.show())
+      core.commands.add('atom-workspace', 'welcome:show', () => this.show())
     );
 
-    if (atom.config.get('welcome.showOnStartup')) {
+    if (core.config.get('welcome.showOnStartup')) {
       await this.show();
       this.reporterProxy.sendEvent('show-on-initial-load');
     }
@@ -44,8 +44,8 @@ export default class WelcomePackage {
 
   show() {
     return Promise.all([
-      atom.workspace.open(WELCOME_URI, { split: 'left' }),
-      atom.workspace.open(GUIDE_URI, { split: 'right' })
+      core.workspace.open(WELCOME_URI, { split: 'left' }),
+      core.workspace.open(GUIDE_URI, { split: 'right' })
     ]);
   }
 

--- a/packages/welcome/lib/welcome-view.js
+++ b/packages/welcome/lib/welcome-view.js
@@ -6,7 +6,7 @@ import etch from 'etch';
 export default class WelcomeView {
   constructor(props) {
     this.props = props;
-    this.brand = atom.branding.name;
+    this.brand = core.branding.name;
     etch.initialize(this);
 
     this.element.addEventListener('click', event => {
@@ -20,7 +20,7 @@ export default class WelcomeView {
   }
 
   didChangeShowOnStartup() {
-    atom.config.set('welcome.showOnStartup', this.checked);
+    core.config.set('welcome.showOnStartup', this.checked);
   }
 
   update() {}
@@ -37,7 +37,7 @@ export default class WelcomeView {
       <div className="welcome">
         <div className="welcome-container">
           <header className="welcome-header">
-            <a href={atom.branding.urlWeb}>
+            <a href={core.branding.urlWeb}>
               <svg
                 className="welcome-logo"
                 width="330px"
@@ -99,7 +99,7 @@ export default class WelcomeView {
             <ul>
               <li>
                 The{' '}
-                {/* // TODO_PULSAR: Update to our docs or test {atom.branding.urlWeb}+"/docs" */}
+                {/* // TODO_PULSAR: Update to our docs or test {core.branding.urlWeb}+"/docs" */}
                 <a
                   href="https://www.atom.io/docs"
                   dataset={{ event: 'atom-docs' }}
@@ -120,7 +120,7 @@ export default class WelcomeView {
               <li>
                 The{' '}
                 <a
-                  href={atom.branding.urlGH}
+                  href={core.branding.urlGH}
                   dataset={{ event: 'atom-org' }}
                 >
                   {this.brand} org
@@ -135,7 +135,7 @@ export default class WelcomeView {
               <input
                 className="input-checkbox"
                 type="checkbox"
-                checked={atom.config.get('welcome.showOnStartup')}
+                checked={core.config.get('welcome.showOnStartup')}
                 onchange={this.didChangeShowOnStartup}
               />
               Show Welcome Guide when opening {this.brand}
@@ -143,7 +143,7 @@ export default class WelcomeView {
           </section>
 
           <footer className="welcome-footer">
-            <a href={atom.branding.urlWeb} dataset={{ event: 'footer-atom-io' }}>
+            <a href={core.branding.urlWeb} dataset={{ event: 'footer-atom-io' }}>
               atom.io
             </a>{' '}
             <span className="text-subtle">×</span>{' '}

--- a/packages/welcome/test/welcome.test.js
+++ b/packages/welcome/test/welcome.test.js
@@ -10,11 +10,11 @@ describe('Welcome', () => {
 
   beforeEach(() => {
     welcomePackage = new WelcomePackage();
-    atom.config.set('welcome.showOnStartup', true);
+    core.config.set('welcome.showOnStartup', true);
   });
 
   afterEach(() => {
-    atom.reset();
+    core.reset();
   });
 
   describe("when welcomePackage.activate is called", () => {
@@ -23,7 +23,7 @@ describe('Welcome', () => {
     });
 
     it('opens the welcome panes', () => {
-      const panes = atom.workspace.getCenter().getPanes();
+      const panes = core.workspace.getCenter().getPanes();
       assert.equal(panes.length, 2);
       assert.equal(panes[0].getItems()[0].getTitle(), 'Welcome');
       assert.equal(panes[1].getItems()[0].getTitle(), 'Welcome Guide');
@@ -37,7 +37,7 @@ describe('Welcome', () => {
 
     describe('when activated for the first time', () =>
       it('shows the welcome panes', () => {
-        const panes = atom.workspace.getCenter().getPanes();
+        const panes = core.workspace.getCenter().getPanes();
         assert.equal(panes.length, 2);
         assert.equal(panes[0].getItems()[0].getTitle(), 'Welcome');
         assert.equal(panes[1].getItems()[0].getTitle(), 'Welcome Guide');
@@ -45,18 +45,18 @@ describe('Welcome', () => {
 
     describe('the welcome:show command', () => {
       it('shows the welcome buffer', async () => {
-        atom.workspace
+        core.workspace
           .getCenter()
           .getPanes()
           .map(pane => pane.destroy());
-        assert(!atom.workspace.getActivePaneItem());
+        assert(!core.workspace.getActivePaneItem());
 
-        const workspaceElement = atom.views.getView(atom.workspace);
-        atom.commands.dispatch(workspaceElement, 'welcome:show');
+        const workspaceElement = core.views.getView(core.workspace);
+        core.commands.dispatch(workspaceElement, 'welcome:show');
 
-        await conditionPromise(() => atom.workspace.getActivePaneItem());
+        await conditionPromise(() => core.workspace.getActivePaneItem());
 
-        const panes = atom.workspace.getCenter().getPanes();
+        const panes = core.workspace.getCenter().getPanes();
         assert.equal(panes.length, 2);
         assert.equal(panes[0].getItems()[0].getTitle(), 'Welcome');
       });
@@ -65,7 +65,7 @@ describe('Welcome', () => {
     describe('deserializing the pane items', () => {
       describe('when GuideView is deserialized', () => {
         it('remembers open sections', () => {
-          const panes = atom.workspace.getCenter().getPanes();
+          const panes = core.workspace.getCenter().getPanes();
           const guideView = panes[1].getItems()[0];
 
           guideView.element
@@ -102,7 +102,7 @@ describe('Welcome', () => {
     describe('reporting events', () => {
       let panes, guideView, reportedEvents;
       beforeEach(() => {
-        panes = atom.workspace.getCenter().getPanes();
+        panes = core.workspace.getCenter().getPanes();
         guideView = panes[1].getItems()[0];
         reportedEvents = [];
 

--- a/spec/atom-environment-spec.js
+++ b/spec/atom-environment-spec.js
@@ -14,26 +14,26 @@ describe('AtomEnvironment', () => {
   describe('window sizing methods', () => {
     describe('::getPosition and ::setPosition', () => {
       let originalPosition = null;
-      beforeEach(() => (originalPosition = atom.getPosition()));
+      beforeEach(() => (originalPosition = core.getPosition()));
 
-      afterEach(() => atom.setPosition(originalPosition.x, originalPosition.y));
+      afterEach(() => core.setPosition(originalPosition.x, originalPosition.y));
 
       it('sets the position of the window, and can retrieve the position just set', () => {
-        atom.setPosition(22, 45);
-        expect(atom.getPosition()).toEqual({ x: 22, y: 45 });
+        core.setPosition(22, 45);
+        expect(core.getPosition()).toEqual({ x: 22, y: 45 });
       });
     });
 
     describe('::getSize and ::setSize', () => {
       let originalSize = null;
-      beforeEach(() => (originalSize = atom.getSize()));
-      afterEach(() => atom.setSize(originalSize.width, originalSize.height));
+      beforeEach(() => (originalSize = core.getSize()));
+      afterEach(() => core.setSize(originalSize.width, originalSize.height));
 
       it('sets the size of the window, and can retrieve the size just set', async () => {
         const newWidth = originalSize.width - 12;
         const newHeight = originalSize.height - 23;
-        await atom.setSize(newWidth, newHeight);
-        expect(atom.getSize()).toEqual({ width: newWidth, height: newHeight });
+        await core.setSize(newWidth, newHeight);
+        expect(core.getSize()).toEqual({ width: newWidth, height: newHeight });
       });
     });
   });
@@ -41,18 +41,18 @@ describe('AtomEnvironment', () => {
   describe('.isReleasedVersion()', () => {
     it('returns false if the version is a SHA and true otherwise', () => {
       let version = '0.1.0';
-      spyOn(atom, 'getVersion').andCallFake(() => version);
-      expect(atom.isReleasedVersion()).toBe(true);
+      spyOn(core, 'getVersion').andCallFake(() => version);
+      expect(core.isReleasedVersion()).toBe(true);
       version = '36b5518';
-      expect(atom.isReleasedVersion()).toBe(false);
+      expect(core.isReleasedVersion()).toBe(false);
     });
   });
 
   describe('loading default config', () => {
     it('loads the default core config schema', () => {
-      expect(atom.config.get('core.excludeVcsIgnoredPaths')).toBe(true);
-      expect(atom.config.get('core.followSymlinks')).toBe(true);
-      expect(atom.config.get('editor.showInvisibles')).toBe(false);
+      expect(core.config.get('core.excludeVcsIgnoredPaths')).toBe(true);
+      expect(core.config.get('core.followSymlinks')).toBe(true);
+      expect(core.config.get('editor.showInvisibles')).toBe(false);
     });
   });
 
@@ -60,8 +60,8 @@ describe('AtomEnvironment', () => {
     let devToolsPromise = null;
     beforeEach(() => {
       devToolsPromise = Promise.resolve();
-      spyOn(atom, 'openDevTools').andReturn(devToolsPromise);
-      spyOn(atom, 'executeJavaScriptInDevTools');
+      spyOn(core, 'openDevTools').andReturn(devToolsPromise);
+      spyOn(core, 'executeJavaScriptInDevTools');
     });
 
     it('will open the dev tools when an error is triggered', async () => {
@@ -72,8 +72,8 @@ describe('AtomEnvironment', () => {
       }
 
       await devToolsPromise;
-      expect(atom.openDevTools).toHaveBeenCalled();
-      expect(atom.executeJavaScriptInDevTools).toHaveBeenCalled();
+      expect(core.openDevTools).toHaveBeenCalled();
+      expect(core.executeJavaScriptInDevTools).toHaveBeenCalled();
     });
 
     describe('::onWillThrowError', () => {
@@ -85,7 +85,7 @@ describe('AtomEnvironment', () => {
 
       it('is called when there is an error', () => {
         let error = null;
-        atom.onWillThrowError(willThrowSpy);
+        core.onWillThrowError(willThrowSpy);
         try {
           a + 1; // eslint-disable-line no-undef, no-unused-expressions
         } catch (e) {
@@ -105,7 +105,7 @@ describe('AtomEnvironment', () => {
 
       it('will not show the devtools when preventDefault() is called', () => {
         willThrowSpy.andCallFake(errorObject => errorObject.preventDefault());
-        atom.onWillThrowError(willThrowSpy);
+        core.onWillThrowError(willThrowSpy);
 
         try {
           a + 1; // eslint-disable-line no-undef, no-unused-expressions
@@ -114,8 +114,8 @@ describe('AtomEnvironment', () => {
         }
 
         expect(willThrowSpy).toHaveBeenCalled();
-        expect(atom.openDevTools).not.toHaveBeenCalled();
-        expect(atom.executeJavaScriptInDevTools).not.toHaveBeenCalled();
+        expect(core.openDevTools).not.toHaveBeenCalled();
+        expect(core.executeJavaScriptInDevTools).not.toHaveBeenCalled();
       });
     });
 
@@ -125,7 +125,7 @@ describe('AtomEnvironment', () => {
 
       it('is called when there is an error', () => {
         let error = null;
-        atom.onDidThrowError(didThrowSpy);
+        core.onDidThrowError(didThrowSpy);
         try {
           a + 1; // eslint-disable-line no-undef, no-unused-expressions
         } catch (e) {
@@ -148,13 +148,13 @@ describe('AtomEnvironment', () => {
 
     beforeEach(() => {
       errors = [];
-      spyOn(atom, 'isReleasedVersion').andReturn(true);
-      atom.onDidFailAssertion(error => errors.push(error));
+      spyOn(core, 'isReleasedVersion').andReturn(true);
+      core.onDidFailAssertion(error => errors.push(error));
     });
 
     describe('if the condition is false', () => {
       it('notifies onDidFailAssertion handlers with an error object based on the call site of the assertion', () => {
-        const result = atom.assert(false, 'a == b');
+        const result = core.assert(false, 'a == b');
         expect(result).toBe(false);
         expect(errors.length).toBe(1);
         expect(errors[0].message).toBe('Assertion failed: a == b');
@@ -164,22 +164,22 @@ describe('AtomEnvironment', () => {
       describe('if passed a callback function', () => {
         it("calls the callback with the assertion failure's error object", () => {
           let error = null;
-          atom.assert(false, 'a == b', e => (error = e));
+          core.assert(false, 'a == b', e => (error = e));
           expect(error).toBe(errors[0]);
         });
       });
 
       describe('if passed metadata', () => {
         it("assigns the metadata on the assertion failure's error object", () => {
-          atom.assert(false, 'a == b', { foo: 'bar' });
+          core.assert(false, 'a == b', { foo: 'bar' });
           expect(errors[0].metadata).toEqual({ foo: 'bar' });
         });
       });
 
       describe('when Atom has been built from source', () => {
         it('throws an error', () => {
-          atom.isReleasedVersion.andReturn(false);
-          expect(() => atom.assert(false, 'testing')).toThrow(
+          core.isReleasedVersion.andReturn(false);
+          expect(() => core.assert(false, 'testing')).toThrow(
             'Assertion failed: testing'
           );
         });
@@ -188,7 +188,7 @@ describe('AtomEnvironment', () => {
 
     describe('if the condition is true', () => {
       it('does nothing', () => {
-        const result = atom.assert(true, 'a == b');
+        const result = core.assert(true, 'a == b');
         expect(result).toBe(true);
         expect(errors).toEqual([]);
       });
@@ -196,38 +196,38 @@ describe('AtomEnvironment', () => {
   });
 
   describe('saving and loading', () => {
-    beforeEach(() => (atom.enablePersistence = true));
+    beforeEach(() => (core.enablePersistence = true));
 
-    afterEach(() => (atom.enablePersistence = false));
+    afterEach(() => (core.enablePersistence = false));
 
     it('selects the state based on the current project paths', async () => {
       jasmine.useRealClock();
 
       const [dir1, dir2] = [temp.mkdirSync('dir1-'), temp.mkdirSync('dir2-')];
 
-      const loadSettings = Object.assign(atom.getLoadSettings(), {
+      const loadSettings = Object.assign(core.getLoadSettings(), {
         initialProjectRoots: [dir1],
         windowState: null
       });
 
-      spyOn(atom, 'getLoadSettings').andCallFake(() => loadSettings);
-      spyOn(atom, 'serialize').andReturn({ stuff: 'cool' });
+      spyOn(core, 'getLoadSettings').andCallFake(() => loadSettings);
+      spyOn(core, 'serialize').andReturn({ stuff: 'cool' });
 
-      atom.project.setPaths([dir1, dir2]);
+      core.project.setPaths([dir1, dir2]);
 
       // State persistence will fail if other Atom instances are running
-      expect(await atom.stateStore.connect()).toBe(true);
+      expect(await core.stateStore.connect()).toBe(true);
 
-      await atom.saveState();
-      expect(await atom.loadState()).toBeFalsy();
+      await core.saveState();
+      expect(await core.loadState()).toBeFalsy();
 
       loadSettings.initialProjectRoots = [dir2, dir1];
-      expect(await atom.loadState()).toEqual({ stuff: 'cool' });
+      expect(await core.loadState()).toEqual({ stuff: 'cool' });
     });
 
     it('saves state when the CPU is idle after a keydown or mousedown event', () => {
       const atomEnv = new AtomEnvironment({
-        applicationDelegate: global.atom.applicationDelegate
+        applicationDelegate: global.core.applicationDelegate
       });
       const idleCallbacks = [];
       atomEnv.initialize({
@@ -263,7 +263,7 @@ describe('AtomEnvironment', () => {
 
     it('ignores mousedown/keydown events happening after calling prepareToUnloadEditorWindow', async () => {
       const atomEnv = new AtomEnvironment({
-        applicationDelegate: global.atom.applicationDelegate
+        applicationDelegate: global.core.applicationDelegate
       });
       const idleCallbacks = [];
       atomEnv.initialize({
@@ -299,53 +299,53 @@ describe('AtomEnvironment', () => {
     });
 
     it('serializes the project state with all the options supplied in saveState', async () => {
-      spyOn(atom.project, 'serialize').andReturn({ foo: 42 });
+      spyOn(core.project, 'serialize').andReturn({ foo: 42 });
 
-      await atom.saveState({ anyOption: 'any option' });
-      expect(atom.project.serialize.calls.length).toBe(1);
-      expect(atom.project.serialize.mostRecentCall.args[0]).toEqual({
+      await core.saveState({ anyOption: 'any option' });
+      expect(core.project.serialize.calls.length).toBe(1);
+      expect(core.project.serialize.mostRecentCall.args[0]).toEqual({
         anyOption: 'any option'
       });
     });
 
     it('serializes the text editor registry', async () => {
-      await atom.packages.activatePackage('language-text');
-      const editor = await atom.workspace.open('sample.js');
-      expect(atom.grammars.assignLanguageMode(editor, 'text.plain')).toBe(true);
+      await core.packages.activatePackage('language-text');
+      const editor = await core.workspace.open('sample.js');
+      expect(core.grammars.assignLanguageMode(editor, 'text.plain')).toBe(true);
 
-      const atom2 = new AtomEnvironment({
-        applicationDelegate: atom.applicationDelegate,
+      const core2 = new AtomEnvironment({
+        applicationDelegate: core.applicationDelegate,
         window: document.createElement('div'),
         document: Object.assign(document.createElement('div'), {
           body: document.createElement('div'),
           head: document.createElement('div')
         })
       });
-      atom2.initialize({ document, window });
+      core2.initialize({ document, window });
 
-      await atom2.deserialize(atom.serialize());
-      await atom2.packages.activatePackage('language-text');
-      const editor2 = atom2.workspace.getActiveTextEditor();
+      await core2.deserialize(core.serialize());
+      await core2.packages.activatePackage('language-text');
+      const editor2 = core2.workspace.getActiveTextEditor();
       expect(
         editor2
           .getBuffer()
           .getLanguageMode()
           .getLanguageId()
       ).toBe('text.plain');
-      atom2.destroy();
+      core2.destroy();
     });
 
     describe('deserialization failures', () => {
       it('propagates unrecognized project state restoration failures', async () => {
         let err;
-        spyOn(atom.project, 'deserialize').andCallFake(() => {
+        spyOn(core.project, 'deserialize').andCallFake(() => {
           err = new Error('deserialization failure');
           return Promise.reject(err);
         });
-        spyOn(atom.notifications, 'addError');
+        spyOn(core.notifications, 'addError');
 
-        await atom.deserialize({ project: 'should work' });
-        expect(atom.notifications.addError).toHaveBeenCalledWith(
+        await core.deserialize({ project: 'should work' });
+        expect(core.notifications.addError).toHaveBeenCalledWith(
           'Unable to deserialize project',
           {
             description: 'deserialization failure',
@@ -355,15 +355,15 @@ describe('AtomEnvironment', () => {
       });
 
       it('disregards missing project folder errors', async () => {
-        spyOn(atom.project, 'deserialize').andCallFake(() => {
+        spyOn(core.project, 'deserialize').andCallFake(() => {
           const err = new Error('deserialization failure');
           err.missingProjectPaths = ['nah'];
           return Promise.reject(err);
         });
-        spyOn(atom.notifications, 'addError');
+        spyOn(core.notifications, 'addError');
 
-        await atom.deserialize({ project: 'should work' });
-        expect(atom.notifications.addError).not.toHaveBeenCalled();
+        await core.deserialize({ project: 'should work' });
+        expect(core.notifications.addError).not.toHaveBeenCalled();
       });
     });
   });
@@ -371,68 +371,68 @@ describe('AtomEnvironment', () => {
   describe('openInitialEmptyEditorIfNecessary', () => {
     describe('when there are no paths set', () => {
       beforeEach(() =>
-        spyOn(atom, 'getLoadSettings').andReturn({ hasOpenFiles: false })
+        spyOn(core, 'getLoadSettings').andReturn({ hasOpenFiles: false })
       );
 
       it('opens an empty buffer', () => {
-        spyOn(atom.workspace, 'open');
-        atom.openInitialEmptyEditorIfNecessary();
-        expect(atom.workspace.open).toHaveBeenCalledWith(null, {
+        spyOn(core.workspace, 'open');
+        core.openInitialEmptyEditorIfNecessary();
+        expect(core.workspace.open).toHaveBeenCalledWith(null, {
           pending: true
         });
       });
 
       it('does not open an empty buffer when a buffer is already open', async () => {
-        await atom.workspace.open();
-        spyOn(atom.workspace, 'open');
-        atom.openInitialEmptyEditorIfNecessary();
-        expect(atom.workspace.open).not.toHaveBeenCalled();
+        await core.workspace.open();
+        spyOn(core.workspace, 'open');
+        core.openInitialEmptyEditorIfNecessary();
+        expect(core.workspace.open).not.toHaveBeenCalled();
       });
 
       it('does not open an empty buffer when core.openEmptyEditorOnStart is false', async () => {
-        atom.config.set('core.openEmptyEditorOnStart', false);
-        spyOn(atom.workspace, 'open');
-        atom.openInitialEmptyEditorIfNecessary();
-        expect(atom.workspace.open).not.toHaveBeenCalled();
+        core.config.set('core.openEmptyEditorOnStart', false);
+        spyOn(core.workspace, 'open');
+        core.openInitialEmptyEditorIfNecessary();
+        expect(core.workspace.open).not.toHaveBeenCalled();
       });
     });
 
     describe('when the project has a path', () => {
       beforeEach(() => {
-        spyOn(atom, 'getLoadSettings').andReturn({ hasOpenFiles: true });
-        spyOn(atom.workspace, 'open');
+        spyOn(core, 'getLoadSettings').andReturn({ hasOpenFiles: true });
+        spyOn(core.workspace, 'open');
       });
 
       it('does not open an empty buffer', () => {
-        atom.openInitialEmptyEditorIfNecessary();
-        expect(atom.workspace.open).not.toHaveBeenCalled();
+        core.openInitialEmptyEditorIfNecessary();
+        expect(core.workspace.open).not.toHaveBeenCalled();
       });
     });
   });
 
   describe('adding a project folder', () => {
     it('does nothing if the user dismisses the file picker', () => {
-      const projectRoots = atom.project.getPaths();
-      spyOn(atom, 'pickFolder').andCallFake(callback => callback(null));
-      atom.addProjectFolder();
-      expect(atom.project.getPaths()).toEqual(projectRoots);
+      const projectRoots = core.project.getPaths();
+      spyOn(core, 'pickFolder').andCallFake(callback => callback(null));
+      core.addProjectFolder();
+      expect(core.project.getPaths()).toEqual(projectRoots);
     });
 
     describe('when there is no saved state for the added folders', () => {
       beforeEach(() => {
-        spyOn(atom, 'loadState').andReturn(Promise.resolve(null));
-        spyOn(atom, 'attemptRestoreProjectStateForPaths');
+        spyOn(core, 'loadState').andReturn(Promise.resolve(null));
+        spyOn(core, 'attemptRestoreProjectStateForPaths');
       });
 
       it('adds the selected folder to the project', async () => {
-        atom.project.setPaths([]);
+        core.project.setPaths([]);
         const tempDirectory = temp.mkdirSync('a-new-directory');
-        spyOn(atom, 'pickFolder').andCallFake(callback =>
+        spyOn(core, 'pickFolder').andCallFake(callback =>
           callback([tempDirectory])
         );
-        await atom.addProjectFolder();
-        expect(atom.project.getPaths()).toEqual([tempDirectory]);
-        expect(atom.attemptRestoreProjectStateForPaths).not.toHaveBeenCalled();
+        await core.addProjectFolder();
+        expect(core.project.getPaths()).toEqual([tempDirectory]);
+        expect(core.attemptRestoreProjectStateForPaths).not.toHaveBeenCalled();
       });
     });
 
@@ -440,39 +440,39 @@ describe('AtomEnvironment', () => {
       const state = Symbol('savedState');
 
       beforeEach(() => {
-        spyOn(atom, 'getStateKey').andCallFake(dirs => dirs.join(':'));
-        spyOn(atom, 'loadState').andCallFake(async key =>
+        spyOn(core, 'getStateKey').andCallFake(dirs => dirs.join(':'));
+        spyOn(core, 'loadState').andCallFake(async key =>
           key === __dirname ? state : null
         );
-        spyOn(atom, 'attemptRestoreProjectStateForPaths');
-        spyOn(atom, 'pickFolder').andCallFake(callback =>
+        spyOn(core, 'attemptRestoreProjectStateForPaths');
+        spyOn(core, 'pickFolder').andCallFake(callback =>
           callback([__dirname])
         );
-        atom.project.setPaths([]);
+        core.project.setPaths([]);
       });
 
       describe('when there are no project folders', () => {
         it('attempts to restore the project state', async () => {
-          await atom.addProjectFolder();
-          expect(atom.attemptRestoreProjectStateForPaths).toHaveBeenCalledWith(
+          await core.addProjectFolder();
+          expect(core.attemptRestoreProjectStateForPaths).toHaveBeenCalledWith(
             state,
             [__dirname]
           );
-          expect(atom.project.getPaths()).toEqual([]);
+          expect(core.project.getPaths()).toEqual([]);
         });
       });
 
       describe('when there are already project folders', () => {
         const openedPath = path.join(__dirname, 'fixtures');
 
-        beforeEach(() => atom.project.setPaths([openedPath]));
+        beforeEach(() => core.project.setPaths([openedPath]));
 
         it('does not attempt to restore the project state, instead adding the project paths', async () => {
-          await atom.addProjectFolder();
+          await core.addProjectFolder();
           expect(
-            atom.attemptRestoreProjectStateForPaths
+            core.attemptRestoreProjectStateForPaths
           ).not.toHaveBeenCalled();
-          expect(atom.project.getPaths()).toEqual([openedPath, __dirname]);
+          expect(core.project.getPaths()).toEqual([openedPath, __dirname]);
         });
       });
     });
@@ -482,7 +482,7 @@ describe('AtomEnvironment', () => {
     describe('when the window is clean (empty or has only unnamed, unmodified buffers)', () => {
       beforeEach(async () => {
         // Unnamed, unmodified buffer doesn't count toward "clean"-ness
-        await atom.workspace.open();
+        await core.workspace.open();
       });
 
       it('automatically restores the saved state into the current environment', async () => {
@@ -495,7 +495,7 @@ describe('AtomEnvironment', () => {
         fs.writeFileSync(filePath3, 'ghi');
 
         const env1 = new AtomEnvironment({
-          applicationDelegate: atom.applicationDelegate
+          applicationDelegate: core.applicationDelegate
         });
         env1.project.setPaths([projectPath]);
         await env1.workspace.open(filePath1);
@@ -505,7 +505,7 @@ describe('AtomEnvironment', () => {
         env1.destroy();
 
         const env2 = new AtomEnvironment({
-          applicationDelegate: atom.applicationDelegate
+          applicationDelegate: core.applicationDelegate
         });
         await env2.attemptRestoreProjectStateForPaths(
           env1State,
@@ -519,7 +519,7 @@ describe('AtomEnvironment', () => {
 
       describe('when a dock has a non-text editor', () => {
         it("doesn't prompt the user to restore state", () => {
-          const dock = atom.workspace.getLeftDock();
+          const dock = core.workspace.getLeftDock();
           dock.getActivePane().addItem({
             getTitle() {
               return 'title';
@@ -527,13 +527,13 @@ describe('AtomEnvironment', () => {
             element: document.createElement('div')
           });
           const state = {};
-          spyOn(atom, 'confirm');
-          atom.attemptRestoreProjectStateForPaths(
+          spyOn(core, 'confirm');
+          core.attemptRestoreProjectStateForPaths(
             state,
             [__dirname],
             [__filename]
           );
-          expect(atom.confirm).not.toHaveBeenCalled();
+          expect(core.confirm).not.toHaveBeenCalled();
         });
       });
     });
@@ -542,65 +542,65 @@ describe('AtomEnvironment', () => {
       let editor;
 
       beforeEach(async () => {
-        editor = await atom.workspace.open();
+        editor = await core.workspace.open();
         editor.setText('new editor');
       });
 
       describe('when a dock has a modified editor', () => {
         it('prompts the user to restore the state', () => {
-          const dock = atom.workspace.getLeftDock();
+          const dock = core.workspace.getLeftDock();
           dock.getActivePane().addItem(editor);
-          spyOn(atom, 'confirm').andReturn(1);
-          spyOn(atom.project, 'addPath');
-          spyOn(atom.workspace, 'open');
+          spyOn(core, 'confirm').andReturn(1);
+          spyOn(core.project, 'addPath');
+          spyOn(core.workspace, 'open');
           const state = Symbol('state');
-          atom.attemptRestoreProjectStateForPaths(
+          core.attemptRestoreProjectStateForPaths(
             state,
             [__dirname],
             [__filename]
           );
-          expect(atom.confirm).toHaveBeenCalled();
+          expect(core.confirm).toHaveBeenCalled();
         });
       });
 
       it('prompts the user to restore the state in a new window, discarding it and adding folder to current window', async () => {
         jasmine.useRealClock();
-        spyOn(atom, 'confirm').andCallFake((options, callback) => callback(1));
-        spyOn(atom.project, 'addPath');
-        spyOn(atom.workspace, 'open');
+        spyOn(core, 'confirm').andCallFake((options, callback) => callback(1));
+        spyOn(core.project, 'addPath');
+        spyOn(core.workspace, 'open');
         const state = Symbol('state');
 
-        atom.attemptRestoreProjectStateForPaths(
+        core.attemptRestoreProjectStateForPaths(
           state,
           [__dirname],
           [__filename]
         );
-        expect(atom.confirm).toHaveBeenCalled();
-        await conditionPromise(() => atom.project.addPath.callCount === 1);
+        expect(core.confirm).toHaveBeenCalled();
+        await conditionPromise(() => core.project.addPath.callCount === 1);
 
-        expect(atom.project.addPath).toHaveBeenCalledWith(__dirname);
-        expect(atom.workspace.open.callCount).toBe(1);
-        expect(atom.workspace.open).toHaveBeenCalledWith(__filename);
+        expect(core.project.addPath).toHaveBeenCalledWith(__dirname);
+        expect(core.workspace.open.callCount).toBe(1);
+        expect(core.workspace.open).toHaveBeenCalledWith(__filename);
       });
 
       it('prompts the user to restore the state in a new window, opening a new window', async () => {
         jasmine.useRealClock();
-        spyOn(atom, 'confirm').andCallFake((options, callback) => callback(0));
-        spyOn(atom, 'open');
+        spyOn(core, 'confirm').andCallFake((options, callback) => callback(0));
+        spyOn(core, 'open');
         const state = Symbol('state');
 
-        atom.attemptRestoreProjectStateForPaths(
+        core.attemptRestoreProjectStateForPaths(
           state,
           [__dirname],
           [__filename]
         );
-        expect(atom.confirm).toHaveBeenCalled();
-        await conditionPromise(() => atom.open.callCount === 1);
-        expect(atom.open).toHaveBeenCalledWith({
+        expect(core.confirm).toHaveBeenCalled();
+        await conditionPromise(() => core.open.callCount === 1);
+        expect(core.open).toHaveBeenCalledWith({
           pathsToOpen: [__dirname, __filename],
           newWindow: true,
-          devMode: atom.inDevMode(),
-          safeMode: atom.inSafeMode()
+          devMode: core.inDevMode(),
+          safeMode: core.inSafeMode()
         });
       });
     });
@@ -611,7 +611,7 @@ describe('AtomEnvironment', () => {
       const configDirPath = temp.mkdirSync('atom-spec-environment');
       const fakeBlobStore = jasmine.createSpyObj('blob store', ['save']);
       const atomEnvironment = new AtomEnvironment({
-        applicationDelegate: atom.applicationDelegate,
+        applicationDelegate: core.applicationDelegate,
         enablePersistence: true
       });
       atomEnvironment.initialize({
@@ -638,7 +638,7 @@ describe('AtomEnvironment', () => {
         body: document.createElement('body')
       };
       const atomEnvironment = new AtomEnvironment({
-        applicationDelegate: atom.applicationDelegate
+        applicationDelegate: core.applicationDelegate
       });
       atomEnvironment.initialize({ window, document: fakeDocument });
       spyOn(atomEnvironment.packages, 'loadPackages').andReturn(
@@ -665,7 +665,7 @@ describe('AtomEnvironment', () => {
         return promise;
       };
       atomEnvironment = new AtomEnvironment({
-        applicationDelegate: atom.applicationDelegate,
+        applicationDelegate: core.applicationDelegate,
         updateProcessEnv() {
           return promise;
         }
@@ -693,32 +693,32 @@ describe('AtomEnvironment', () => {
 
   describe('::openLocations(locations)', () => {
     beforeEach(() => {
-      atom.project.setPaths([]);
+      core.project.setPaths([]);
     });
 
     describe('when there is no saved state', () => {
       beforeEach(() => {
-        spyOn(atom, 'loadState').andReturn(Promise.resolve(null));
+        spyOn(core, 'loadState').andReturn(Promise.resolve(null));
       });
 
       describe('when the opened path exists', () => {
         it('opens a file', async () => {
           const pathToOpen = __filename;
-          await atom.openLocations([
+          await core.openLocations([
             { pathToOpen, exists: true, isFile: true }
           ]);
-          expect(atom.project.getPaths()).toEqual([]);
+          expect(core.project.getPaths()).toEqual([]);
         });
 
         it('opens a directory as a project folder', async () => {
           const pathToOpen = __dirname;
-          await atom.openLocations([
+          await core.openLocations([
             { pathToOpen, exists: true, isDirectory: true }
           ]);
-          expect(atom.workspace.getTextEditors().map(e => e.getPath())).toEqual(
+          expect(core.workspace.getTextEditors().map(e => e.getPath())).toEqual(
             []
           );
-          expect(atom.project.getPaths()).toEqual([pathToOpen]);
+          expect(core.project.getPaths()).toEqual([pathToOpen]);
         });
       });
 
@@ -728,30 +728,30 @@ describe('AtomEnvironment', () => {
             __dirname,
             'this-path-does-not-exist.txt'
           );
-          await atom.openLocations([{ pathToOpen, exists: false }]);
-          expect(atom.workspace.getTextEditors().map(e => e.getPath())).toEqual(
+          await core.openLocations([{ pathToOpen, exists: false }]);
+          expect(core.workspace.getTextEditors().map(e => e.getPath())).toEqual(
             [pathToOpen]
           );
-          expect(atom.project.getPaths()).toEqual([]);
+          expect(core.project.getPaths()).toEqual([]);
         });
 
         it('may be required to be an existing directory', async () => {
-          spyOn(atom.notifications, 'addWarning');
+          spyOn(core.notifications, 'addWarning');
 
           const nonExistent = path.join(__dirname, 'no');
           const existingFile = __filename;
           const existingDir = path.join(__dirname, 'fixtures');
 
-          await atom.openLocations([
+          await core.openLocations([
             { pathToOpen: nonExistent, isDirectory: true },
             { pathToOpen: existingFile, isDirectory: true },
             { pathToOpen: existingDir, isDirectory: true }
           ]);
 
-          expect(atom.workspace.getTextEditors()).toEqual([]);
-          expect(atom.project.getPaths()).toEqual([existingDir]);
+          expect(core.workspace.getTextEditors()).toEqual([]);
+          expect(core.project.getPaths()).toEqual([existingDir]);
 
-          expect(atom.notifications.addWarning).toHaveBeenCalledWith(
+          expect(core.notifications.addWarning).toHaveBeenCalledWith(
             'Unable to open project folders',
             {
               description: `The directories \`${nonExistent}\` and \`${existingFile}\` do not exist.`
@@ -764,7 +764,7 @@ describe('AtomEnvironment', () => {
         let serviceDisposable;
 
         beforeEach(() => {
-          serviceDisposable = atom.packages.serviceHub.provide(
+          serviceDisposable = core.packages.serviceHub.provide(
             'atom.directory-provider',
             '0.1.0',
             {
@@ -782,7 +782,7 @@ describe('AtomEnvironment', () => {
             }
           );
 
-          waitsFor(() => atom.project.directoryProviders.length > 0);
+          waitsFor(() => core.project.directoryProviders.length > 0);
         });
 
         afterEach(() => {
@@ -791,9 +791,9 @@ describe('AtomEnvironment', () => {
 
         it("adds it to the project's paths as is", async () => {
           const pathToOpen = 'remote://server:7644/some/dir/path';
-          spyOn(atom.project, 'addPath');
-          await atom.openLocations([{ pathToOpen }]);
-          expect(atom.project.addPath).toHaveBeenCalledWith(pathToOpen);
+          spyOn(core.project, 'addPath');
+          await core.openLocations([{ pathToOpen }]);
+          expect(core.project.addPath).toHaveBeenCalledWith(pathToOpen);
         });
       });
     });
@@ -802,34 +802,34 @@ describe('AtomEnvironment', () => {
       const state = Symbol('savedState');
 
       beforeEach(() => {
-        spyOn(atom, 'getStateKey').andCallFake(dirs => dirs.join(':'));
-        spyOn(atom, 'loadState').andCallFake(function(key) {
+        spyOn(core, 'getStateKey').andCallFake(dirs => dirs.join(':'));
+        spyOn(core, 'loadState').andCallFake(function(key) {
           if (key === __dirname) {
             return Promise.resolve(state);
           } else {
             return Promise.resolve(null);
           }
         });
-        spyOn(atom, 'attemptRestoreProjectStateForPaths');
+        spyOn(core, 'attemptRestoreProjectStateForPaths');
       });
 
       describe('when there are no project folders', () => {
         it('attempts to restore the project state', async () => {
           const pathToOpen = __dirname;
-          await atom.openLocations([{ pathToOpen, isDirectory: true }]);
-          expect(atom.attemptRestoreProjectStateForPaths).toHaveBeenCalledWith(
+          await core.openLocations([{ pathToOpen, isDirectory: true }]);
+          expect(core.attemptRestoreProjectStateForPaths).toHaveBeenCalledWith(
             state,
             [pathToOpen],
             []
           );
-          expect(atom.project.getPaths()).toEqual([]);
+          expect(core.project.getPaths()).toEqual([]);
         });
 
         it('includes missing mandatory project folders in computation of initial state key', async () => {
           const existingDir = path.join(__dirname, 'fixtures');
           const missingDir = path.join(__dirname, 'no');
 
-          atom.loadState.andCallFake(function(key) {
+          core.loadState.andCallFake(function(key) {
             if (key === `${existingDir}:${missingDir}`) {
               return Promise.resolve(state);
             } else {
@@ -837,58 +837,58 @@ describe('AtomEnvironment', () => {
             }
           });
 
-          await atom.openLocations([
+          await core.openLocations([
             { pathToOpen: existingDir },
             { pathToOpen: missingDir, isDirectory: true }
           ]);
 
-          expect(atom.attemptRestoreProjectStateForPaths).toHaveBeenCalledWith(
+          expect(core.attemptRestoreProjectStateForPaths).toHaveBeenCalledWith(
             state,
             [existingDir],
             []
           );
-          expect(atom.project.getPaths(), [existingDir]);
+          expect(core.project.getPaths(), [existingDir]);
         });
 
         it('opens the specified files', async () => {
-          await atom.openLocations([
+          await core.openLocations([
             { pathToOpen: __dirname, isDirectory: true },
             { pathToOpen: __filename }
           ]);
-          expect(atom.attemptRestoreProjectStateForPaths).toHaveBeenCalledWith(
+          expect(core.attemptRestoreProjectStateForPaths).toHaveBeenCalledWith(
             state,
             [__dirname],
             [__filename]
           );
-          expect(atom.project.getPaths()).toEqual([]);
+          expect(core.project.getPaths()).toEqual([]);
         });
       });
 
       describe('when there are already project folders', () => {
-        beforeEach(() => atom.project.setPaths([__dirname]));
+        beforeEach(() => core.project.setPaths([__dirname]));
 
         it('does not attempt to restore the project state, instead adding the project paths', async () => {
           const pathToOpen = path.join(__dirname, 'fixtures');
-          await atom.openLocations([
+          await core.openLocations([
             { pathToOpen, exists: true, isDirectory: true }
           ]);
           expect(
-            atom.attemptRestoreProjectStateForPaths
+            core.attemptRestoreProjectStateForPaths
           ).not.toHaveBeenCalled();
-          expect(atom.project.getPaths()).toEqual([__dirname, pathToOpen]);
+          expect(core.project.getPaths()).toEqual([__dirname, pathToOpen]);
         });
 
         it('opens the specified files', async () => {
           const pathToOpen = path.join(__dirname, 'fixtures');
           const fileToOpen = path.join(pathToOpen, 'michelle-is-awesome.txt');
-          await atom.openLocations([
+          await core.openLocations([
             { pathToOpen, exists: true, isDirectory: true },
             { pathToOpen: fileToOpen, exists: true, isFile: true }
           ]);
           expect(
-            atom.attemptRestoreProjectStateForPaths
+            core.attemptRestoreProjectStateForPaths
           ).not.toHaveBeenCalledWith(state, [pathToOpen], [fileToOpen]);
-          expect(atom.project.getPaths()).toEqual([__dirname, pathToOpen]);
+          expect(core.project.getPaths()).toEqual([__dirname, pathToOpen]);
         });
       });
     });
@@ -898,18 +898,18 @@ describe('AtomEnvironment', () => {
     let version;
 
     beforeEach(() => {
-      spyOn(atom, 'getVersion').andCallFake(() => version);
+      spyOn(core, 'getVersion').andCallFake(() => version);
     });
 
     it('returns the correct channel based on the version number', () => {
       version = '1.5.6';
-      expect(atom.getReleaseChannel()).toBe('stable');
+      expect(core.getReleaseChannel()).toBe('stable');
 
       version = '1.5.0-beta10';
-      expect(atom.getReleaseChannel()).toBe('beta');
+      expect(core.getReleaseChannel()).toBe('beta');
 
       version = '1.7.0-dev-5340c91';
-      expect(atom.getReleaseChannel()).toBe('dev');
+      expect(core.getReleaseChannel()).toBe('dev');
     });
   });
 });

--- a/spec/auto-update-manager-spec.js
+++ b/spec/auto-update-manager-spec.js
@@ -9,7 +9,7 @@ describe('AutoUpdateManager (renderer)', () => {
 
   beforeEach(() => {
     autoUpdateManager = new AutoUpdateManager({
-      applicationDelegate: atom.applicationDelegate
+      applicationDelegate: core.applicationDelegate
     });
     autoUpdateManager.initialize();
   });
@@ -81,7 +81,7 @@ describe('AutoUpdateManager (renderer)', () => {
     let state, releaseChannel;
     it('returns true on macOS and Windows when in stable', () => {
       spyOn(autoUpdateManager, 'getState').andCallFake(() => state);
-      spyOn(atom, 'getReleaseChannel').andCallFake(() => releaseChannel);
+      spyOn(core, 'getReleaseChannel').andCallFake(() => releaseChannel);
 
       state = 'idle';
       releaseChannel = 'stable';
@@ -105,7 +105,7 @@ describe('AutoUpdateManager (renderer)', () => {
     it('unsubscribes from all events', () => {
       const spy = jasmine.createSpy('spy');
       const doneIndicator = jasmine.createSpy('spy');
-      atom.applicationDelegate.onUpdateNotAvailable(doneIndicator);
+      core.applicationDelegate.onUpdateNotAvailable(doneIndicator);
       autoUpdateManager.onDidBeginCheckingForUpdate(spy);
       autoUpdateManager.onDidBeginDownloadingUpdate(spy);
       autoUpdateManager.onDidCompleteDownloadingUpdate(spy);

--- a/spec/buffered-process-spec.js
+++ b/spec/buffered-process-spec.js
@@ -103,7 +103,7 @@ describe('BufferedProcess', function() {
       const exitCallback = jasmine.createSpy('exit callback');
       const apmProcess = new BufferedProcess({
         autoStart: false,
-        command: atom.packages.getApmPath(),
+        command: core.packages.getApmPath(),
         args: ['-h'],
         options: {},
         stdout(lines) {
@@ -134,7 +134,7 @@ describe('BufferedProcess', function() {
     let stderr = '';
     const exitCallback = jasmine.createSpy('exit callback');
     new BufferedProcess({
-      command: atom.packages.getApmPath(),
+      command: core.packages.getApmPath(),
       args: ['-h'],
       options: {},
       stdout(lines) {

--- a/spec/clipboard-spec.js
+++ b/spec/clipboard-spec.js
@@ -1,16 +1,16 @@
 describe('Clipboard', () => {
   describe('write(text, metadata) and read()', () => {
     it('writes and reads text to/from the native clipboard', () => {
-      expect(atom.clipboard.read()).toBe('initial clipboard content');
-      atom.clipboard.write('next');
-      expect(atom.clipboard.read()).toBe('next');
+      expect(core.clipboard.read()).toBe('initial clipboard content');
+      core.clipboard.write('next');
+      expect(core.clipboard.read()).toBe('next');
     });
 
     it('returns metadata if the item on the native clipboard matches the last written item', () => {
-      atom.clipboard.write('next', { meta: 'data' });
-      expect(atom.clipboard.read()).toBe('next');
-      expect(atom.clipboard.readWithMetadata().text).toBe('next');
-      expect(atom.clipboard.readWithMetadata().metadata).toEqual({
+      core.clipboard.write('next', { meta: 'data' });
+      expect(core.clipboard.read()).toBe('next');
+      expect(core.clipboard.readWithMetadata().text).toBe('next');
+      expect(core.clipboard.readWithMetadata().metadata).toEqual({
         meta: 'data'
       });
     });
@@ -28,8 +28,8 @@ describe('Clipboard', () => {
       it(`converts line endings to the OS's native line endings on ${platform}`, () => {
         Object.defineProperty(process, 'platform', { value: platform });
 
-        atom.clipboard.write('next\ndone\r\n\n', { meta: 'data' });
-        expect(atom.clipboard.readWithMetadata()).toEqual({
+        core.clipboard.write('next\ndone\r\n\n', { meta: 'data' });
+        expect(core.clipboard.readWithMetadata()).toEqual({
           text: `next${eol}done${eol}${eol}`,
           metadata: { meta: 'data' }
         });

--- a/spec/compile-cache-spec.js
+++ b/spec/compile-cache-spec.js
@@ -17,7 +17,7 @@ describe('CompileCache', () => {
   let [atomHome, fixtures] = Array.from([]);
 
   beforeEach(() => {
-    fixtures = atom.project.getPaths()[0];
+    fixtures = core.project.getPaths()[0];
     atomHome = temp.mkdirSync('fake-atom-home');
 
     CSON.setCacheDir(null);

--- a/spec/config-spec.js
+++ b/spec/config-spec.js
@@ -3,153 +3,153 @@ describe('Config', () => {
 
   beforeEach(() => {
     spyOn(console, 'warn');
-    atom.config.settingsLoaded = true;
+    core.config.settingsLoaded = true;
 
     savedSettings = [];
-    atom.config.saveCallback = function(settings) {
+    core.config.saveCallback = function(settings) {
       savedSettings.push(settings);
     };
   });
 
   describe('.get(keyPath, {scope, sources, excludeSources})', () => {
     it("allows a key path's value to be read", () => {
-      expect(atom.config.set('foo.bar.baz', 42)).toBe(true);
-      expect(atom.config.get('foo.bar.baz')).toBe(42);
-      expect(atom.config.get('foo.quux')).toBeUndefined();
+      expect(core.config.set('foo.bar.baz', 42)).toBe(true);
+      expect(core.config.get('foo.bar.baz')).toBe(42);
+      expect(core.config.get('foo.quux')).toBeUndefined();
     });
 
     it("returns a deep clone of the key path's value", () => {
-      atom.config.set('value', { array: [1, { b: 2 }, 3] });
-      const retrievedValue = atom.config.get('value');
+      core.config.set('value', { array: [1, { b: 2 }, 3] });
+      const retrievedValue = core.config.get('value');
       retrievedValue.array[0] = 4;
       retrievedValue.array[1].b = 2.1;
-      expect(atom.config.get('value')).toEqual({ array: [1, { b: 2 }, 3] });
+      expect(core.config.get('value')).toEqual({ array: [1, { b: 2 }, 3] });
     });
 
     it('merges defaults into the returned value if both the assigned value and the default value are objects', () => {
-      atom.config.setDefaults('foo.bar', { baz: 1, ok: 2 });
-      atom.config.set('foo.bar', { baz: 3 });
-      expect(atom.config.get('foo.bar')).toEqual({ baz: 3, ok: 2 });
+      core.config.setDefaults('foo.bar', { baz: 1, ok: 2 });
+      core.config.set('foo.bar', { baz: 3 });
+      expect(core.config.get('foo.bar')).toEqual({ baz: 3, ok: 2 });
 
-      atom.config.setDefaults('other', { baz: 1 });
-      atom.config.set('other', 7);
-      expect(atom.config.get('other')).toBe(7);
+      core.config.setDefaults('other', { baz: 1 });
+      core.config.set('other', 7);
+      expect(core.config.get('other')).toBe(7);
 
-      atom.config.set('bar.baz', { a: 3 });
-      atom.config.setDefaults('bar', { baz: 7 });
-      expect(atom.config.get('bar.baz')).toEqual({ a: 3 });
+      core.config.set('bar.baz', { a: 3 });
+      core.config.setDefaults('bar', { baz: 7 });
+      expect(core.config.get('bar.baz')).toEqual({ a: 3 });
     });
 
     describe("when a 'sources' option is specified", () =>
       it('only retrieves values from the specified sources', () => {
-        atom.config.set('x.y', 1, { scopeSelector: '.foo', source: 'a' });
-        atom.config.set('x.y', 2, { scopeSelector: '.foo', source: 'b' });
-        atom.config.set('x.y', 3, { scopeSelector: '.foo', source: 'c' });
-        atom.config.setSchema('x.y', { type: 'integer', default: 4 });
+        core.config.set('x.y', 1, { scopeSelector: '.foo', source: 'a' });
+        core.config.set('x.y', 2, { scopeSelector: '.foo', source: 'b' });
+        core.config.set('x.y', 3, { scopeSelector: '.foo', source: 'c' });
+        core.config.setSchema('x.y', { type: 'integer', default: 4 });
 
         expect(
-          atom.config.get('x.y', { sources: ['a'], scope: ['.foo'] })
+          core.config.get('x.y', { sources: ['a'], scope: ['.foo'] })
         ).toBe(1);
         expect(
-          atom.config.get('x.y', { sources: ['b'], scope: ['.foo'] })
+          core.config.get('x.y', { sources: ['b'], scope: ['.foo'] })
         ).toBe(2);
         expect(
-          atom.config.get('x.y', { sources: ['c'], scope: ['.foo'] })
+          core.config.get('x.y', { sources: ['c'], scope: ['.foo'] })
         ).toBe(3);
         // Schema defaults never match a specific source. We could potentially add a special "schema" source.
         expect(
-          atom.config.get('x.y', { sources: ['x'], scope: ['.foo'] })
+          core.config.get('x.y', { sources: ['x'], scope: ['.foo'] })
         ).toBeUndefined();
 
         expect(
-          atom.config.get(null, { sources: ['a'], scope: ['.foo'] }).x.y
+          core.config.get(null, { sources: ['a'], scope: ['.foo'] }).x.y
         ).toBe(1);
       }));
 
     describe("when an 'excludeSources' option is specified", () =>
       it('only retrieves values from the specified sources', () => {
-        atom.config.set('x.y', 0);
-        atom.config.set('x.y', 1, { scopeSelector: '.foo', source: 'a' });
-        atom.config.set('x.y', 2, { scopeSelector: '.foo', source: 'b' });
-        atom.config.set('x.y', 3, { scopeSelector: '.foo', source: 'c' });
-        atom.config.setSchema('x.y', { type: 'integer', default: 4 });
+        core.config.set('x.y', 0);
+        core.config.set('x.y', 1, { scopeSelector: '.foo', source: 'a' });
+        core.config.set('x.y', 2, { scopeSelector: '.foo', source: 'b' });
+        core.config.set('x.y', 3, { scopeSelector: '.foo', source: 'c' });
+        core.config.setSchema('x.y', { type: 'integer', default: 4 });
 
         expect(
-          atom.config.get('x.y', { excludeSources: ['a'], scope: ['.foo'] })
+          core.config.get('x.y', { excludeSources: ['a'], scope: ['.foo'] })
         ).toBe(3);
         expect(
-          atom.config.get('x.y', { excludeSources: ['c'], scope: ['.foo'] })
+          core.config.get('x.y', { excludeSources: ['c'], scope: ['.foo'] })
         ).toBe(2);
         expect(
-          atom.config.get('x.y', {
+          core.config.get('x.y', {
             excludeSources: ['b', 'c'],
             scope: ['.foo']
           })
         ).toBe(1);
         expect(
-          atom.config.get('x.y', {
+          core.config.get('x.y', {
             excludeSources: ['b', 'c', 'a'],
             scope: ['.foo']
           })
         ).toBe(0);
         expect(
-          atom.config.get('x.y', {
-            excludeSources: ['b', 'c', 'a', atom.config.getUserConfigPath()],
+          core.config.get('x.y', {
+            excludeSources: ['b', 'c', 'a', core.config.getUserConfigPath()],
             scope: ['.foo']
           })
         ).toBe(4);
         expect(
-          atom.config.get('x.y', {
-            excludeSources: [atom.config.getUserConfigPath()]
+          core.config.get('x.y', {
+            excludeSources: [core.config.getUserConfigPath()]
           })
         ).toBe(4);
       }));
 
     describe("when a 'scope' option is given", () => {
       it('returns the property with the most specific scope selector', () => {
-        atom.config.set('foo.bar.baz', 42, {
+        core.config.set('foo.bar.baz', 42, {
           scopeSelector: '.source.coffee .string.quoted.double.coffee'
         });
-        atom.config.set('foo.bar.baz', 22, {
+        core.config.set('foo.bar.baz', 22, {
           scopeSelector: '.source .string.quoted.double'
         });
-        atom.config.set('foo.bar.baz', 11, { scopeSelector: '.source' });
+        core.config.set('foo.bar.baz', 11, { scopeSelector: '.source' });
 
         expect(
-          atom.config.get('foo.bar.baz', {
+          core.config.get('foo.bar.baz', {
             scope: ['.source.coffee', '.string.quoted.double.coffee']
           })
         ).toBe(42);
         expect(
-          atom.config.get('foo.bar.baz', {
+          core.config.get('foo.bar.baz', {
             scope: ['.source.js', '.string.quoted.double.js']
           })
         ).toBe(22);
         expect(
-          atom.config.get('foo.bar.baz', {
+          core.config.get('foo.bar.baz', {
             scope: ['.source.js', '.variable.assignment.js']
           })
         ).toBe(11);
         expect(
-          atom.config.get('foo.bar.baz', { scope: ['.text'] })
+          core.config.get('foo.bar.baz', { scope: ['.text'] })
         ).toBeUndefined();
       });
 
       it('favors the most recently added properties in the event of a specificity tie', () => {
-        atom.config.set('foo.bar.baz', 42, {
+        core.config.set('foo.bar.baz', 42, {
           scopeSelector: '.source.coffee .string.quoted.single'
         });
-        atom.config.set('foo.bar.baz', 22, {
+        core.config.set('foo.bar.baz', 22, {
           scopeSelector: '.source.coffee .string.quoted.double'
         });
 
         expect(
-          atom.config.get('foo.bar.baz', {
+          core.config.get('foo.bar.baz', {
             scope: ['.source.coffee', '.string.quoted.single']
           })
         ).toBe(42);
         expect(
-          atom.config.get('foo.bar.baz', {
+          core.config.get('foo.bar.baz', {
             scope: ['.source.coffee', '.string.quoted.single.double']
           })
         ).toBe(22);
@@ -157,9 +157,9 @@ describe('Config', () => {
 
       describe('when there are global defaults', () =>
         it('falls back to the global when there is no scoped property specified', () => {
-          atom.config.setDefaults('foo', { hasDefault: 'ok' });
+          core.config.setDefaults('foo', { hasDefault: 'ok' });
           expect(
-            atom.config.get('foo.hasDefault', {
+            core.config.get('foo.hasDefault', {
               scope: ['.source.coffee', '.string.quoted.single']
             })
           ).toBe('ok');
@@ -167,15 +167,15 @@ describe('Config', () => {
 
       describe('when package settings are added after user settings', () =>
         it("returns the user's setting because the user's setting has higher priority", () => {
-          atom.config.set('foo.bar.baz', 100, {
+          core.config.set('foo.bar.baz', 100, {
             scopeSelector: '.source.coffee'
           });
-          atom.config.set('foo.bar.baz', 1, {
+          core.config.set('foo.bar.baz', 1, {
             scopeSelector: '.source.coffee',
             source: 'some-package'
           });
           expect(
-            atom.config.get('foo.bar.baz', { scope: ['.source.coffee'] })
+            core.config.get('foo.bar.baz', { scope: ['.source.coffee'] })
           ).toBe(100);
         }));
     });
@@ -183,16 +183,16 @@ describe('Config', () => {
 
   describe('.getAll(keyPath, {scope, sources, excludeSources})', () => {
     it('reads all of the values for a given key-path', () => {
-      expect(atom.config.set('foo', 41)).toBe(true);
-      expect(atom.config.set('foo', 43, { scopeSelector: '.a .b' })).toBe(true);
-      expect(atom.config.set('foo', 42, { scopeSelector: '.a' })).toBe(true);
-      expect(atom.config.set('foo', 44, { scopeSelector: '.a .b.c' })).toBe(
+      expect(core.config.set('foo', 41)).toBe(true);
+      expect(core.config.set('foo', 43, { scopeSelector: '.a .b' })).toBe(true);
+      expect(core.config.set('foo', 42, { scopeSelector: '.a' })).toBe(true);
+      expect(core.config.set('foo', 44, { scopeSelector: '.a .b.c' })).toBe(
         true
       );
 
-      expect(atom.config.set('foo', -44, { scopeSelector: '.d' })).toBe(true);
+      expect(core.config.set('foo', -44, { scopeSelector: '.d' })).toBe(true);
 
-      expect(atom.config.getAll('foo', { scope: ['.a', '.b.c'] })).toEqual([
+      expect(core.config.getAll('foo', { scope: ['.a', '.b.c'] })).toEqual([
         { scopeSelector: '.a .b.c', value: 44 },
         { scopeSelector: '.a .b', value: 43 },
         { scopeSelector: '.a', value: 42 },
@@ -201,9 +201,9 @@ describe('Config', () => {
     });
 
     it("includes the schema's default value", () => {
-      atom.config.setSchema('foo', { type: 'number', default: 40 });
-      expect(atom.config.set('foo', 43, { scopeSelector: '.a .b' })).toBe(true);
-      expect(atom.config.getAll('foo', { scope: ['.a', '.b.c'] })).toEqual([
+      core.config.setSchema('foo', { type: 'number', default: 40 });
+      expect(core.config.set('foo', 43, { scopeSelector: '.a .b' })).toBe(true);
+      expect(core.config.getAll('foo', { scope: ['.a', '.b.c'] })).toEqual([
         { scopeSelector: '.a .b', value: 43 },
         { scopeSelector: '*', value: 40 }
       ]);
@@ -212,22 +212,22 @@ describe('Config', () => {
 
   describe('.set(keyPath, value, {source, scopeSelector})', () => {
     it("allows a key path's value to be written", () => {
-      expect(atom.config.set('foo.bar.baz', 42)).toBe(true);
-      expect(atom.config.get('foo.bar.baz')).toBe(42);
+      expect(core.config.set('foo.bar.baz', 42)).toBe(true);
+      expect(core.config.get('foo.bar.baz')).toBe(42);
     });
 
     it("saves the user's config to disk after it stops changing", () => {
-      atom.config.set('foo.bar.baz', 42);
+      core.config.set('foo.bar.baz', 42);
       expect(savedSettings.length).toBe(0);
-      atom.config.set('foo.bar.baz', 43);
+      core.config.set('foo.bar.baz', 43);
       expect(savedSettings.length).toBe(0);
-      atom.config.set('foo.bar.baz', 44);
+      core.config.set('foo.bar.baz', 44);
       advanceClock(10);
       expect(savedSettings.length).toBe(1);
     });
 
     it("does not save when a non-default 'source' is given", () => {
-      atom.config.set('foo.bar.baz', 42, {
+      core.config.set('foo.bar.baz', 42, {
         source: 'some-other-source',
         scopeSelector: '.a'
       });
@@ -237,27 +237,27 @@ describe('Config', () => {
 
     it("does not allow a 'source' option without a 'scopeSelector'", () => {
       expect(() =>
-        atom.config.set('foo', 1, { source: ['.source.ruby'] })
+        core.config.set('foo', 1, { source: ['.source.ruby'] })
       ).toThrow();
     });
 
     describe('when the key-path is null', () =>
       it('sets the root object', () => {
-        expect(atom.config.set(null, { editor: { tabLength: 6 } })).toBe(true);
-        expect(atom.config.get('editor.tabLength')).toBe(6);
+        expect(core.config.set(null, { editor: { tabLength: 6 } })).toBe(true);
+        expect(core.config.get('editor.tabLength')).toBe(6);
         expect(
-          atom.config.set(null, {
+          core.config.set(null, {
             editor: { tabLength: 8, scopeSelector: ['.source.js'] }
           })
         ).toBe(true);
         expect(
-          atom.config.get('editor.tabLength', { scope: ['.source.js'] })
+          core.config.get('editor.tabLength', { scope: ['.source.js'] })
         ).toBe(8);
       }));
 
     describe('when the value equals the default value', () =>
       it("does not store the value in the user's config", () => {
-        atom.config.setSchema('foo', {
+        core.config.setSchema('foo', {
           type: 'object',
           properties: {
             same: {
@@ -286,55 +286,55 @@ describe('Config', () => {
             }
           }
         });
-        expect(atom.config.settings.foo).toBeUndefined();
+        expect(core.config.settings.foo).toBeUndefined();
 
-        atom.config.set('foo.same', 1);
-        atom.config.set('foo.changes', 2);
-        atom.config.set('foo.sameArray', [1, 2, 3]);
-        atom.config.set('foo.null', undefined);
-        atom.config.set('foo.undefined', null);
-        atom.config.set('foo.sameObject', { b: 2, a: 1 });
+        core.config.set('foo.same', 1);
+        core.config.set('foo.changes', 2);
+        core.config.set('foo.sameArray', [1, 2, 3]);
+        core.config.set('foo.null', undefined);
+        core.config.set('foo.undefined', null);
+        core.config.set('foo.sameObject', { b: 2, a: 1 });
 
-        const userConfigPath = atom.config.getUserConfigPath();
+        const userConfigPath = core.config.getUserConfigPath();
 
         expect(
-          atom.config.get('foo.same', { sources: [userConfigPath] })
+          core.config.get('foo.same', { sources: [userConfigPath] })
         ).toBeUndefined();
 
-        expect(atom.config.get('foo.changes')).toBe(2);
+        expect(core.config.get('foo.changes')).toBe(2);
         expect(
-          atom.config.get('foo.changes', { sources: [userConfigPath] })
+          core.config.get('foo.changes', { sources: [userConfigPath] })
         ).toBe(2);
 
-        atom.config.set('foo.changes', 1);
+        core.config.set('foo.changes', 1);
         expect(
-          atom.config.get('foo.changes', { sources: [userConfigPath] })
+          core.config.get('foo.changes', { sources: [userConfigPath] })
         ).toBeUndefined();
       }));
 
     describe("when a 'scopeSelector' is given", () =>
       it('sets the value and overrides the others', () => {
-        atom.config.set('foo.bar.baz', 42, {
+        core.config.set('foo.bar.baz', 42, {
           scopeSelector: '.source.coffee .string.quoted.double.coffee'
         });
-        atom.config.set('foo.bar.baz', 22, {
+        core.config.set('foo.bar.baz', 22, {
           scopeSelector: '.source .string.quoted.double'
         });
-        atom.config.set('foo.bar.baz', 11, { scopeSelector: '.source' });
+        core.config.set('foo.bar.baz', 11, { scopeSelector: '.source' });
 
         expect(
-          atom.config.get('foo.bar.baz', {
+          core.config.get('foo.bar.baz', {
             scope: ['.source.coffee', '.string.quoted.double.coffee']
           })
         ).toBe(42);
 
         expect(
-          atom.config.set('foo.bar.baz', 100, {
+          core.config.set('foo.bar.baz', 100, {
             scopeSelector: '.source.coffee .string.quoted.double.coffee'
           })
         ).toBe(true);
         expect(
-          atom.config.get('foo.bar.baz', {
+          core.config.get('foo.bar.baz', {
             scope: ['.source.coffee', '.string.quoted.double.coffee']
           })
         ).toBe(100);
@@ -343,7 +343,7 @@ describe('Config', () => {
 
   describe('.unset(keyPath, {source, scopeSelector})', () => {
     beforeEach(() =>
-      atom.config.setSchema('foo', {
+      core.config.setSchema('foo', {
         type: 'object',
         properties: {
           bar: {
@@ -368,24 +368,24 @@ describe('Config', () => {
     );
 
     it('sets the value of the key path to its default', () => {
-      atom.config.setDefaults('a', { b: 3 });
-      atom.config.set('a.b', 4);
-      expect(atom.config.get('a.b')).toBe(4);
-      atom.config.unset('a.b');
-      expect(atom.config.get('a.b')).toBe(3);
+      core.config.setDefaults('a', { b: 3 });
+      core.config.set('a.b', 4);
+      expect(core.config.get('a.b')).toBe(4);
+      core.config.unset('a.b');
+      expect(core.config.get('a.b')).toBe(3);
 
-      atom.config.set('a.c', 5);
-      expect(atom.config.get('a.c')).toBe(5);
-      atom.config.unset('a.c');
-      expect(atom.config.get('a.c')).toBeUndefined();
+      core.config.set('a.c', 5);
+      expect(core.config.get('a.c')).toBe(5);
+      core.config.unset('a.c');
+      expect(core.config.get('a.c')).toBeUndefined();
     });
 
     it('calls ::save()', () => {
-      atom.config.setDefaults('a', { b: 3 });
-      atom.config.set('a.b', 4);
+      core.config.setDefaults('a', { b: 3 });
+      core.config.set('a.b', 4);
       savedSettings.length = 0;
 
-      atom.config.unset('a.c');
+      core.config.unset('a.c');
       advanceClock(500);
       expect(savedSettings.length).toBe(1);
     });
@@ -393,21 +393,21 @@ describe('Config', () => {
     describe("when no 'scopeSelector' is given", () => {
       describe("when a 'source' but no key-path is given", () =>
         it('removes all scoped settings with the given source', () => {
-          atom.config.set('foo.bar.baz', 1, {
+          core.config.set('foo.bar.baz', 1, {
             scopeSelector: '.a',
             source: 'source-a'
           });
-          atom.config.set('foo.bar.quux', 2, {
+          core.config.set('foo.bar.quux', 2, {
             scopeSelector: '.b',
             source: 'source-a'
           });
-          expect(atom.config.get('foo.bar', { scope: ['.a.b'] })).toEqual({
+          expect(core.config.get('foo.bar', { scope: ['.a.b'] })).toEqual({
             baz: 1,
             quux: 2
           });
 
-          atom.config.unset(null, { source: 'source-a' });
-          expect(atom.config.get('foo.bar', { scope: ['.a'] })).toEqual({
+          core.config.unset(null, { source: 'source-a' });
+          expect(core.config.get('foo.bar', { scope: ['.a'] })).toEqual({
             baz: 0,
             ok: 0
           });
@@ -415,151 +415,151 @@ describe('Config', () => {
 
       describe("when a 'source' and a key-path is given", () =>
         it('removes all scoped settings with the given source and key-path', () => {
-          atom.config.set('foo.bar.baz', 1);
-          atom.config.set('foo.bar.baz', 2, {
+          core.config.set('foo.bar.baz', 1);
+          core.config.set('foo.bar.baz', 2, {
             scopeSelector: '.a',
             source: 'source-a'
           });
-          atom.config.set('foo.bar.baz', 3, {
+          core.config.set('foo.bar.baz', 3, {
             scopeSelector: '.a.b',
             source: 'source-b'
           });
-          expect(atom.config.get('foo.bar.baz', { scope: ['.a.b'] })).toEqual(
+          expect(core.config.get('foo.bar.baz', { scope: ['.a.b'] })).toEqual(
             3
           );
 
-          atom.config.unset('foo.bar.baz', { source: 'source-b' });
-          expect(atom.config.get('foo.bar.baz', { scope: ['.a.b'] })).toEqual(
+          core.config.unset('foo.bar.baz', { source: 'source-b' });
+          expect(core.config.get('foo.bar.baz', { scope: ['.a.b'] })).toEqual(
             2
           );
-          expect(atom.config.get('foo.bar.baz')).toEqual(1);
+          expect(core.config.get('foo.bar.baz')).toEqual(1);
         }));
 
       describe("when no 'source' is given", () =>
         it('removes all scoped and unscoped properties for that key-path', () => {
-          atom.config.setDefaults('foo.bar', { baz: 100 });
+          core.config.setDefaults('foo.bar', { baz: 100 });
 
-          atom.config.set(
+          core.config.set(
             'foo.bar',
             { baz: 1, ok: 2 },
             { scopeSelector: '.a' }
           );
-          atom.config.set(
+          core.config.set(
             'foo.bar',
             { baz: 11, ok: 12 },
             { scopeSelector: '.b' }
           );
-          atom.config.set('foo.bar', { baz: 21, ok: 22 });
+          core.config.set('foo.bar', { baz: 21, ok: 22 });
 
-          atom.config.unset('foo.bar.baz');
+          core.config.unset('foo.bar.baz');
 
-          expect(atom.config.get('foo.bar.baz', { scope: ['.a'] })).toBe(100);
-          expect(atom.config.get('foo.bar.baz', { scope: ['.b'] })).toBe(100);
-          expect(atom.config.get('foo.bar.baz')).toBe(100);
+          expect(core.config.get('foo.bar.baz', { scope: ['.a'] })).toBe(100);
+          expect(core.config.get('foo.bar.baz', { scope: ['.b'] })).toBe(100);
+          expect(core.config.get('foo.bar.baz')).toBe(100);
 
-          expect(atom.config.get('foo.bar.ok', { scope: ['.a'] })).toBe(2);
-          expect(atom.config.get('foo.bar.ok', { scope: ['.b'] })).toBe(12);
-          expect(atom.config.get('foo.bar.ok')).toBe(22);
+          expect(core.config.get('foo.bar.ok', { scope: ['.a'] })).toBe(2);
+          expect(core.config.get('foo.bar.ok', { scope: ['.b'] })).toBe(12);
+          expect(core.config.get('foo.bar.ok')).toBe(22);
         }));
     });
 
     describe("when a 'scopeSelector' is given", () => {
       it('restores the global default when no scoped default set', () => {
-        atom.config.setDefaults('foo', { bar: { baz: 10 } });
-        atom.config.set('foo.bar.baz', 55, { scopeSelector: '.source.coffee' });
+        core.config.setDefaults('foo', { bar: { baz: 10 } });
+        core.config.set('foo.bar.baz', 55, { scopeSelector: '.source.coffee' });
         expect(
-          atom.config.get('foo.bar.baz', { scope: ['.source.coffee'] })
+          core.config.get('foo.bar.baz', { scope: ['.source.coffee'] })
         ).toBe(55);
 
-        atom.config.unset('foo.bar.baz', { scopeSelector: '.source.coffee' });
+        core.config.unset('foo.bar.baz', { scopeSelector: '.source.coffee' });
         expect(
-          atom.config.get('foo.bar.baz', { scope: ['.source.coffee'] })
+          core.config.get('foo.bar.baz', { scope: ['.source.coffee'] })
         ).toBe(10);
       });
 
       it('restores the scoped default when a scoped default is set', () => {
-        atom.config.setDefaults('foo', { bar: { baz: 10 } });
-        atom.config.set('foo.bar.baz', 42, {
+        core.config.setDefaults('foo', { bar: { baz: 10 } });
+        core.config.set('foo.bar.baz', 42, {
           scopeSelector: '.source.coffee',
           source: 'some-source'
         });
-        atom.config.set('foo.bar.baz', 55, { scopeSelector: '.source.coffee' });
-        atom.config.set('foo.bar.ok', 100, { scopeSelector: '.source.coffee' });
+        core.config.set('foo.bar.baz', 55, { scopeSelector: '.source.coffee' });
+        core.config.set('foo.bar.ok', 100, { scopeSelector: '.source.coffee' });
         expect(
-          atom.config.get('foo.bar.baz', { scope: ['.source.coffee'] })
+          core.config.get('foo.bar.baz', { scope: ['.source.coffee'] })
         ).toBe(55);
 
-        atom.config.unset('foo.bar.baz', { scopeSelector: '.source.coffee' });
+        core.config.unset('foo.bar.baz', { scopeSelector: '.source.coffee' });
         expect(
-          atom.config.get('foo.bar.baz', { scope: ['.source.coffee'] })
+          core.config.get('foo.bar.baz', { scope: ['.source.coffee'] })
         ).toBe(42);
         expect(
-          atom.config.get('foo.bar.ok', { scope: ['.source.coffee'] })
+          core.config.get('foo.bar.ok', { scope: ['.source.coffee'] })
         ).toBe(100);
       });
 
       it('calls ::save()', () => {
-        atom.config.setDefaults('foo', { bar: { baz: 10 } });
-        atom.config.set('foo.bar.baz', 55, { scopeSelector: '.source.coffee' });
+        core.config.setDefaults('foo', { bar: { baz: 10 } });
+        core.config.set('foo.bar.baz', 55, { scopeSelector: '.source.coffee' });
         savedSettings.length = 0;
 
-        atom.config.unset('foo.bar.baz', { scopeSelector: '.source.coffee' });
+        core.config.unset('foo.bar.baz', { scopeSelector: '.source.coffee' });
         advanceClock(150);
         expect(savedSettings.length).toBe(1);
       });
 
       it('allows removing settings for a specific source and scope selector', () => {
-        atom.config.set('foo.bar.baz', 55, {
+        core.config.set('foo.bar.baz', 55, {
           scopeSelector: '.source.coffee',
           source: 'source-a'
         });
-        atom.config.set('foo.bar.baz', 65, {
+        core.config.set('foo.bar.baz', 65, {
           scopeSelector: '.source.coffee',
           source: 'source-b'
         });
         expect(
-          atom.config.get('foo.bar.baz', { scope: ['.source.coffee'] })
+          core.config.get('foo.bar.baz', { scope: ['.source.coffee'] })
         ).toBe(65);
 
-        atom.config.unset('foo.bar.baz', {
+        core.config.unset('foo.bar.baz', {
           source: 'source-b',
           scopeSelector: '.source.coffee'
         });
         expect(
-          atom.config.get('foo.bar.baz', {
+          core.config.get('foo.bar.baz', {
             scope: ['.source.coffee', '.string']
           })
         ).toBe(55);
       });
 
       it('allows removing all settings for a specific source', () => {
-        atom.config.set('foo.bar.baz', 55, {
+        core.config.set('foo.bar.baz', 55, {
           scopeSelector: '.source.coffee',
           source: 'source-a'
         });
-        atom.config.set('foo.bar.baz', 65, {
+        core.config.set('foo.bar.baz', 65, {
           scopeSelector: '.source.coffee',
           source: 'source-b'
         });
-        atom.config.set('foo.bar.ok', 65, {
+        core.config.set('foo.bar.ok', 65, {
           scopeSelector: '.source.coffee',
           source: 'source-b'
         });
         expect(
-          atom.config.get('foo.bar.baz', { scope: ['.source.coffee'] })
+          core.config.get('foo.bar.baz', { scope: ['.source.coffee'] })
         ).toBe(65);
 
-        atom.config.unset(null, {
+        core.config.unset(null, {
           source: 'source-b',
           scopeSelector: '.source.coffee'
         });
         expect(
-          atom.config.get('foo.bar.baz', {
+          core.config.get('foo.bar.baz', {
             scope: ['.source.coffee', '.string']
           })
         ).toBe(55);
         expect(
-          atom.config.get('foo.bar.ok', {
+          core.config.get('foo.bar.ok', {
             scope: ['.source.coffee', '.string']
           })
         ).toBe(0);
@@ -567,38 +567,38 @@ describe('Config', () => {
 
       it('does not call ::save or add a scoped property when no value has been set', () => {
         // see https://github.com/atom/atom/issues/4175
-        atom.config.setDefaults('foo', { bar: { baz: 10 } });
-        atom.config.unset('foo.bar.baz', { scopeSelector: '.source.coffee' });
+        core.config.setDefaults('foo', { bar: { baz: 10 } });
+        core.config.unset('foo.bar.baz', { scopeSelector: '.source.coffee' });
         expect(
-          atom.config.get('foo.bar.baz', { scope: ['.source.coffee'] })
+          core.config.get('foo.bar.baz', { scope: ['.source.coffee'] })
         ).toBe(10);
 
         expect(savedSettings.length).toBe(0);
 
-        const scopedProperties = atom.config.scopedSettingsStore.propertiesForSource(
+        const scopedProperties = core.config.scopedSettingsStore.propertiesForSource(
           'user-config'
         );
         expect(scopedProperties['.coffee.source']).toBeUndefined();
       });
 
       it('removes the scoped value when it was the only set value on the object', () => {
-        atom.config.setDefaults('foo', { bar: { baz: 10 } });
-        atom.config.set('foo.bar.baz', 55, { scopeSelector: '.source.coffee' });
-        atom.config.set('foo.bar.ok', 20, { scopeSelector: '.source.coffee' });
+        core.config.setDefaults('foo', { bar: { baz: 10 } });
+        core.config.set('foo.bar.baz', 55, { scopeSelector: '.source.coffee' });
+        core.config.set('foo.bar.ok', 20, { scopeSelector: '.source.coffee' });
         expect(
-          atom.config.get('foo.bar.baz', { scope: ['.source.coffee'] })
+          core.config.get('foo.bar.baz', { scope: ['.source.coffee'] })
         ).toBe(55);
 
         advanceClock(150);
         
         savedSettings.length = 0;
 
-        atom.config.unset('foo.bar.baz', { scopeSelector: '.source.coffee' });
+        core.config.unset('foo.bar.baz', { scopeSelector: '.source.coffee' });
         expect(
-          atom.config.get('foo.bar.baz', { scope: ['.source.coffee'] })
+          core.config.get('foo.bar.baz', { scope: ['.source.coffee'] })
         ).toBe(10);
         expect(
-          atom.config.get('foo.bar.ok', { scope: ['.source.coffee'] })
+          core.config.get('foo.bar.ok', { scope: ['.source.coffee'] })
         ).toBe(20);
 
         advanceClock(150);
@@ -611,7 +611,7 @@ describe('Config', () => {
           }
         });
 
-        atom.config.unset('foo.bar.ok', { scopeSelector: '.source.coffee' });
+        core.config.unset('foo.bar.ok', { scopeSelector: '.source.coffee' });
 
         advanceClock(150);
 
@@ -620,16 +620,16 @@ describe('Config', () => {
       });
 
       it('does not call ::save when the value is already at the default', () => {
-        atom.config.setDefaults('foo', { bar: { baz: 10 } });
-        atom.config.set('foo.bar.baz', 55);
+        core.config.setDefaults('foo', { bar: { baz: 10 } });
+        core.config.set('foo.bar.baz', 55);
         advanceClock(150);
         savedSettings.length = 0;
 
-        atom.config.unset('foo.bar.ok', { scopeSelector: '.source.coffee' });
+        core.config.unset('foo.bar.ok', { scopeSelector: '.source.coffee' });
         advanceClock(150);
         expect(savedSettings.length).toBe(0);
         expect(
-          atom.config.get('foo.bar.baz', { scope: ['.source.coffee'] })
+          core.config.get('foo.bar.baz', { scope: ['.source.coffee'] })
         ).toBe(55);
       });
     });
@@ -641,15 +641,15 @@ describe('Config', () => {
     describe('when a keyPath is specified', () => {
       beforeEach(() => {
         observeHandler = jasmine.createSpy('observeHandler');
-        atom.config.set('foo.bar.baz', 'value 1');
-        atom.config.onDidChange('foo.bar.baz', observeHandler);
+        core.config.set('foo.bar.baz', 'value 1');
+        core.config.onDidChange('foo.bar.baz', observeHandler);
       });
 
       it('does not fire the given callback with the current value at the keypath', () =>
         expect(observeHandler).not.toHaveBeenCalled());
 
       it('fires the callback every time the observed value changes', () => {
-        atom.config.set('foo.bar.baz', 'value 2');
+        core.config.set('foo.bar.baz', 'value 2');
         expect(observeHandler).toHaveBeenCalledWith({
           newValue: 'value 2',
           oldValue: 'value 1'
@@ -658,7 +658,7 @@ describe('Config', () => {
         observeHandler.andCallFake(() => {
           throw new Error('oops');
         });
-        expect(() => atom.config.set('foo.bar.baz', 'value 1')).toThrow('oops');
+        expect(() => core.config.set('foo.bar.baz', 'value 1')).toThrow('oops');
         expect(observeHandler).toHaveBeenCalledWith({
           newValue: 'value 1',
           oldValue: 'value 2'
@@ -667,7 +667,7 @@ describe('Config', () => {
 
         // Regression: exception in earlier handler shouldn't put observer
         // into a bad state.
-        atom.config.set('something.else', 'new value');
+        core.config.set('something.else', 'new value');
         expect(observeHandler).not.toHaveBeenCalled();
       });
     });
@@ -675,8 +675,8 @@ describe('Config', () => {
     describe('when a keyPath is not specified', () => {
       beforeEach(() => {
         observeHandler = jasmine.createSpy('observeHandler');
-        atom.config.set('foo.bar.baz', 'value 1');
-        atom.config.onDidChange(observeHandler);
+        core.config.set('foo.bar.baz', 'value 1');
+        core.config.onDidChange(observeHandler);
       });
 
       it('does not fire the given callback initially', () =>
@@ -684,7 +684,7 @@ describe('Config', () => {
 
       it('fires the callback every time any value changes', () => {
         observeHandler.reset(); // clear the initial call
-        atom.config.set('foo.bar.baz', 'value 2');
+        core.config.set('foo.bar.baz', 'value 2');
         expect(observeHandler).toHaveBeenCalled();
         expect(observeHandler.mostRecentCall.args[0].newValue.foo.bar.baz).toBe(
           'value 2'
@@ -694,7 +694,7 @@ describe('Config', () => {
         );
 
         observeHandler.reset();
-        atom.config.set('foo.bar.baz', 'value 1');
+        core.config.set('foo.bar.baz', 'value 1');
         expect(observeHandler).toHaveBeenCalled();
         expect(observeHandler.mostRecentCall.args[0].newValue.foo.bar.baz).toBe(
           'value 1'
@@ -704,7 +704,7 @@ describe('Config', () => {
         );
 
         observeHandler.reset();
-        atom.config.set('foo.bar.int', 1);
+        core.config.set('foo.bar.int', 1);
         expect(observeHandler).toHaveBeenCalled();
         expect(observeHandler.mostRecentCall.args[0].newValue.foo.bar.int).toBe(
           1
@@ -718,48 +718,48 @@ describe('Config', () => {
     describe("when a 'scope' is given", () =>
       it('calls the supplied callback when the value at the descriptor/keypath changes', () => {
         const changeSpy = jasmine.createSpy('onDidChange callback');
-        atom.config.onDidChange(
+        core.config.onDidChange(
           'foo.bar.baz',
           { scope: ['.source.coffee', '.string.quoted.double.coffee'] },
           changeSpy
         );
 
-        atom.config.set('foo.bar.baz', 12);
+        core.config.set('foo.bar.baz', 12);
         expect(changeSpy).toHaveBeenCalledWith({
           oldValue: undefined,
           newValue: 12
         });
         changeSpy.reset();
 
-        atom.config.set('foo.bar.baz', 22, {
+        core.config.set('foo.bar.baz', 22, {
           scopeSelector: '.source .string.quoted.double',
           source: 'a'
         });
         expect(changeSpy).toHaveBeenCalledWith({ oldValue: 12, newValue: 22 });
         changeSpy.reset();
 
-        atom.config.set('foo.bar.baz', 42, {
+        core.config.set('foo.bar.baz', 42, {
           scopeSelector: '.source.coffee .string.quoted.double.coffee',
           source: 'b'
         });
         expect(changeSpy).toHaveBeenCalledWith({ oldValue: 22, newValue: 42 });
         changeSpy.reset();
 
-        atom.config.unset(null, {
+        core.config.unset(null, {
           scopeSelector: '.source.coffee .string.quoted.double.coffee',
           source: 'b'
         });
         expect(changeSpy).toHaveBeenCalledWith({ oldValue: 42, newValue: 22 });
         changeSpy.reset();
 
-        atom.config.unset(null, {
+        core.config.unset(null, {
           scopeSelector: '.source .string.quoted.double',
           source: 'a'
         });
         expect(changeSpy).toHaveBeenCalledWith({ oldValue: 22, newValue: 12 });
         changeSpy.reset();
 
-        atom.config.set('foo.bar.baz', undefined);
+        core.config.set('foo.bar.baz', undefined);
         expect(changeSpy).toHaveBeenCalledWith({
           oldValue: 12,
           newValue: undefined
@@ -773,8 +773,8 @@ describe('Config', () => {
 
     beforeEach(() => {
       observeHandler = jasmine.createSpy('observeHandler');
-      atom.config.set('foo.bar.baz', 'value 1');
-      observeSubscription = atom.config.observe('foo.bar.baz', observeHandler);
+      core.config.set('foo.bar.baz', 'value 1');
+      observeSubscription = core.config.observe('foo.bar.baz', observeHandler);
     });
 
     it('fires the given callback with the current value at the keypath', () =>
@@ -782,51 +782,51 @@ describe('Config', () => {
 
     it('fires the callback every time the observed value changes', () => {
       observeHandler.reset(); // clear the initial call
-      atom.config.set('foo.bar.baz', 'value 2');
+      core.config.set('foo.bar.baz', 'value 2');
       expect(observeHandler).toHaveBeenCalledWith('value 2');
 
       observeHandler.reset();
-      atom.config.set('foo.bar.baz', 'value 1');
+      core.config.set('foo.bar.baz', 'value 1');
       expect(observeHandler).toHaveBeenCalledWith('value 1');
       advanceClock(100); // complete pending save that was requested in ::set
 
       observeHandler.reset();
-      atom.config.resetUserSettings({ foo: {} });
+      core.config.resetUserSettings({ foo: {} });
       expect(observeHandler).toHaveBeenCalledWith(undefined);
     });
 
     it('fires the callback when the observed value is deleted', () => {
       observeHandler.reset(); // clear the initial call
-      atom.config.set('foo.bar.baz', undefined);
+      core.config.set('foo.bar.baz', undefined);
       expect(observeHandler).toHaveBeenCalledWith(undefined);
     });
 
     it('fires the callback when the full key path goes into and out of existence', () => {
       observeHandler.reset(); // clear the initial call
-      atom.config.set('foo.bar', undefined);
+      core.config.set('foo.bar', undefined);
       expect(observeHandler).toHaveBeenCalledWith(undefined);
 
       observeHandler.reset();
-      atom.config.set('foo.bar.baz', "i'm back");
+      core.config.set('foo.bar.baz', "i'm back");
       expect(observeHandler).toHaveBeenCalledWith("i'm back");
     });
 
     it('does not fire the callback once the subscription is disposed', () => {
       observeHandler.reset(); // clear the initial call
       observeSubscription.dispose();
-      atom.config.set('foo.bar.baz', 'value 2');
+      core.config.set('foo.bar.baz', 'value 2');
       expect(observeHandler).not.toHaveBeenCalled();
     });
 
     it('does not fire the callback for a similarly named keyPath', () => {
       const bazCatHandler = jasmine.createSpy('bazCatHandler');
-      observeSubscription = atom.config.observe(
+      observeSubscription = core.config.observe(
         'foo.bar.bazCat',
         bazCatHandler
       );
 
       bazCatHandler.reset();
-      atom.config.set('foo.bar.baz', 'value 10');
+      core.config.set('foo.bar.baz', 'value 10');
       expect(bazCatHandler).not.toHaveBeenCalled();
     });
 
@@ -839,25 +839,25 @@ describe('Config', () => {
       });
 
       it('allows settings to be observed in a specific scope', () => {
-        atom.config.observe(
+        core.config.observe(
           'foo.bar.baz',
           { scope: ['.some.scope'] },
           observeHandler
         );
-        atom.config.observe(
+        core.config.observe(
           'foo.bar.baz',
           { scope: ['.another.scope'] },
           otherHandler
         );
 
-        atom.config.set('foo.bar.baz', 'value 2', { scopeSelector: '.some' });
+        core.config.set('foo.bar.baz', 'value 2', { scopeSelector: '.some' });
         expect(observeHandler).toHaveBeenCalledWith('value 2');
         expect(otherHandler).not.toHaveBeenCalledWith('value 2');
       });
 
       it('calls the callback when properties with more specific selectors are removed', () => {
         const changeSpy = jasmine.createSpy();
-        atom.config.observe(
+        core.config.observe(
           'foo.bar.baz',
           { scope: ['.source.coffee', '.string.quoted.double.coffee'] },
           changeSpy
@@ -865,39 +865,39 @@ describe('Config', () => {
         expect(changeSpy).toHaveBeenCalledWith('value 1');
         changeSpy.reset();
 
-        atom.config.set('foo.bar.baz', 12);
+        core.config.set('foo.bar.baz', 12);
         expect(changeSpy).toHaveBeenCalledWith(12);
         changeSpy.reset();
 
-        atom.config.set('foo.bar.baz', 22, {
+        core.config.set('foo.bar.baz', 22, {
           scopeSelector: '.source .string.quoted.double',
           source: 'a'
         });
         expect(changeSpy).toHaveBeenCalledWith(22);
         changeSpy.reset();
 
-        atom.config.set('foo.bar.baz', 42, {
+        core.config.set('foo.bar.baz', 42, {
           scopeSelector: '.source.coffee .string.quoted.double.coffee',
           source: 'b'
         });
         expect(changeSpy).toHaveBeenCalledWith(42);
         changeSpy.reset();
 
-        atom.config.unset(null, {
+        core.config.unset(null, {
           scopeSelector: '.source.coffee .string.quoted.double.coffee',
           source: 'b'
         });
         expect(changeSpy).toHaveBeenCalledWith(22);
         changeSpy.reset();
 
-        atom.config.unset(null, {
+        core.config.unset(null, {
           scopeSelector: '.source .string.quoted.double',
           source: 'a'
         });
         expect(changeSpy).toHaveBeenCalledWith(12);
         changeSpy.reset();
 
-        atom.config.set('foo.bar.baz', undefined);
+        core.config.set('foo.bar.baz', undefined);
         expect(changeSpy).toHaveBeenCalledWith(undefined);
         changeSpy.reset();
       });
@@ -909,14 +909,14 @@ describe('Config', () => {
 
     beforeEach(() => {
       changeSpy = jasmine.createSpy('onDidChange callback');
-      atom.config.onDidChange('foo.bar.baz', changeSpy);
+      core.config.onDidChange('foo.bar.baz', changeSpy);
     });
 
     it('allows only one change event for the duration of the given callback', () => {
-      atom.config.transact(() => {
-        atom.config.set('foo.bar.baz', 1);
-        atom.config.set('foo.bar.baz', 2);
-        atom.config.set('foo.bar.baz', 3);
+      core.config.transact(() => {
+        core.config.set('foo.bar.baz', 1);
+        core.config.set('foo.bar.baz', 2);
+        core.config.set('foo.bar.baz', 3);
       });
 
       expect(changeSpy.callCount).toBe(1);
@@ -927,7 +927,7 @@ describe('Config', () => {
     });
 
     it('does not emit an event if no changes occur while paused', () => {
-      atom.config.transact(() => {});
+      core.config.transact(() => {});
       expect(changeSpy).not.toHaveBeenCalled();
     });
   });
@@ -937,15 +937,15 @@ describe('Config', () => {
 
     beforeEach(() => {
       changeSpy = jasmine.createSpy('onDidChange callback');
-      atom.config.onDidChange('foo.bar.baz', changeSpy);
+      core.config.onDidChange('foo.bar.baz', changeSpy);
     });
 
     it('allows only one change event for the duration of the given promise if it gets resolved', () => {
       let promiseResult = null;
-      const transactionPromise = atom.config.transactAsync(() => {
-        atom.config.set('foo.bar.baz', 1);
-        atom.config.set('foo.bar.baz', 2);
-        atom.config.set('foo.bar.baz', 3);
+      const transactionPromise = core.config.transactAsync(() => {
+        core.config.set('foo.bar.baz', 1);
+        core.config.set('foo.bar.baz', 2);
+        core.config.set('foo.bar.baz', 3);
         return Promise.resolve('a result');
       });
 
@@ -967,10 +967,10 @@ describe('Config', () => {
 
     it('allows only one change event for the duration of the given promise if it gets rejected', () => {
       let promiseError = null;
-      const transactionPromise = atom.config.transactAsync(() => {
-        atom.config.set('foo.bar.baz', 1);
-        atom.config.set('foo.bar.baz', 2);
-        atom.config.set('foo.bar.baz', 3);
+      const transactionPromise = core.config.transactAsync(() => {
+        core.config.set('foo.bar.baz', 1);
+        core.config.set('foo.bar.baz', 2);
+        core.config.set('foo.bar.baz', 3);
         return Promise.reject(new Error('an error'));
       });
 
@@ -993,10 +993,10 @@ describe('Config', () => {
     it('allows only one change event even when the given callback throws', () => {
       const error = new Error('Oops!');
       let promiseError = null;
-      const transactionPromise = atom.config.transactAsync(() => {
-        atom.config.set('foo.bar.baz', 1);
-        atom.config.set('foo.bar.baz', 2);
-        atom.config.set('foo.bar.baz', 3);
+      const transactionPromise = core.config.transactAsync(() => {
+        core.config.set('foo.bar.baz', 1);
+        core.config.set('foo.bar.baz', 2);
+        core.config.set('foo.bar.baz', 3);
         throw error;
       });
 
@@ -1019,14 +1019,14 @@ describe('Config', () => {
 
   describe('.getSources()', () => {
     it("returns an array of all of the config's source names", () => {
-      expect(atom.config.getSources()).toEqual([]);
+      expect(core.config.getSources()).toEqual([]);
 
-      atom.config.set('a.b', 1, { scopeSelector: '.x1', source: 'source-1' });
-      atom.config.set('a.c', 1, { scopeSelector: '.x1', source: 'source-1' });
-      atom.config.set('a.b', 2, { scopeSelector: '.x2', source: 'source-2' });
-      atom.config.set('a.b', 1, { scopeSelector: '.x3', source: 'source-3' });
+      core.config.set('a.b', 1, { scopeSelector: '.x1', source: 'source-1' });
+      core.config.set('a.c', 1, { scopeSelector: '.x1', source: 'source-1' });
+      core.config.set('a.b', 2, { scopeSelector: '.x2', source: 'source-2' });
+      core.config.set('a.b', 1, { scopeSelector: '.x3', source: 'source-3' });
 
-      expect(atom.config.getSources()).toEqual([
+      expect(core.config.getSources()).toEqual([
         'source-1',
         'source-2',
         'source-3'
@@ -1036,26 +1036,26 @@ describe('Config', () => {
 
   describe('.save()', () => {
     it('calls the save callback with any non-default properties', () => {
-      atom.config.set('a.b.c', 1);
-      atom.config.set('a.b.d', 2);
-      atom.config.set('x.y.z', 3);
-      atom.config.setDefaults('a.b', { e: 4, f: 5 });
+      core.config.set('a.b.c', 1);
+      core.config.set('a.b.d', 2);
+      core.config.set('x.y.z', 3);
+      core.config.setDefaults('a.b', { e: 4, f: 5 });
 
-      atom.config.save();
-      expect(savedSettings).toEqual([{ '*': atom.config.settings }]);
+      core.config.save();
+      expect(savedSettings).toEqual([{ '*': core.config.settings }]);
     });
 
     it('serializes properties in alphabetical order', () => {
-      atom.config.set('foo', 1);
-      atom.config.set('bar', 2);
-      atom.config.set('baz.foo', 3);
-      atom.config.set('baz.bar', 4);
+      core.config.set('foo', 1);
+      core.config.set('bar', 2);
+      core.config.set('baz.foo', 3);
+      core.config.set('baz.bar', 4);
 
       savedSettings.length = 0;
-      atom.config.save();
+      core.config.save();
 
       const writtenConfig = savedSettings[0];
-      expect(writtenConfig).toEqual({ '*': atom.config.settings });
+      expect(writtenConfig).toEqual({ '*': core.config.settings });
 
       let expectedKeys = ['bar', 'baz', 'foo'];
       let foundKeys = [];
@@ -1077,18 +1077,18 @@ describe('Config', () => {
 
     describe('when scoped settings are defined', () => {
       it('serializes any explicitly set config settings', () => {
-        atom.config.set('foo.bar', 'ruby', { scopeSelector: '.source.ruby' });
-        atom.config.set('foo.omg', 'wow', { scopeSelector: '.source.ruby' });
-        atom.config.set('foo.bar', 'coffee', {
+        core.config.set('foo.bar', 'ruby', { scopeSelector: '.source.ruby' });
+        core.config.set('foo.omg', 'wow', { scopeSelector: '.source.ruby' });
+        core.config.set('foo.bar', 'coffee', {
           scopeSelector: '.source.coffee'
         });
 
         savedSettings.length = 0;
-        atom.config.save();
+        core.config.save();
 
         const writtenConfig = savedSettings[0];
         expect(writtenConfig).toEqualJson({
-          '*': atom.config.settings,
+          '*': core.config.settings,
           '.ruby.source': {
             foo: {
               bar: 'ruby',
@@ -1107,7 +1107,7 @@ describe('Config', () => {
 
   describe('.resetUserSettings()', () => {
     beforeEach(() => {
-      atom.config.setSchema('foo', {
+      core.config.setSchema('foo', {
         type: 'object',
         properties: {
           bar: {
@@ -1124,7 +1124,7 @@ describe('Config', () => {
 
     describe('when the config file contains scoped settings', () => {
       it('updates the config data based on the file contents', () => {
-        atom.config.resetUserSettings({
+        core.config.resetUserSettings({
           '*': {
             foo: {
               bar: 'baz'
@@ -1137,8 +1137,8 @@ describe('Config', () => {
             }
           }
         });
-        expect(atom.config.get('foo.bar')).toBe('baz');
-        expect(atom.config.get('foo.bar', { scope: ['.source.ruby'] })).toBe(
+        expect(core.config.get('foo.bar')).toBe('baz');
+        expect(core.config.get('foo.bar', { scope: ['.source.ruby'] })).toBe(
           'more-specific'
         );
       });
@@ -1146,7 +1146,7 @@ describe('Config', () => {
 
     describe('when the config file does not conform to the schema', () => {
       it('validates and does not load the incorrect values', () => {
-        atom.config.resetUserSettings({
+        core.config.resetUserSettings({
           '*': {
             foo: {
               bar: 'omg',
@@ -1160,94 +1160,94 @@ describe('Config', () => {
             }
           }
         });
-        expect(atom.config.get('foo.int')).toBe(12);
-        expect(atom.config.get('foo.bar')).toBe('omg');
-        expect(atom.config.get('foo.int', { scope: ['.source.ruby'] })).toBe(
+        expect(core.config.get('foo.int')).toBe(12);
+        expect(core.config.get('foo.bar')).toBe('omg');
+        expect(core.config.get('foo.int', { scope: ['.source.ruby'] })).toBe(
           12
         );
-        expect(atom.config.get('foo.bar', { scope: ['.source.ruby'] })).toBe(
+        expect(core.config.get('foo.bar', { scope: ['.source.ruby'] })).toBe(
           'scoped'
         );
       });
     });
 
     it('updates the config data based on the file contents', () => {
-      atom.config.resetUserSettings({ foo: { bar: 'baz' } });
-      expect(atom.config.get('foo.bar')).toBe('baz');
+      core.config.resetUserSettings({ foo: { bar: 'baz' } });
+      expect(core.config.get('foo.bar')).toBe('baz');
     });
 
     it('notifies observers for updated keypaths on load', () => {
       const observeHandler = jasmine.createSpy('observeHandler');
-      atom.config.observe('foo.bar', observeHandler);
-      atom.config.resetUserSettings({ foo: { bar: 'baz' } });
+      core.config.observe('foo.bar', observeHandler);
+      core.config.resetUserSettings({ foo: { bar: 'baz' } });
       expect(observeHandler).toHaveBeenCalledWith('baz');
     });
 
     describe('when the config file contains values that do not adhere to the schema', () => {
       it('updates the only the settings that have values matching the schema', () => {
-        atom.config.resetUserSettings({
+        core.config.resetUserSettings({
           foo: {
             bar: 'baz',
             int: 'bad value'
           }
         });
-        expect(atom.config.get('foo.bar')).toBe('baz');
-        expect(atom.config.get('foo.int')).toBe(12);
+        expect(core.config.get('foo.bar')).toBe('baz');
+        expect(core.config.get('foo.int')).toBe(12);
         expect(console.warn).toHaveBeenCalled();
         expect(console.warn.mostRecentCall.args[0]).toContain('foo.int');
       });
     });
 
     it('does not fire a change event for paths that did not change', () => {
-      atom.config.resetUserSettings({
+      core.config.resetUserSettings({
         foo: { bar: 'baz', int: 3 }
       });
 
       const noChangeSpy = jasmine.createSpy('unchanged');
-      atom.config.onDidChange('foo.bar', noChangeSpy);
+      core.config.onDidChange('foo.bar', noChangeSpy);
 
-      atom.config.resetUserSettings({
+      core.config.resetUserSettings({
         foo: { bar: 'baz', int: 4 }
       });
 
       expect(noChangeSpy).not.toHaveBeenCalled();
-      expect(atom.config.get('foo.bar')).toBe('baz');
-      expect(atom.config.get('foo.int')).toBe(4);
+      expect(core.config.get('foo.bar')).toBe('baz');
+      expect(core.config.get('foo.int')).toBe(4);
     });
 
     it('does not fire a change event for paths whose non-primitive values did not change', () => {
-      atom.config.setSchema('foo.bar', {
+      core.config.setSchema('foo.bar', {
         type: 'array',
         items: {
           type: 'string'
         }
       });
 
-      atom.config.resetUserSettings({
+      core.config.resetUserSettings({
         foo: { bar: ['baz', 'quux'], int: 2 }
       });
 
       const noChangeSpy = jasmine.createSpy('unchanged');
-      atom.config.onDidChange('foo.bar', noChangeSpy);
+      core.config.onDidChange('foo.bar', noChangeSpy);
 
-      atom.config.resetUserSettings({
+      core.config.resetUserSettings({
         foo: { bar: ['baz', 'quux'], int: 2 }
       });
 
       expect(noChangeSpy).not.toHaveBeenCalled();
-      expect(atom.config.get('foo.bar')).toEqual(['baz', 'quux']);
+      expect(core.config.get('foo.bar')).toEqual(['baz', 'quux']);
     });
 
     describe('when a setting with a default is removed', () => {
       it('resets the setting back to the default', () => {
-        atom.config.resetUserSettings({
+        core.config.resetUserSettings({
           foo: { bar: ['baz', 'quux'], int: 2 }
         });
 
         const events = [];
-        atom.config.onDidChange('foo.int', event => events.push(event));
+        core.config.onDidChange('foo.int', event => events.push(event));
 
-        atom.config.resetUserSettings({
+        core.config.resetUserSettings({
           foo: { bar: ['baz', 'quux'] }
         });
 
@@ -1257,7 +1257,7 @@ describe('Config', () => {
     });
 
     it('keeps all the global scope settings after overriding one', () => {
-      atom.config.resetUserSettings({
+      core.config.resetUserSettings({
         '*': {
           foo: {
             bar: 'baz',
@@ -1266,7 +1266,7 @@ describe('Config', () => {
         }
       });
 
-      atom.config.set('foo.int', 50, { scopeSelector: '*' });
+      core.config.set('foo.int', 50, { scopeSelector: '*' });
 
       advanceClock(100);
 
@@ -1274,78 +1274,78 @@ describe('Config', () => {
         bar: 'baz',
         int: 50
       });
-      expect(atom.config.get('foo.int', { scope: ['*'] })).toEqual(50);
-      expect(atom.config.get('foo.bar', { scope: ['*'] })).toEqual('baz');
-      expect(atom.config.get('foo.int')).toEqual(50);
+      expect(core.config.get('foo.int', { scope: ['*'] })).toEqual(50);
+      expect(core.config.get('foo.bar', { scope: ['*'] })).toEqual('baz');
+      expect(core.config.get('foo.int')).toEqual(50);
     });
   });
 
   describe('.pushAtKeyPath(keyPath, value)', () => {
     it('pushes the given value to the array at the key path and updates observers', () => {
-      atom.config.set('foo.bar.baz', ['a']);
+      core.config.set('foo.bar.baz', ['a']);
       const observeHandler = jasmine.createSpy('observeHandler');
-      atom.config.observe('foo.bar.baz', observeHandler);
+      core.config.observe('foo.bar.baz', observeHandler);
       observeHandler.reset();
 
-      expect(atom.config.pushAtKeyPath('foo.bar.baz', 'b')).toBe(2);
-      expect(atom.config.get('foo.bar.baz')).toEqual(['a', 'b']);
+      expect(core.config.pushAtKeyPath('foo.bar.baz', 'b')).toBe(2);
+      expect(core.config.get('foo.bar.baz')).toEqual(['a', 'b']);
       expect(observeHandler).toHaveBeenCalledWith(
-        atom.config.get('foo.bar.baz')
+        core.config.get('foo.bar.baz')
       );
     });
   });
 
   describe('.unshiftAtKeyPath(keyPath, value)', () => {
     it('unshifts the given value to the array at the key path and updates observers', () => {
-      atom.config.set('foo.bar.baz', ['b']);
+      core.config.set('foo.bar.baz', ['b']);
       const observeHandler = jasmine.createSpy('observeHandler');
-      atom.config.observe('foo.bar.baz', observeHandler);
+      core.config.observe('foo.bar.baz', observeHandler);
       observeHandler.reset();
 
-      expect(atom.config.unshiftAtKeyPath('foo.bar.baz', 'a')).toBe(2);
-      expect(atom.config.get('foo.bar.baz')).toEqual(['a', 'b']);
+      expect(core.config.unshiftAtKeyPath('foo.bar.baz', 'a')).toBe(2);
+      expect(core.config.get('foo.bar.baz')).toEqual(['a', 'b']);
       expect(observeHandler).toHaveBeenCalledWith(
-        atom.config.get('foo.bar.baz')
+        core.config.get('foo.bar.baz')
       );
     });
   });
 
   describe('.removeAtKeyPath(keyPath, value)', () => {
     it('removes the given value from the array at the key path and updates observers', () => {
-      atom.config.set('foo.bar.baz', ['a', 'b', 'c']);
+      core.config.set('foo.bar.baz', ['a', 'b', 'c']);
       const observeHandler = jasmine.createSpy('observeHandler');
-      atom.config.observe('foo.bar.baz', observeHandler);
+      core.config.observe('foo.bar.baz', observeHandler);
       observeHandler.reset();
 
-      expect(atom.config.removeAtKeyPath('foo.bar.baz', 'b')).toEqual([
+      expect(core.config.removeAtKeyPath('foo.bar.baz', 'b')).toEqual([
         'a',
         'c'
       ]);
-      expect(atom.config.get('foo.bar.baz')).toEqual(['a', 'c']);
+      expect(core.config.get('foo.bar.baz')).toEqual(['a', 'c']);
       expect(observeHandler).toHaveBeenCalledWith(
-        atom.config.get('foo.bar.baz')
+        core.config.get('foo.bar.baz')
       );
     });
   });
 
   describe('.setDefaults(keyPath, defaults)', () => {
     it('assigns any previously-unassigned keys to the object at the key path', () => {
-      atom.config.set('foo.bar.baz', { a: 1 });
-      atom.config.setDefaults('foo.bar.baz', { a: 2, b: 3, c: 4 });
-      expect(atom.config.get('foo.bar.baz.a')).toBe(1);
-      expect(atom.config.get('foo.bar.baz.b')).toBe(3);
-      expect(atom.config.get('foo.bar.baz.c')).toBe(4);
+      core.config.set('foo.bar.baz', { a: 1 });
+      core.config.setDefaults('foo.bar.baz', { a: 2, b: 3, c: 4 });
+      expect(core.config.get('foo.bar.baz.a')).toBe(1);
+      expect(core.config.get('foo.bar.baz.b')).toBe(3);
+      expect(core.config.get('foo.bar.baz.c')).toBe(4);
 
-      atom.config.setDefaults('foo.quux', { x: 0, y: 1 });
-      expect(atom.config.get('foo.quux.x')).toBe(0);
-      expect(atom.config.get('foo.quux.y')).toBe(1);
+      core.config.setDefaults('foo.quux', { x: 0, y: 1 });
+      expect(core.config.get('foo.quux.x')).toBe(0);
+      expect(core.config.get('foo.quux.y')).toBe(1);
     });
 
     it('emits an updated event', () => {
       const updatedCallback = jasmine.createSpy('updated');
-      atom.config.onDidChange('foo.bar.baz.a', updatedCallback);
+      core.config.onDidChange('foo.bar.baz.a', updatedCallback);
       expect(updatedCallback.callCount).toBe(0);
-      atom.config.setDefaults('foo.bar.baz', { a: 2 });
+      core.config.setDefaults('foo.bar.baz', { a: 2 });
       expect(updatedCallback.callCount).toBe(1);
     });
   });
@@ -1362,9 +1362,9 @@ describe('Config', () => {
         }
       };
 
-      atom.config.setSchema('foo.bar', schema);
+      core.config.setSchema('foo.bar', schema);
 
-      expect(atom.config.getSchema('foo')).toEqual({
+      expect(core.config.getSchema('foo')).toEqual({
         type: 'object',
         properties: {
           bar: {
@@ -1409,16 +1409,16 @@ describe('Config', () => {
         }
       };
 
-      atom.config.setSchema('foo.bar', schema);
-      expect(atom.config.get('foo.bar.anInt')).toBe(12);
-      expect(atom.config.get('foo.bar.anObject')).toEqual({
+      core.config.setSchema('foo.bar', schema);
+      expect(core.config.get('foo.bar.anInt')).toBe(12);
+      expect(core.config.get('foo.bar.anObject')).toEqual({
         nestedInt: 24,
         nestedObject: {
           superNestedInt: 36
         }
       });
 
-      expect(atom.config.get('foo')).toEqual({
+      expect(core.config.get('foo')).toEqual({
         bar: {
           anInt: 12,
           anObject: {
@@ -1429,8 +1429,8 @@ describe('Config', () => {
           }
         }
       });
-      atom.config.set('foo.bar.anObject.nestedObject.superNestedInt', 37);
-      expect(atom.config.get('foo')).toEqual({
+      core.config.set('foo.bar.anObject.nestedObject.superNestedInt', 37);
+      expect(core.config.get('foo')).toEqual({
         bar: {
           anInt: 12,
           anObject: {
@@ -1449,9 +1449,9 @@ describe('Config', () => {
         default: 12
       };
 
-      atom.config.setSchema('foo.bar.anInt', schema);
-      expect(atom.config.get('foo.bar.anInt')).toBe(12);
-      expect(atom.config.getSchema('foo.bar.anInt')).toEqual({
+      core.config.setSchema('foo.bar.anInt', schema);
+      expect(core.config.get('foo.bar.anInt')).toBe(12);
+      expect(core.config.getSchema('foo.bar.anInt')).toEqual({
         type: 'integer',
         default: 12
       });
@@ -1468,9 +1468,9 @@ describe('Config', () => {
         }
       };
 
-      atom.config.setSchema('foo.bar', schema);
+      core.config.setSchema('foo.bar', schema);
 
-      expect(atom.config.getSchema('foo.bar')).toEqual({
+      expect(core.config.getSchema('foo.bar')).toEqual({
         type: 'object',
         properties: {
           anInt: {
@@ -1480,13 +1480,13 @@ describe('Config', () => {
         }
       });
 
-      expect(atom.config.getSchema('foo.bar.anInt')).toEqual({
+      expect(core.config.getSchema('foo.bar.anInt')).toEqual({
         type: 'integer',
         default: 12
       });
 
-      expect(atom.config.getSchema('foo.baz')).toEqual({ type: 'any' });
-      expect(atom.config.getSchema('foo.bar.anInt.baz')).toBe(null);
+      expect(core.config.getSchema('foo.baz')).toEqual({ type: 'any' });
+      expect(core.config.getSchema('foo.bar.anInt.baz')).toBe(null);
     });
 
     it('respects the schema for scoped settings', () => {
@@ -1499,14 +1499,14 @@ describe('Config', () => {
           }
         }
       };
-      atom.config.setSchema('foo.bar.str', schema);
+      core.config.setSchema('foo.bar.str', schema);
 
-      expect(atom.config.get('foo.bar.str')).toBe('ok');
-      expect(atom.config.get('foo.bar.str', { scope: ['.source.js'] })).toBe(
+      expect(core.config.get('foo.bar.str')).toBe('ok');
+      expect(core.config.get('foo.bar.str', { scope: ['.source.js'] })).toBe(
         'omg'
       );
       expect(
-        atom.config.get('foo.bar.str', { scope: ['.source.coffee'] })
+        core.config.get('foo.bar.str', { scope: ['.source.coffee'] })
       ).toBe('ok');
     });
 
@@ -1529,93 +1529,93 @@ describe('Config', () => {
       });
 
       it('respects the new schema when values are set', () => {
-        expect(atom.config.set('foo.bar.str', 'global')).toBe(true);
+        expect(core.config.set('foo.bar.str', 'global')).toBe(true);
         expect(
-          atom.config.set('foo.bar.str', 'scoped', {
+          core.config.set('foo.bar.str', 'scoped', {
             scopeSelector: '.source.js'
           })
         ).toBe(true);
-        expect(atom.config.get('foo.bar.str')).toBe('global');
-        expect(atom.config.get('foo.bar.str', { scope: ['.source.js'] })).toBe(
+        expect(core.config.get('foo.bar.str')).toBe('global');
+        expect(core.config.get('foo.bar.str', { scope: ['.source.js'] })).toBe(
           'scoped'
         );
 
-        expect(atom.config.set('foo.bar.noschema', 'nsGlobal')).toBe(true);
+        expect(core.config.set('foo.bar.noschema', 'nsGlobal')).toBe(true);
         expect(
-          atom.config.set('foo.bar.noschema', 'nsScoped', {
+          core.config.set('foo.bar.noschema', 'nsScoped', {
             scopeSelector: '.source.js'
           })
         ).toBe(true);
-        expect(atom.config.get('foo.bar.noschema')).toBe('nsGlobal');
+        expect(core.config.get('foo.bar.noschema')).toBe('nsGlobal');
         expect(
-          atom.config.get('foo.bar.noschema', { scope: ['.source.js'] })
+          core.config.get('foo.bar.noschema', { scope: ['.source.js'] })
         ).toBe('nsScoped');
 
-        expect(atom.config.set('foo.bar.int', 'nope')).toBe(true);
+        expect(core.config.set('foo.bar.int', 'nope')).toBe(true);
         expect(
-          atom.config.set('foo.bar.int', 'notanint', {
+          core.config.set('foo.bar.int', 'notanint', {
             scopeSelector: '.source.js'
           })
         ).toBe(true);
         expect(
-          atom.config.set('foo.bar.int', 23, {
+          core.config.set('foo.bar.int', 23, {
             scopeSelector: '.source.coffee'
           })
         ).toBe(true);
-        expect(atom.config.get('foo.bar.int')).toBe('nope');
-        expect(atom.config.get('foo.bar.int', { scope: ['.source.js'] })).toBe(
+        expect(core.config.get('foo.bar.int')).toBe('nope');
+        expect(core.config.get('foo.bar.int', { scope: ['.source.js'] })).toBe(
           'notanint'
         );
         expect(
-          atom.config.get('foo.bar.int', { scope: ['.source.coffee'] })
+          core.config.get('foo.bar.int', { scope: ['.source.coffee'] })
         ).toBe(23);
 
-        atom.config.setSchema('foo.bar', schema);
+        core.config.setSchema('foo.bar', schema);
 
-        expect(atom.config.get('foo.bar.str')).toBe('global');
-        expect(atom.config.get('foo.bar.str', { scope: ['.source.js'] })).toBe(
+        expect(core.config.get('foo.bar.str')).toBe('global');
+        expect(core.config.get('foo.bar.str', { scope: ['.source.js'] })).toBe(
           'scoped'
         );
-        expect(atom.config.get('foo.bar.noschema')).toBe('nsGlobal');
+        expect(core.config.get('foo.bar.noschema')).toBe('nsGlobal');
         expect(
-          atom.config.get('foo.bar.noschema', { scope: ['.source.js'] })
+          core.config.get('foo.bar.noschema', { scope: ['.source.js'] })
         ).toBe('nsScoped');
 
-        expect(atom.config.get('foo.bar.int')).toBe(2);
-        expect(atom.config.get('foo.bar.int', { scope: ['.source.js'] })).toBe(
+        expect(core.config.get('foo.bar.int')).toBe(2);
+        expect(core.config.get('foo.bar.int', { scope: ['.source.js'] })).toBe(
           2
         );
         expect(
-          atom.config.get('foo.bar.int', { scope: ['.source.coffee'] })
+          core.config.get('foo.bar.int', { scope: ['.source.coffee'] })
         ).toBe(23);
       });
 
       it('sets all values that adhere to the schema', () => {
-        expect(atom.config.set('foo.bar.int', 10)).toBe(true);
+        expect(core.config.set('foo.bar.int', 10)).toBe(true);
         expect(
-          atom.config.set('foo.bar.int', 15, { scopeSelector: '.source.js' })
+          core.config.set('foo.bar.int', 15, { scopeSelector: '.source.js' })
         ).toBe(true);
         expect(
-          atom.config.set('foo.bar.int', 23, {
+          core.config.set('foo.bar.int', 23, {
             scopeSelector: '.source.coffee'
           })
         ).toBe(true);
-        expect(atom.config.get('foo.bar.int')).toBe(10);
-        expect(atom.config.get('foo.bar.int', { scope: ['.source.js'] })).toBe(
+        expect(core.config.get('foo.bar.int')).toBe(10);
+        expect(core.config.get('foo.bar.int', { scope: ['.source.js'] })).toBe(
           15
         );
         expect(
-          atom.config.get('foo.bar.int', { scope: ['.source.coffee'] })
+          core.config.get('foo.bar.int', { scope: ['.source.coffee'] })
         ).toBe(23);
 
-        atom.config.setSchema('foo.bar', schema);
+        core.config.setSchema('foo.bar', schema);
 
-        expect(atom.config.get('foo.bar.int')).toBe(10);
-        expect(atom.config.get('foo.bar.int', { scope: ['.source.js'] })).toBe(
+        expect(core.config.get('foo.bar.int')).toBe(10);
+        expect(core.config.get('foo.bar.int', { scope: ['.source.js'] })).toBe(
           15
         );
         expect(
-          atom.config.get('foo.bar.int', { scope: ['.source.coffee'] })
+          core.config.get('foo.bar.int', { scope: ['.source.coffee'] })
         ).toBe(23);
       });
     });
@@ -1626,30 +1626,30 @@ describe('Config', () => {
           type: 'integer',
           default: 12
         };
-        atom.config.setSchema('foo.bar.anInt', schema);
+        core.config.setSchema('foo.bar.anInt', schema);
       });
 
       it('coerces a string to an int', () => {
-        atom.config.set('foo.bar.anInt', '123');
-        expect(atom.config.get('foo.bar.anInt')).toBe(123);
+        core.config.set('foo.bar.anInt', '123');
+        expect(core.config.get('foo.bar.anInt')).toBe(123);
       });
 
       it('does not allow infinity', () => {
-        atom.config.set('foo.bar.anInt', Infinity);
-        expect(atom.config.get('foo.bar.anInt')).toBe(12);
+        core.config.set('foo.bar.anInt', Infinity);
+        expect(core.config.get('foo.bar.anInt')).toBe(12);
       });
 
       it('coerces a float to an int', () => {
-        atom.config.set('foo.bar.anInt', 12.3);
-        expect(atom.config.get('foo.bar.anInt')).toBe(12);
+        core.config.set('foo.bar.anInt', 12.3);
+        expect(core.config.get('foo.bar.anInt')).toBe(12);
       });
 
       it('will not set non-integers', () => {
-        atom.config.set('foo.bar.anInt', null);
-        expect(atom.config.get('foo.bar.anInt')).toBe(12);
+        core.config.set('foo.bar.anInt', null);
+        expect(core.config.get('foo.bar.anInt')).toBe(12);
 
-        atom.config.set('foo.bar.anInt', 'nope');
-        expect(atom.config.get('foo.bar.anInt')).toBe(12);
+        core.config.set('foo.bar.anInt', 'nope');
+        expect(core.config.get('foo.bar.anInt')).toBe(12);
       });
 
       describe('when the minimum and maximum keys are used', () => {
@@ -1660,15 +1660,15 @@ describe('Config', () => {
             maximum: 20,
             default: 12
           };
-          atom.config.setSchema('foo.bar.anInt', schema);
+          core.config.setSchema('foo.bar.anInt', schema);
         });
 
         it('keeps the specified value within the specified range', () => {
-          atom.config.set('foo.bar.anInt', '123');
-          expect(atom.config.get('foo.bar.anInt')).toBe(20);
+          core.config.set('foo.bar.anInt', '123');
+          expect(core.config.get('foo.bar.anInt')).toBe(20);
 
-          atom.config.set('foo.bar.anInt', '1');
-          expect(atom.config.get('foo.bar.anInt')).toBe(10);
+          core.config.set('foo.bar.anInt', '1');
+          expect(core.config.get('foo.bar.anInt')).toBe(10);
         });
       });
     });
@@ -1679,15 +1679,15 @@ describe('Config', () => {
           type: ['integer', 'string'],
           default: 12
         };
-        atom.config.setSchema('foo.bar.anInt', schema);
+        core.config.setSchema('foo.bar.anInt', schema);
       });
 
       it('can coerce an int, and fallback to a string', () => {
-        atom.config.set('foo.bar.anInt', '123');
-        expect(atom.config.get('foo.bar.anInt')).toBe(123);
+        core.config.set('foo.bar.anInt', '123');
+        expect(core.config.get('foo.bar.anInt')).toBe(123);
 
-        atom.config.set('foo.bar.anInt', 'cats');
-        expect(atom.config.get('foo.bar.anInt')).toBe('cats');
+        core.config.set('foo.bar.anInt', 'cats');
+        expect(core.config.get('foo.bar.anInt')).toBe('cats');
       });
     });
 
@@ -1697,18 +1697,18 @@ describe('Config', () => {
           type: ['string', 'boolean'],
           default: 'def'
         };
-        atom.config.setSchema('foo.bar', schema);
+        core.config.setSchema('foo.bar', schema);
       });
 
       it('can set a string, a boolean, and revert back to the default', () => {
-        atom.config.set('foo.bar', 'ok');
-        expect(atom.config.get('foo.bar')).toBe('ok');
+        core.config.set('foo.bar', 'ok');
+        expect(core.config.get('foo.bar')).toBe('ok');
 
-        atom.config.set('foo.bar', false);
-        expect(atom.config.get('foo.bar')).toBe(false);
+        core.config.set('foo.bar', false);
+        expect(core.config.get('foo.bar')).toBe(false);
 
-        atom.config.set('foo.bar', undefined);
-        expect(atom.config.get('foo.bar')).toBe('def');
+        core.config.set('foo.bar', undefined);
+        expect(core.config.get('foo.bar')).toBe('def');
       });
     });
 
@@ -1718,20 +1718,20 @@ describe('Config', () => {
           type: 'number',
           default: 12.1
         };
-        atom.config.setSchema('foo.bar.aFloat', schema);
+        core.config.setSchema('foo.bar.aFloat', schema);
       });
 
       it('coerces a string to a float', () => {
-        atom.config.set('foo.bar.aFloat', '12.23');
-        expect(atom.config.get('foo.bar.aFloat')).toBe(12.23);
+        core.config.set('foo.bar.aFloat', '12.23');
+        expect(core.config.get('foo.bar.aFloat')).toBe(12.23);
       });
 
       it('will not set non-numbers', () => {
-        atom.config.set('foo.bar.aFloat', null);
-        expect(atom.config.get('foo.bar.aFloat')).toBe(12.1);
+        core.config.set('foo.bar.aFloat', null);
+        expect(core.config.get('foo.bar.aFloat')).toBe(12.1);
 
-        atom.config.set('foo.bar.aFloat', 'nope');
-        expect(atom.config.get('foo.bar.aFloat')).toBe(12.1);
+        core.config.set('foo.bar.aFloat', 'nope');
+        expect(core.config.get('foo.bar.aFloat')).toBe(12.1);
       });
 
       describe('when the minimum and maximum keys are used', () => {
@@ -1742,15 +1742,15 @@ describe('Config', () => {
             maximum: 25.4,
             default: 12.1
           };
-          atom.config.setSchema('foo.bar.aFloat', schema);
+          core.config.setSchema('foo.bar.aFloat', schema);
         });
 
         it('keeps the specified value within the specified range', () => {
-          atom.config.set('foo.bar.aFloat', '123.2');
-          expect(atom.config.get('foo.bar.aFloat')).toBe(25.4);
+          core.config.set('foo.bar.aFloat', '123.2');
+          expect(core.config.get('foo.bar.aFloat')).toBe(25.4);
 
-          atom.config.set('foo.bar.aFloat', '1.0');
-          expect(atom.config.get('foo.bar.aFloat')).toBe(11.2);
+          core.config.set('foo.bar.aFloat', '1.0');
+          expect(core.config.get('foo.bar.aFloat')).toBe(11.2);
         });
       });
     });
@@ -1761,34 +1761,34 @@ describe('Config', () => {
           type: 'boolean',
           default: true
         };
-        atom.config.setSchema('foo.bar.aBool', schema);
+        core.config.setSchema('foo.bar.aBool', schema);
       });
 
       it('coerces various types to a boolean', () => {
-        atom.config.set('foo.bar.aBool', 'true');
-        expect(atom.config.get('foo.bar.aBool')).toBe(true);
-        atom.config.set('foo.bar.aBool', 'false');
-        expect(atom.config.get('foo.bar.aBool')).toBe(false);
-        atom.config.set('foo.bar.aBool', 'TRUE');
-        expect(atom.config.get('foo.bar.aBool')).toBe(true);
-        atom.config.set('foo.bar.aBool', 'FALSE');
-        expect(atom.config.get('foo.bar.aBool')).toBe(false);
-        atom.config.set('foo.bar.aBool', 1);
-        expect(atom.config.get('foo.bar.aBool')).toBe(false);
-        atom.config.set('foo.bar.aBool', 0);
-        expect(atom.config.get('foo.bar.aBool')).toBe(false);
-        atom.config.set('foo.bar.aBool', {});
-        expect(atom.config.get('foo.bar.aBool')).toBe(false);
-        atom.config.set('foo.bar.aBool', null);
-        expect(atom.config.get('foo.bar.aBool')).toBe(false);
+        core.config.set('foo.bar.aBool', 'true');
+        expect(core.config.get('foo.bar.aBool')).toBe(true);
+        core.config.set('foo.bar.aBool', 'false');
+        expect(core.config.get('foo.bar.aBool')).toBe(false);
+        core.config.set('foo.bar.aBool', 'TRUE');
+        expect(core.config.get('foo.bar.aBool')).toBe(true);
+        core.config.set('foo.bar.aBool', 'FALSE');
+        expect(core.config.get('foo.bar.aBool')).toBe(false);
+        core.config.set('foo.bar.aBool', 1);
+        expect(core.config.get('foo.bar.aBool')).toBe(false);
+        core.config.set('foo.bar.aBool', 0);
+        expect(core.config.get('foo.bar.aBool')).toBe(false);
+        core.config.set('foo.bar.aBool', {});
+        expect(core.config.get('foo.bar.aBool')).toBe(false);
+        core.config.set('foo.bar.aBool', null);
+        expect(core.config.get('foo.bar.aBool')).toBe(false);
       });
 
       it('reverts back to the default value when undefined is passed to set', () => {
-        atom.config.set('foo.bar.aBool', 'false');
-        expect(atom.config.get('foo.bar.aBool')).toBe(false);
+        core.config.set('foo.bar.aBool', 'false');
+        expect(core.config.get('foo.bar.aBool')).toBe(false);
 
-        atom.config.set('foo.bar.aBool', undefined);
-        expect(atom.config.get('foo.bar.aBool')).toBe(true);
+        core.config.set('foo.bar.aBool', undefined);
+        expect(core.config.get('foo.bar.aBool')).toBe(true);
       });
     });
 
@@ -1798,36 +1798,36 @@ describe('Config', () => {
           type: 'string',
           default: 'ok'
         };
-        atom.config.setSchema('foo.bar.aString', schema);
+        core.config.setSchema('foo.bar.aString', schema);
       });
 
       it('allows strings', () => {
-        atom.config.set('foo.bar.aString', 'yep');
-        expect(atom.config.get('foo.bar.aString')).toBe('yep');
+        core.config.set('foo.bar.aString', 'yep');
+        expect(core.config.get('foo.bar.aString')).toBe('yep');
       });
 
       it('will only set strings', () => {
-        expect(atom.config.set('foo.bar.aString', 123)).toBe(false);
-        expect(atom.config.get('foo.bar.aString')).toBe('ok');
+        expect(core.config.set('foo.bar.aString', 123)).toBe(false);
+        expect(core.config.get('foo.bar.aString')).toBe('ok');
 
-        expect(atom.config.set('foo.bar.aString', true)).toBe(false);
-        expect(atom.config.get('foo.bar.aString')).toBe('ok');
+        expect(core.config.set('foo.bar.aString', true)).toBe(false);
+        expect(core.config.get('foo.bar.aString')).toBe('ok');
 
-        expect(atom.config.set('foo.bar.aString', null)).toBe(false);
-        expect(atom.config.get('foo.bar.aString')).toBe('ok');
+        expect(core.config.set('foo.bar.aString', null)).toBe(false);
+        expect(core.config.get('foo.bar.aString')).toBe('ok');
 
-        expect(atom.config.set('foo.bar.aString', [])).toBe(false);
-        expect(atom.config.get('foo.bar.aString')).toBe('ok');
+        expect(core.config.set('foo.bar.aString', [])).toBe(false);
+        expect(core.config.get('foo.bar.aString')).toBe('ok');
 
-        expect(atom.config.set('foo.bar.aString', { nope: 'nope' })).toBe(
+        expect(core.config.set('foo.bar.aString', { nope: 'nope' })).toBe(
           false
         );
-        expect(atom.config.get('foo.bar.aString')).toBe('ok');
+        expect(core.config.get('foo.bar.aString')).toBe('ok');
       });
 
       it('does not allow setting children of that key-path', () => {
-        expect(atom.config.set('foo.bar.aString.something', 123)).toBe(false);
-        expect(atom.config.get('foo.bar.aString')).toBe('ok');
+        expect(core.config.set('foo.bar.aString.something', 123)).toBe(false);
+        expect(core.config.get('foo.bar.aString')).toBe('ok');
       });
 
       describe('when the schema has a "maximumLength" key', () =>
@@ -1837,9 +1837,9 @@ describe('Config', () => {
             default: 'ok',
             maximumLength: 3
           };
-          atom.config.setSchema('foo.bar.aString', schema);
-          atom.config.set('foo.bar.aString', 'abcdefg');
-          expect(atom.config.get('foo.bar.aString')).toBe('abc');
+          core.config.setSchema('foo.bar.aString', schema);
+          core.config.set('foo.bar.aString', 'abcdefg');
+          expect(core.config.get('foo.bar.aString')).toBe('abc');
         }));
     });
 
@@ -1863,17 +1863,17 @@ describe('Config', () => {
             }
           }
         };
-        atom.config.setSchema('foo.bar', schema);
+        core.config.setSchema('foo.bar', schema);
       });
 
       it('converts and validates all the children', () => {
-        atom.config.set('foo.bar', {
+        core.config.set('foo.bar', {
           anInt: '23',
           nestedObject: {
             nestedBool: 'true'
           }
         });
-        expect(atom.config.get('foo.bar')).toEqual({
+        expect(core.config.get('foo.bar')).toEqual({
           anInt: 23,
           nestedObject: {
             nestedBool: true
@@ -1883,22 +1883,22 @@ describe('Config', () => {
 
       it('will set only the values that adhere to the schema', () => {
         expect(
-          atom.config.set('foo.bar', {
+          core.config.set('foo.bar', {
             anInt: 'nope',
             nestedObject: {
               nestedBool: true
             }
           })
         ).toBe(true);
-        expect(atom.config.get('foo.bar.anInt')).toEqual(12);
-        expect(atom.config.get('foo.bar.nestedObject.nestedBool')).toEqual(
+        expect(core.config.get('foo.bar.anInt')).toEqual(12);
+        expect(core.config.get('foo.bar.nestedObject.nestedBool')).toEqual(
           true
         );
       });
 
       describe('when the value has additionalProperties set to false', () =>
         it('does not allow other properties to be set on the object', () => {
-          atom.config.setSchema('foo.bar', {
+          core.config.setSchema('foo.bar', {
             type: 'object',
             properties: {
               anInt: {
@@ -1910,20 +1910,20 @@ describe('Config', () => {
           });
 
           expect(
-            atom.config.set('foo.bar', { anInt: 5, somethingElse: 'ok' })
+            core.config.set('foo.bar', { anInt: 5, somethingElse: 'ok' })
           ).toBe(true);
-          expect(atom.config.get('foo.bar.anInt')).toBe(5);
-          expect(atom.config.get('foo.bar.somethingElse')).toBeUndefined();
+          expect(core.config.get('foo.bar.anInt')).toBe(5);
+          expect(core.config.get('foo.bar.somethingElse')).toBeUndefined();
 
-          expect(atom.config.set('foo.bar.somethingElse', { anInt: 5 })).toBe(
+          expect(core.config.set('foo.bar.somethingElse', { anInt: 5 })).toBe(
             false
           );
-          expect(atom.config.get('foo.bar.somethingElse')).toBeUndefined();
+          expect(core.config.get('foo.bar.somethingElse')).toBeUndefined();
         }));
 
       describe('when the value has an additionalProperties schema', () =>
         it('validates properties of the object against that schema', () => {
-          atom.config.setSchema('foo.bar', {
+          core.config.setSchema('foo.bar', {
             type: 'object',
             properties: {
               anInt: {
@@ -1937,19 +1937,19 @@ describe('Config', () => {
           });
 
           expect(
-            atom.config.set('foo.bar', { anInt: 5, somethingElse: 'ok' })
+            core.config.set('foo.bar', { anInt: 5, somethingElse: 'ok' })
           ).toBe(true);
-          expect(atom.config.get('foo.bar.anInt')).toBe(5);
-          expect(atom.config.get('foo.bar.somethingElse')).toBe('ok');
+          expect(core.config.get('foo.bar.anInt')).toBe(5);
+          expect(core.config.get('foo.bar.somethingElse')).toBe('ok');
 
-          expect(atom.config.set('foo.bar.somethingElse', 7)).toBe(false);
-          expect(atom.config.get('foo.bar.somethingElse')).toBe('ok');
+          expect(core.config.set('foo.bar.somethingElse', 7)).toBe(false);
+          expect(core.config.get('foo.bar.somethingElse')).toBe('ok');
 
           expect(
-            atom.config.set('foo.bar', { anInt: 6, somethingElse: 7 })
+            core.config.set('foo.bar', { anInt: 6, somethingElse: 7 })
           ).toBe(true);
-          expect(atom.config.get('foo.bar.anInt')).toBe(6);
-          expect(atom.config.get('foo.bar.somethingElse')).toBe(undefined);
+          expect(core.config.get('foo.bar.anInt')).toBe(6);
+          expect(core.config.get('foo.bar.somethingElse')).toBe(undefined);
         }));
     });
 
@@ -1962,18 +1962,18 @@ describe('Config', () => {
             type: 'integer'
           }
         };
-        atom.config.setSchema('foo.bar', schema);
+        core.config.setSchema('foo.bar', schema);
       });
 
       it('converts an array of strings to an array of ints', () => {
-        atom.config.set('foo.bar', ['2', '3', '4']);
-        expect(atom.config.get('foo.bar')).toEqual([2, 3, 4]);
+        core.config.set('foo.bar', ['2', '3', '4']);
+        expect(core.config.get('foo.bar')).toEqual([2, 3, 4]);
       });
 
       it('does not allow setting children of that key-path', () => {
-        expect(atom.config.set('foo.bar.child', 123)).toBe(false);
-        expect(atom.config.set('foo.bar.child.grandchild', 123)).toBe(false);
-        expect(atom.config.get('foo.bar')).toEqual([1, 2, 3]);
+        expect(core.config.set('foo.bar.child', 123)).toBe(false);
+        expect(core.config.set('foo.bar.child.grandchild', 123)).toBe(false);
+        expect(core.config.get('foo.bar')).toEqual([1, 2, 3]);
       });
     });
 
@@ -1983,11 +1983,11 @@ describe('Config', () => {
           type: 'color',
           default: 'white'
         };
-        atom.config.setSchema('foo.bar.aColor', schema);
+        core.config.setSchema('foo.bar.aColor', schema);
       });
 
       it('returns a Color object', () => {
-        let color = atom.config.get('foo.bar.aColor');
+        let color = core.config.get('foo.bar.aColor');
         expect(color.toHexString()).toBe('#ffffff');
         expect(color.toRGBAString()).toBe('rgba(255, 255, 255, 1)');
 
@@ -1995,9 +1995,9 @@ describe('Config', () => {
         color.green = 0;
         color.blue = 0;
         color.alpha = 0;
-        atom.config.set('foo.bar.aColor', color);
+        core.config.set('foo.bar.aColor', color);
 
-        color = atom.config.get('foo.bar.aColor');
+        color = core.config.get('foo.bar.aColor');
         expect(color.toHexString()).toBe('#000000');
         expect(color.toRGBAString()).toBe('rgba(0, 0, 0, 0)');
 
@@ -2005,9 +2005,9 @@ describe('Config', () => {
         color.green = -200;
         color.blue = -1;
         color.alpha = 'not see through';
-        atom.config.set('foo.bar.aColor', color);
+        core.config.set('foo.bar.aColor', color);
 
-        color = atom.config.get('foo.bar.aColor');
+        color = core.config.get('foo.bar.aColor');
         expect(color.toHexString()).toBe('#ff0000');
         expect(color.toRGBAString()).toBe('rgba(255, 0, 0, 1)');
 
@@ -2015,91 +2015,91 @@ describe('Config', () => {
         color.green = 11;
         color.blue = 124;
         color.alpha = 1;
-        atom.config.set('foo.bar.aColor', color);
+        core.config.set('foo.bar.aColor', color);
 
-        color = atom.config.get('foo.bar.aColor');
+        color = core.config.get('foo.bar.aColor');
         expect(color.toHexString()).toBe('#0b0b7c');
         expect(color.toRGBAString()).toBe('rgba(11, 11, 124, 1)');
       });
 
       it('coerces various types to a color object', () => {
-        atom.config.set('foo.bar.aColor', 'red');
-        expect(atom.config.get('foo.bar.aColor')).toEqual({
+        core.config.set('foo.bar.aColor', 'red');
+        expect(core.config.get('foo.bar.aColor')).toEqual({
           red: 255,
           green: 0,
           blue: 0,
           alpha: 1
         });
-        atom.config.set('foo.bar.aColor', '#020');
-        expect(atom.config.get('foo.bar.aColor')).toEqual({
+        core.config.set('foo.bar.aColor', '#020');
+        expect(core.config.get('foo.bar.aColor')).toEqual({
           red: 0,
           green: 34,
           blue: 0,
           alpha: 1
         });
-        atom.config.set('foo.bar.aColor', '#abcdef');
-        expect(atom.config.get('foo.bar.aColor')).toEqual({
+        core.config.set('foo.bar.aColor', '#abcdef');
+        expect(core.config.get('foo.bar.aColor')).toEqual({
           red: 171,
           green: 205,
           blue: 239,
           alpha: 1
         });
-        atom.config.set('foo.bar.aColor', 'rgb(1,2,3)');
-        expect(atom.config.get('foo.bar.aColor')).toEqual({
+        core.config.set('foo.bar.aColor', 'rgb(1,2,3)');
+        expect(core.config.get('foo.bar.aColor')).toEqual({
           red: 1,
           green: 2,
           blue: 3,
           alpha: 1
         });
-        atom.config.set('foo.bar.aColor', 'rgba(4,5,6,.7)');
-        expect(atom.config.get('foo.bar.aColor')).toEqual({
+        core.config.set('foo.bar.aColor', 'rgba(4,5,6,.7)');
+        expect(core.config.get('foo.bar.aColor')).toEqual({
           red: 4,
           green: 5,
           blue: 6,
           alpha: 0.7
         });
-        atom.config.set('foo.bar.aColor', 'hsl(120,100%,50%)');
-        expect(atom.config.get('foo.bar.aColor')).toEqual({
+        core.config.set('foo.bar.aColor', 'hsl(120,100%,50%)');
+        expect(core.config.get('foo.bar.aColor')).toEqual({
           red: 0,
           green: 255,
           blue: 0,
           alpha: 1
         });
-        atom.config.set('foo.bar.aColor', 'hsla(120,100%,50%,0.3)');
-        expect(atom.config.get('foo.bar.aColor')).toEqual({
+        core.config.set('foo.bar.aColor', 'hsla(120,100%,50%,0.3)');
+        expect(core.config.get('foo.bar.aColor')).toEqual({
           red: 0,
           green: 255,
           blue: 0,
           alpha: 0.3
         });
-        atom.config.set('foo.bar.aColor', {
+        core.config.set('foo.bar.aColor', {
           red: 100,
           green: 255,
           blue: 2,
           alpha: 0.5
         });
-        expect(atom.config.get('foo.bar.aColor')).toEqual({
+        expect(core.config.get('foo.bar.aColor')).toEqual({
           red: 100,
           green: 255,
           blue: 2,
           alpha: 0.5
         });
-        atom.config.set('foo.bar.aColor', { red: 255 });
-        expect(atom.config.get('foo.bar.aColor')).toEqual({
+        core.config.set('foo.bar.aColor', { red: 255 });
+        expect(core.config.get('foo.bar.aColor')).toEqual({
           red: 255,
           green: 0,
           blue: 0,
           alpha: 1
         });
-        atom.config.set('foo.bar.aColor', { red: 1000 });
-        expect(atom.config.get('foo.bar.aColor')).toEqual({
+        core.config.set('foo.bar.aColor', { red: 1000 });
+        expect(core.config.get('foo.bar.aColor')).toEqual({
           red: 255,
           green: 0,
           blue: 0,
           alpha: 1
         });
-        atom.config.set('foo.bar.aColor', { red: 'dark' });
-        expect(atom.config.get('foo.bar.aColor')).toEqual({
+        core.config.set('foo.bar.aColor', { red: 'dark' });
+        expect(core.config.get('foo.bar.aColor')).toEqual({
           red: 0,
           green: 0,
           blue: 0,
@@ -2108,8 +2108,8 @@ describe('Config', () => {
       });
 
       it('reverts back to the default value when undefined is passed to set', () => {
-        atom.config.set('foo.bar.aColor', undefined);
-        expect(atom.config.get('foo.bar.aColor')).toEqual({
+        core.config.set('foo.bar.aColor', undefined);
+        expect(core.config.get('foo.bar.aColor')).toEqual({
           red: 255,
           green: 255,
           blue: 255,
@@ -2118,32 +2118,32 @@ describe('Config', () => {
       });
 
       it('will not set non-colors', () => {
-        atom.config.set('foo.bar.aColor', null);
-        expect(atom.config.get('foo.bar.aColor')).toEqual({
+        core.config.set('foo.bar.aColor', null);
+        expect(core.config.get('foo.bar.aColor')).toEqual({
           red: 255,
           green: 255,
           blue: 255,
           alpha: 1
         });
 
-        atom.config.set('foo.bar.aColor', 'nope');
-        expect(atom.config.get('foo.bar.aColor')).toEqual({
+        core.config.set('foo.bar.aColor', 'nope');
+        expect(core.config.get('foo.bar.aColor')).toEqual({
           red: 255,
           green: 255,
           blue: 255,
           alpha: 1
         });
 
-        atom.config.set('foo.bar.aColor', 30);
-        expect(atom.config.get('foo.bar.aColor')).toEqual({
+        core.config.set('foo.bar.aColor', 30);
+        expect(core.config.get('foo.bar.aColor')).toEqual({
           red: 255,
           green: 255,
           blue: 255,
           alpha: 1
         });
 
-        atom.config.set('foo.bar.aColor', false);
-        expect(atom.config.get('foo.bar.aColor')).toEqual({
+        core.config.set('foo.bar.aColor', false);
+        expect(core.config.get('foo.bar.aColor')).toEqual({
           red: 255,
           green: 255,
           blue: 255,
@@ -2152,8 +2152,8 @@ describe('Config', () => {
       });
 
       it('returns a clone of the Color when returned in a parent object', () => {
-        const color1 = atom.config.get('foo.bar').aColor;
-        const color2 = atom.config.get('foo.bar').aColor;
+        const color1 = core.config.get('foo.bar').aColor;
+        const color2 = core.config.get('foo.bar').aColor;
         expect(color1.toRGBAString()).toBe('rgba(255, 255, 255, 1)');
         expect(color2.toRGBAString()).toBe('rgba(255, 255, 255, 1)');
         expect(color1).not.toBe(color2);
@@ -2196,63 +2196,63 @@ describe('Config', () => {
           }
         };
 
-        atom.config.setSchema('foo.bar', schema);
+        core.config.setSchema('foo.bar', schema);
       });
 
       it('will only set a string when the string is in the enum values', () => {
-        expect(atom.config.set('foo.bar.str', 'nope')).toBe(false);
-        expect(atom.config.get('foo.bar.str')).toBe('ok');
+        expect(core.config.set('foo.bar.str', 'nope')).toBe(false);
+        expect(core.config.get('foo.bar.str')).toBe('ok');
 
-        expect(atom.config.set('foo.bar.str', 'one')).toBe(true);
-        expect(atom.config.get('foo.bar.str')).toBe('one');
+        expect(core.config.set('foo.bar.str', 'one')).toBe(true);
+        expect(core.config.get('foo.bar.str')).toBe('one');
       });
 
       it('will only set an integer when the integer is in the enum values', () => {
-        expect(atom.config.set('foo.bar.int', '400')).toBe(false);
-        expect(atom.config.get('foo.bar.int')).toBe(2);
+        expect(core.config.set('foo.bar.int', '400')).toBe(false);
+        expect(core.config.get('foo.bar.int')).toBe(2);
 
-        expect(atom.config.set('foo.bar.int', '3')).toBe(true);
-        expect(atom.config.get('foo.bar.int')).toBe(3);
+        expect(core.config.set('foo.bar.int', '3')).toBe(true);
+        expect(core.config.get('foo.bar.int')).toBe(3);
       });
 
       it('will only set an array when the array values are in the enum values', () => {
-        expect(atom.config.set('foo.bar.arr', ['one', 'five'])).toBe(true);
-        expect(atom.config.get('foo.bar.arr')).toEqual(['one']);
+        expect(core.config.set('foo.bar.arr', ['one', 'five'])).toBe(true);
+        expect(core.config.get('foo.bar.arr')).toEqual(['one']);
 
-        expect(atom.config.set('foo.bar.arr', ['two', 'three'])).toBe(true);
-        expect(atom.config.get('foo.bar.arr')).toEqual(['two', 'three']);
+        expect(core.config.set('foo.bar.arr', ['two', 'three'])).toBe(true);
+        expect(core.config.get('foo.bar.arr')).toEqual(['two', 'three']);
       });
 
       it('will honor the enum when specified as an array', () => {
-        expect(atom.config.set('foo.bar.str_options', 'one')).toBe(true);
-        expect(atom.config.get('foo.bar.str_options')).toEqual('one');
+        expect(core.config.set('foo.bar.str_options', 'one')).toBe(true);
+        expect(core.config.get('foo.bar.str_options')).toEqual('one');
 
-        expect(atom.config.set('foo.bar.str_options', 'two')).toBe(true);
-        expect(atom.config.get('foo.bar.str_options')).toEqual('two');
+        expect(core.config.set('foo.bar.str_options', 'two')).toBe(true);
+        expect(core.config.get('foo.bar.str_options')).toEqual('two');
 
-        expect(atom.config.set('foo.bar.str_options', 'One')).toBe(false);
-        expect(atom.config.get('foo.bar.str_options')).toEqual('two');
+        expect(core.config.set('foo.bar.str_options', 'One')).toBe(false);
+        expect(core.config.get('foo.bar.str_options')).toEqual('two');
       });
     });
   });
 
   describe('when .set/.unset is called prior to .resetUserSettings', () => {
     beforeEach(() => {
-      atom.config.settingsLoaded = false;
+      core.config.settingsLoaded = false;
     });
 
     it('ensures that early set and unset calls are replayed after the config is loaded from disk', () => {
-      atom.config.unset('foo.bar');
-      atom.config.set('foo.qux', 'boo');
+      core.config.unset('foo.bar');
+      core.config.set('foo.qux', 'boo');
 
-      expect(atom.config.get('foo.bar')).toBeUndefined();
-      expect(atom.config.get('foo.qux')).toBe('boo');
-      expect(atom.config.get('do.ray')).toBeUndefined();
+      expect(core.config.get('foo.bar')).toBeUndefined();
+      expect(core.config.get('foo.qux')).toBe('boo');
+      expect(core.config.get('do.ray')).toBeUndefined();
 
       advanceClock(100);
       expect(savedSettings.length).toBe(0);
 
-      atom.config.resetUserSettings({
+      core.config.resetUserSettings({
         '*': {
           foo: {
             bar: 'baz'
@@ -2265,17 +2265,17 @@ describe('Config', () => {
 
       advanceClock(100);
       expect(savedSettings.length).toBe(1);
-      expect(atom.config.get('foo.bar')).toBeUndefined();
-      expect(atom.config.get('foo.qux')).toBe('boo');
-      expect(atom.config.get('do.ray')).toBe('me');
+      expect(core.config.get('foo.bar')).toBeUndefined();
+      expect(core.config.get('foo.qux')).toBe('boo');
+      expect(core.config.get('do.ray')).toBe('me');
     });
   });
 
   describe('project specific settings', () => {
     describe('config.resetProjectSettings', () => {
       it('gracefully handles invalid config objects', () => {
-        atom.config.resetProjectSettings({});
-        expect(atom.config.get('foo.bar')).toBeUndefined();
+        core.config.resetProjectSettings({});
+        expect(core.config.get('foo.bar')).toBeUndefined();
       });
     });
 
@@ -2283,83 +2283,83 @@ describe('Config', () => {
       const dummyPath = '/Users/dummy/path.json';
       describe('project settings', () => {
         it('returns a deep clone of the property value', () => {
-          atom.config.resetProjectSettings(
+          core.config.resetProjectSettings(
             { '*': { value: { array: [1, { b: 2 }, 3] } } },
             dummyPath
           );
-          const retrievedValue = atom.config.get('value');
+          const retrievedValue = core.config.get('value');
           retrievedValue.array[0] = 4;
           retrievedValue.array[1].b = 2.1;
-          expect(atom.config.get('value')).toEqual({ array: [1, { b: 2 }, 3] });
+          expect(core.config.get('value')).toEqual({ array: [1, { b: 2 }, 3] });
         });
 
         it('properly gets project settings', () => {
-          atom.config.resetProjectSettings({ '*': { foo: 'wei' } }, dummyPath);
-          expect(atom.config.get('foo')).toBe('wei');
-          atom.config.resetProjectSettings(
+          core.config.resetProjectSettings({ '*': { foo: 'wei' } }, dummyPath);
+          expect(core.config.get('foo')).toBe('wei');
+          core.config.resetProjectSettings(
             { '*': { foo: { bar: 'baz' } } },
             dummyPath
           );
-          expect(atom.config.get('foo.bar')).toBe('baz');
+          expect(core.config.get('foo.bar')).toBe('baz');
         });
 
         it('gets project settings with higher priority than regular settings', () => {
-          atom.config.set('foo', 'bar');
-          atom.config.resetProjectSettings({ '*': { foo: 'baz' } }, dummyPath);
-          expect(atom.config.get('foo')).toBe('baz');
+          core.config.set('foo', 'bar');
+          core.config.resetProjectSettings({ '*': { foo: 'baz' } }, dummyPath);
+          expect(core.config.get('foo')).toBe('baz');
         });
 
         it('correctly gets nested and scoped properties for project settings', () => {
-          expect(atom.config.set('foo.bar.str', 'global')).toBe(true);
+          expect(core.config.set('foo.bar.str', 'global')).toBe(true);
           expect(
-            atom.config.set('foo.bar.str', 'scoped', {
+            core.config.set('foo.bar.str', 'scoped', {
               scopeSelector: '.source.js'
             })
           ).toBe(true);
-          expect(atom.config.get('foo.bar.str')).toBe('global');
+          expect(core.config.get('foo.bar.str')).toBe('global');
           expect(
-            atom.config.get('foo.bar.str', { scope: ['.source.js'] })
+            core.config.get('foo.bar.str', { scope: ['.source.js'] })
           ).toBe('scoped');
         });
 
         it('returns a deep clone of the property value', () => {
-          atom.config.set('value', { array: [1, { b: 2 }, 3] });
-          const retrievedValue = atom.config.get('value');
+          core.config.set('value', { array: [1, { b: 2 }, 3] });
+          const retrievedValue = core.config.get('value');
           retrievedValue.array[0] = 4;
           retrievedValue.array[1].b = 2.1;
-          expect(atom.config.get('value')).toEqual({ array: [1, { b: 2 }, 3] });
+          expect(core.config.get('value')).toEqual({ array: [1, { b: 2 }, 3] });
         });
 
         it('gets scoped values correctly', () => {
-          atom.config.set('foo', 'bam', { scope: ['second'] });
-          expect(atom.config.get('foo', { scopeSelector: 'second' })).toBe(
+          core.config.set('foo', 'bam', { scope: ['second'] });
+          expect(core.config.get('foo', { scopeSelector: 'second' })).toBe(
             'bam'
           );
-          atom.config.resetProjectSettings(
+          core.config.resetProjectSettings(
             { '*': { foo: 'baz' }, second: { foo: 'bar' } },
             dummyPath
           );
-          expect(atom.config.get('foo', { scopeSelector: 'second' })).toBe(
+          expect(core.config.get('foo', { scopeSelector: 'second' })).toBe(
             'baz'
           );
-          atom.config.clearProjectSettings();
-          expect(atom.config.get('foo', { scopeSelector: 'second' })).toBe(
+          core.config.clearProjectSettings();
+          expect(core.config.get('foo', { scopeSelector: 'second' })).toBe(
             'bam'
           );
         });
 
         it('clears project settings correctly', () => {
-          atom.config.set('foo', 'bar');
-          expect(atom.config.get('foo')).toBe('bar');
-          atom.config.resetProjectSettings(
+          core.config.set('foo', 'bar');
+          expect(core.config.get('foo')).toBe('bar');
+          core.config.resetProjectSettings(
             { '*': { foo: 'baz' }, second: { foo: 'bar' } },
             dummyPath
           );
-          expect(atom.config.get('foo')).toBe('baz');
-          expect(atom.config.getSources().length).toBe(1);
-          atom.config.clearProjectSettings();
-          expect(atom.config.get('foo')).toBe('bar');
-          expect(atom.config.getSources().length).toBe(0);
+          expect(core.config.get('foo')).toBe('baz');
+          expect(core.config.getSources().length).toBe(1);
+          core.config.clearProjectSettings();
+          expect(core.config.get('foo')).toBe('bar');
+          expect(core.config.getSources().length).toBe(0);
         });
       });
     });
@@ -2367,9 +2367,9 @@ describe('Config', () => {
     describe('config.getAll', () => {
       const dummyPath = '/Users/dummy/path.json';
       it('gets settings in the same way .get would return them', () => {
-        atom.config.resetProjectSettings({ '*': { a: 'b' } }, dummyPath);
-        atom.config.set('a', 'f');
-        expect(atom.config.getAll('a')).toEqual([
+        core.config.resetProjectSettings({ '*': { a: 'b' } }, dummyPath);
+        core.config.set('a', 'f');
+        expect(core.config.getAll('a')).toEqual([
           {
             scopeSelector: '*',
             value: 'b'

--- a/spec/context-menu-manager-spec.js
+++ b/spec/context-menu-manager-spec.js
@@ -4,8 +4,8 @@ describe('ContextMenuManager', function() {
   let [contextMenu, parent, child, grandchild] = [];
 
   beforeEach(function() {
-    const { resourcePath } = atom.getLoadSettings();
-    contextMenu = new ContextMenuManager({ keymapManager: atom.keymaps });
+    const { resourcePath } = core.getLoadSettings();
+    contextMenu = new ContextMenuManager({ keymapManager: core.keymaps });
     contextMenu.initialize({ resourcePath });
 
     parent = document.createElement('div');
@@ -315,7 +315,7 @@ describe('ContextMenuManager', function() {
     let [keymaps, item] = [];
 
     beforeEach(function() {
-      keymaps = atom.keymaps.add('source', {
+      keymaps = core.keymaps.add('source', {
         '.child': {
           'ctrl-a': 'test:my-command',
           'shift-b': 'test:my-other-command'
@@ -419,7 +419,7 @@ describe('ContextMenuManager', function() {
     });
 
     it('does not add accelerators for multi-keystroke key bindings', function() {
-      atom.keymaps.add('source', {
+      core.keymaps.add('source', {
         '.child': {
           'ctrl-a ctrl-b': 'test:multi-keystroke-command'
         }

--- a/spec/decoration-manager-spec.js
+++ b/spec/decoration-manager-spec.js
@@ -5,13 +5,13 @@ describe('DecorationManager', function() {
   let [decorationManager, buffer, editor, markerLayer1, markerLayer2] = [];
 
   beforeEach(function() {
-    buffer = atom.project.bufferForPathSync('sample.js');
+    buffer = core.project.bufferForPathSync('sample.js');
     editor = new TextEditor({ buffer });
     markerLayer1 = editor.addMarkerLayer();
     markerLayer2 = editor.addMarkerLayer();
     decorationManager = new DecorationManager(editor);
 
-    waitsForPromise(() => atom.packages.activatePackage('language-javascript'));
+    waitsForPromise(() => core.packages.activatePackage('language-javascript'));
   });
 
   afterEach(() => buffer.destroy());

--- a/spec/dock-spec.js
+++ b/spec/dock-spec.js
@@ -9,14 +9,14 @@ const getNextUpdatePromise = () => etch.getScheduler().nextUpdatePromise;
 describe('Dock', () => {
   describe('when a dock is activated', () => {
     it('opens the dock and activates its active pane', () => {
-      jasmine.attachToDOM(atom.workspace.getElement());
-      const dock = atom.workspace.getLeftDock();
+      jasmine.attachToDOM(core.workspace.getElement());
+      const dock = core.workspace.getLeftDock();
       const didChangeVisibleSpy = jasmine.createSpy();
       dock.onDidChangeVisible(didChangeVisibleSpy);
 
       expect(dock.isVisible()).toBe(false);
       expect(document.activeElement).toBe(
-        atom.workspace
+        core.workspace
           .getCenter()
           .getActivePane()
           .getElement()
@@ -30,8 +30,8 @@ describe('Dock', () => {
 
   describe('when a dock is hidden', () => {
     it('transfers focus back to the active center pane if the dock had focus', () => {
-      jasmine.attachToDOM(atom.workspace.getElement());
-      const dock = atom.workspace.getLeftDock();
+      jasmine.attachToDOM(core.workspace.getElement());
+      const dock = core.workspace.getLeftDock();
       const didChangeVisibleSpy = jasmine.createSpy();
       dock.onDidChangeVisible(didChangeVisibleSpy);
 
@@ -41,7 +41,7 @@ describe('Dock', () => {
 
       dock.hide();
       expect(document.activeElement).toBe(
-        atom.workspace
+        core.workspace
           .getCenter()
           .getActivePane()
           .getElement()
@@ -54,7 +54,7 @@ describe('Dock', () => {
 
       dock.toggle();
       expect(document.activeElement).toBe(
-        atom.workspace
+        core.workspace
           .getCenter()
           .getActivePane()
           .getElement()
@@ -64,7 +64,7 @@ describe('Dock', () => {
       // Don't change focus if the dock was not focused in the first place
       const modalElement = document.createElement('div');
       modalElement.setAttribute('tabindex', -1);
-      atom.workspace.addModalPanel({ item: modalElement });
+      core.workspace.addModalPanel({ item: modalElement });
       modalElement.focus();
       expect(document.activeElement).toBe(modalElement);
 
@@ -87,21 +87,21 @@ describe('Dock', () => {
         }
       };
 
-      await atom.workspace.open(item, { activatePane: false });
-      expect(atom.workspace.getLeftDock().isVisible()).toBe(false);
+      await core.workspace.open(item, { activatePane: false });
+      expect(core.workspace.getLeftDock().isVisible()).toBe(false);
 
-      atom.workspace
+      core.workspace
         .getLeftDock()
         .getPanes()[0]
         .activate();
-      expect(atom.workspace.getLeftDock().isVisible()).toBe(true);
+      expect(core.workspace.getLeftDock().isVisible()).toBe(true);
     });
   });
 
   describe('activating the next pane', () => {
     describe('when the dock has more than one pane', () => {
       it('activates the next pane', () => {
-        const dock = atom.workspace.getLeftDock();
+        const dock = core.workspace.getLeftDock();
         const pane1 = dock.getPanes()[0];
         const pane2 = pane1.splitRight();
         const pane3 = pane2.splitRight();
@@ -119,7 +119,7 @@ describe('Dock', () => {
 
     describe('when the dock has only one pane', () => {
       it('leaves the current pane active', () => {
-        const dock = atom.workspace.getLeftDock();
+        const dock = core.workspace.getLeftDock();
 
         expect(dock.getPanes().length).toBe(1);
         const pane = dock.getPanes()[0];
@@ -133,7 +133,7 @@ describe('Dock', () => {
   describe('activating the previous pane', () => {
     describe('when the dock has more than one pane', () => {
       it('activates the previous pane', () => {
-        const dock = atom.workspace.getLeftDock();
+        const dock = core.workspace.getLeftDock();
         const pane1 = dock.getPanes()[0];
         const pane2 = pane1.splitRight();
         const pane3 = pane2.splitRight();
@@ -151,7 +151,7 @@ describe('Dock', () => {
 
     describe('when the dock has only one pane', () => {
       it('leaves the current pane active', () => {
-        const dock = atom.workspace.getLeftDock();
+        const dock = core.workspace.getLeftDock();
 
         expect(dock.getPanes().length).toBe(1);
         const pane = dock.getPanes()[0];
@@ -165,7 +165,7 @@ describe('Dock', () => {
   describe('when the dock resize handle is double-clicked', () => {
     describe('when the dock is open', () => {
       it("resizes a vertically-oriented dock to the current item's preferred width", async () => {
-        jasmine.attachToDOM(atom.workspace.getElement());
+        jasmine.attachToDOM(core.workspace.getElement());
 
         const item = {
           element: document.createElement('div'),
@@ -180,8 +180,8 @@ describe('Dock', () => {
           }
         };
 
-        await atom.workspace.open(item);
-        const dock = atom.workspace.getLeftDock();
+        await core.workspace.open(item);
+        const dock = core.workspace.getLeftDock();
         const dockElement = dock.getElement();
 
         dock.setState({ size: 300 });
@@ -196,7 +196,7 @@ describe('Dock', () => {
       });
 
       it("resizes a horizontally-oriented dock to the current item's preferred width", async () => {
-        jasmine.attachToDOM(atom.workspace.getElement());
+        jasmine.attachToDOM(core.workspace.getElement());
 
         const item = {
           element: document.createElement('div'),
@@ -211,8 +211,8 @@ describe('Dock', () => {
           }
         };
 
-        await atom.workspace.open(item);
-        const dock = atom.workspace.getBottomDock();
+        await core.workspace.open(item);
+        const dock = core.workspace.getBottomDock();
         const dockElement = dock.getElement();
 
         dock.setState({ size: 300 });
@@ -229,7 +229,7 @@ describe('Dock', () => {
 
     describe('when the dock is closed', () => {
       it('does nothing', async () => {
-        jasmine.attachToDOM(atom.workspace.getElement());
+        jasmine.attachToDOM(core.workspace.getElement());
 
         const item = {
           element: document.createElement('div'),
@@ -244,9 +244,9 @@ describe('Dock', () => {
           }
         };
 
-        await atom.workspace.open(item, { activatePane: false });
+        await core.workspace.open(item, { activatePane: false });
 
-        const dockElement = atom.workspace.getBottomDock().getElement();
+        const dockElement = core.workspace.getBottomDock().getElement();
         dockElement
           .querySelector('.atom-dock-resize-handle')
           .dispatchEvent(new MouseEvent('mousedown', { detail: 2 }));
@@ -265,7 +265,7 @@ describe('Dock', () => {
   describe('when you add an item to an empty dock', () => {
     describe('when the item has a preferred size', () => {
       it('is takes the preferred size of the item', async () => {
-        jasmine.attachToDOM(atom.workspace.getElement());
+        jasmine.attachToDOM(core.workspace.getElement());
 
         const createItem = preferredWidth => ({
           element: document.createElement('div'),
@@ -277,12 +277,12 @@ describe('Dock', () => {
           }
         });
 
-        const dock = atom.workspace.getLeftDock();
+        const dock = core.workspace.getLeftDock();
         const dockElement = dock.getElement();
         expect(dock.getPaneItems()).toHaveLength(0);
 
         const item1 = createItem(111);
-        await atom.workspace.open(item1);
+        await core.workspace.open(item1);
 
         // It should update the width every time we go from 0 -> 1 items, not just the first.
         expect(dock.isVisible()).toBe(true);
@@ -291,20 +291,20 @@ describe('Dock', () => {
         expect(dock.getPaneItems()).toHaveLength(0);
         expect(dock.isVisible()).toBe(false);
         const item2 = createItem(222);
-        await atom.workspace.open(item2);
+        await core.workspace.open(item2);
         expect(dock.isVisible()).toBe(true);
         expect(dockElement.offsetWidth).toBe(222);
 
         // Adding a second shouldn't change the size.
         const item3 = createItem(333);
-        await atom.workspace.open(item3);
+        await core.workspace.open(item3);
         expect(dockElement.offsetWidth).toBe(222);
       });
     });
 
     describe('when the item has no preferred size', () => {
       it('is still has an explicit size', async () => {
-        jasmine.attachToDOM(atom.workspace.getElement());
+        jasmine.attachToDOM(core.workspace.getElement());
 
         const item = {
           element: document.createElement('div'),
@@ -312,11 +312,11 @@ describe('Dock', () => {
             return 'left';
           }
         };
-        const dock = atom.workspace.getLeftDock();
+        const dock = core.workspace.getLeftDock();
         expect(dock.getPaneItems()).toHaveLength(0);
 
         expect(dock.state.size).toBe(null);
-        await atom.workspace.open(item);
+        await core.workspace.open(item);
         expect(dock.state.size).not.toBe(null);
       });
     });
@@ -324,7 +324,7 @@ describe('Dock', () => {
 
   describe('a deserialized dock', () => {
     it('restores the serialized size', async () => {
-      jasmine.attachToDOM(atom.workspace.getElement());
+      jasmine.attachToDOM(core.workspace.getElement());
 
       const item = {
         element: document.createElement('div'),
@@ -336,26 +336,26 @@ describe('Dock', () => {
         },
         serialize: () => ({ deserializer: 'DockTestItem' })
       };
-      atom.deserializers.add({
+      core.deserializers.add({
         name: 'DockTestItem',
         deserialize: () => item
       });
-      const dock = atom.workspace.getLeftDock();
+      const dock = core.workspace.getLeftDock();
       const dockElement = dock.getElement();
 
-      await atom.workspace.open(item);
+      await core.workspace.open(item);
       dock.setState({ size: 150 });
       expect(dockElement.offsetWidth).toBe(150);
       const serialized = dock.serialize();
       dock.setState({ size: 122 });
       expect(dockElement.offsetWidth).toBe(122);
       dock.destroyActivePane();
-      dock.deserialize(serialized, atom.deserializers);
+      dock.deserialize(serialized, core.deserializers);
       expect(dockElement.offsetWidth).toBe(150);
     });
 
     it("isn't visible if it has no items", async () => {
-      jasmine.attachToDOM(atom.workspace.getElement());
+      jasmine.attachToDOM(core.workspace.getElement());
 
       const item = {
         element: document.createElement('div'),
@@ -366,12 +366,12 @@ describe('Dock', () => {
           return 122;
         }
       };
-      const dock = atom.workspace.getLeftDock();
+      const dock = core.workspace.getLeftDock();
 
-      await atom.workspace.open(item);
+      await core.workspace.open(item);
       expect(dock.isVisible()).toBe(true);
       const serialized = dock.serialize();
-      dock.deserialize(serialized, atom.deserializers);
+      dock.deserialize(serialized, core.deserializers);
       expect(dock.getPaneItems()).toHaveLength(0);
       expect(dock.isVisible()).toBe(false);
     });
@@ -379,7 +379,7 @@ describe('Dock', () => {
 
   describe('drag handling', () => {
     it('expands docks to match the preferred size of the dragged item', async () => {
-      jasmine.attachToDOM(atom.workspace.getElement());
+      jasmine.attachToDOM(core.workspace.getElement());
 
       const element = document.createElement('div');
       element.setAttribute('is', 'tabs-tab');
@@ -396,15 +396,15 @@ describe('Dock', () => {
       const dragEvent = new DragEvent('dragstart');
       Object.defineProperty(dragEvent, 'target', { value: element });
 
-      atom.workspace.getElement().handleDragStart(dragEvent);
+      core.workspace.getElement().handleDragStart(dragEvent);
       await getNextUpdatePromise();
-      expect(atom.workspace.getLeftDock().refs.wrapperElement.offsetWidth).toBe(
+      expect(core.workspace.getLeftDock().refs.wrapperElement.offsetWidth).toBe(
         144
       );
     });
 
     it('does nothing when text nodes are dragged', () => {
-      jasmine.attachToDOM(atom.workspace.getElement());
+      jasmine.attachToDOM(core.workspace.getElement());
 
       const textNode = document.createTextNode('hello');
 
@@ -412,7 +412,7 @@ describe('Dock', () => {
       Object.defineProperty(dragEvent, 'target', { value: textNode });
 
       expect(() =>
-        atom.workspace.getElement().handleDragStart(dragEvent)
+        core.workspace.getElement().handleDragStart(dragEvent)
       ).not.toThrow();
     });
   });
@@ -421,7 +421,7 @@ describe('Dock', () => {
     it('is deprecated', () => {
       spyOn(Grim, 'deprecate');
 
-      atom.workspace.getLeftDock().getActiveTextEditor();
+      core.workspace.getLeftDock().getActiveTextEditor();
       expect(Grim.deprecate.callCount).toBe(1);
     });
   });

--- a/spec/fixtures/packages/package-with-activation-commands-and-deserializers/index.js
+++ b/spec/fixtures/packages/package-with-activation-commands-and-deserializers/index.js
@@ -6,7 +6,7 @@ module.exports = {
   activate () {
     this.activateCallCount++
 
-    atom.commands.add('atom-workspace', 'activation-command-2', () => this.activationCommandCallCount++)
+    core.commands.add('atom-workspace', 'activation-command-2', () => this.activationCommandCallCount++)
   },
 
   deserializeMethod1 (state) {

--- a/spec/fixtures/packages/package-with-activation-commands/index.coffee
+++ b/spec/fixtures/packages/package-with-activation-commands/index.coffee
@@ -5,5 +5,5 @@ module.exports =
   activate: ->
     @activateCallCount++
 
-    atom.commands.add 'atom-workspace', 'activation-command', =>
+    core.commands.add 'atom-workspace', 'activation-command', =>
       @activationCommandCallCount++

--- a/spec/fixtures/packages/package-with-deprecated-pane-item-method/index.coffee
+++ b/spec/fixtures/packages/package-with-deprecated-pane-item-method/index.coffee
@@ -2,4 +2,4 @@ class TestItem
   getUri: -> "test"
 
 exports.activate = ->
-  atom.workspace.addOpener -> new TestItem
+  core.workspace.addOpener -> new TestItem

--- a/spec/fixtures/packages/package-with-eval-time-api-calls/index.js
+++ b/spec/fixtures/packages/package-with-eval-time-api-calls/index.js
@@ -1,4 +1,4 @@
-atom.deserializers.add('MyDeserializer', function (state) {
+core.deserializers.add('MyDeserializer', function (state) {
   return {state: state, a: 'b'}
 })
 

--- a/spec/fixtures/packages/package-with-workspace-openers/index.coffee
+++ b/spec/fixtures/packages/package-with-workspace-openers/index.coffee
@@ -4,6 +4,6 @@ module.exports =
 
   activate: ->
     @activateCallCount++
-    atom.workspace.addOpener (filePath) =>
+    core.workspace.addOpener (filePath) =>
       if filePath is 'atom://fictitious'
         @openerCount++

--- a/spec/git-repository-provider-spec.js
+++ b/spec/git-repository-provider-spec.js
@@ -10,9 +10,9 @@ describe('GitRepositoryProvider', () => {
 
   beforeEach(() => {
     provider = new GitRepositoryProvider(
-      atom.project,
-      atom.config,
-      atom.confirm
+      core.project,
+      core.config,
+      core.confirm
     );
   });
 

--- a/spec/grammar-registry-spec.js
+++ b/spec/grammar-registry-spec.js
@@ -12,7 +12,7 @@ describe('GrammarRegistry', () => {
   let grammarRegistry;
 
   beforeEach(() => {
-    grammarRegistry = new GrammarRegistry({ config: atom.config });
+    grammarRegistry = new GrammarRegistry({ config: core.config });
     expect(subscriptionCount(grammarRegistry)).toBe(1);
   });
 
@@ -88,7 +88,7 @@ describe('GrammarRegistry', () => {
 
   describe('.grammarForId(languageId)', () => {
     it('returns a text-mate grammar when `core.useTreeSitterParsers` is false', () => {
-      atom.config.set('core.useTreeSitterParsers', false, {
+      core.config.set('core.useTreeSitterParsers', false, {
         scopeSelector: '.source.js'
       });
 
@@ -110,7 +110,7 @@ describe('GrammarRegistry', () => {
     });
 
     it('returns a tree-sitter grammar when `core.useTreeSitterParsers` is true', () => {
-      atom.config.set('core.useTreeSitterParsers', true);
+      core.config.set('core.useTreeSitterParsers', true);
 
       grammarRegistry.loadGrammarSync(
         require.resolve('language-javascript/grammars/javascript.cson')
@@ -173,7 +173,7 @@ describe('GrammarRegistry', () => {
     });
 
     it("updates the buffer's grammar when a more appropriate text-mate grammar is added for its path", async () => {
-      atom.config.set('core.useTreeSitterParsers', false);
+      core.config.set('core.useTreeSitterParsers', false);
 
       const buffer = new TextBuffer();
       expect(buffer.getLanguageMode().getLanguageId()).toBe(null);
@@ -195,7 +195,7 @@ describe('GrammarRegistry', () => {
     });
 
     it("updates the buffer's grammar when a more appropriate tree-sitter grammar is added for its path", async () => {
-      atom.config.set('core.useTreeSitterParsers', true);
+      core.config.set('core.useTreeSitterParsers', true);
 
       const buffer = new TextBuffer();
       expect(buffer.getLanguageMode().getLanguageId()).toBe(null);
@@ -334,25 +334,25 @@ describe('GrammarRegistry', () => {
 
   describe('.selectGrammar(filePath)', () => {
     it('always returns a grammar', () => {
-      const registry = new GrammarRegistry({ config: atom.config });
+      const registry = new GrammarRegistry({ config: core.config });
       expect(registry.selectGrammar().scopeName).toBe(
         'text.plain.null-grammar'
       );
     });
 
     it('selects the text.plain grammar over the null grammar', async () => {
-      await atom.packages.activatePackage('language-text');
-      expect(atom.grammars.selectGrammar('test.txt').scopeName).toBe(
+      await core.packages.activatePackage('language-text');
+      expect(core.grammars.selectGrammar('test.txt').scopeName).toBe(
         'text.plain'
       );
     });
 
     it('selects a grammar based on the file path case insensitively', async () => {
-      await atom.packages.activatePackage('language-coffee-script');
-      expect(atom.grammars.selectGrammar('/tmp/source.coffee').scopeName).toBe(
+      await core.packages.activatePackage('language-coffee-script');
+      expect(core.grammars.selectGrammar('/tmp/source.coffee').scopeName).toBe(
         'source.coffee'
       );
-      expect(atom.grammars.selectGrammar('/tmp/source.COFFEE').scopeName).toBe(
+      expect(core.grammars.selectGrammar('/tmp/source.COFFEE').scopeName).toBe(
         'source.coffee'
       );
     });
@@ -370,65 +370,65 @@ describe('GrammarRegistry', () => {
       });
 
       it('normalizes back slashes to forward slashes when matching the fileTypes', async () => {
-        await atom.packages.activatePackage('language-git');
+        await core.packages.activatePackage('language-git');
         expect(
-          atom.grammars.selectGrammar('something\\.git\\config').scopeName
+          core.grammars.selectGrammar('something\\.git\\config').scopeName
         ).toBe('source.git-config');
       });
     });
 
     it("can use the filePath to load the correct grammar based on the grammar's filetype", async () => {
-      await atom.packages.activatePackage('language-git');
-      await atom.packages.activatePackage('language-javascript');
-      await atom.packages.activatePackage('language-ruby');
+      await core.packages.activatePackage('language-git');
+      await core.packages.activatePackage('language-javascript');
+      await core.packages.activatePackage('language-ruby');
 
-      expect(atom.grammars.selectGrammar('file.js').name).toBe('JavaScript'); // based on extension (.js)
+      expect(core.grammars.selectGrammar('file.js').name).toBe('JavaScript'); // based on extension (.js)
       expect(
-        atom.grammars.selectGrammar(path.join(temp.dir, '.git', 'config')).name
+        core.grammars.selectGrammar(path.join(temp.dir, '.git', 'config')).name
       ).toBe('Git Config'); // based on end of the path (.git/config)
-      expect(atom.grammars.selectGrammar('Rakefile').name).toBe('Ruby'); // based on the file's basename (Rakefile)
-      expect(atom.grammars.selectGrammar('curb').name).toBe('Null Grammar');
-      expect(atom.grammars.selectGrammar('/hu.git/config').name).toBe(
+      expect(core.grammars.selectGrammar('Rakefile').name).toBe('Ruby'); // based on the file's basename (Rakefile)
+      expect(core.grammars.selectGrammar('curb').name).toBe('Null Grammar');
+      expect(core.grammars.selectGrammar('/hu.git/config').name).toBe(
         'Null Grammar'
       );
     });
 
     it("uses the filePath's shebang line if the grammar cannot be determined by the extension or basename", async () => {
-      await atom.packages.activatePackage('language-javascript');
-      await atom.packages.activatePackage('language-ruby');
+      await core.packages.activatePackage('language-javascript');
+      await core.packages.activatePackage('language-ruby');
 
       const filePath = require.resolve('./fixtures/shebang');
-      expect(atom.grammars.selectGrammar(filePath).name).toBe('Ruby');
+      expect(core.grammars.selectGrammar(filePath).name).toBe('Ruby');
     });
 
     it('uses the number of newlines in the first line regex to determine the number of lines to test against', async () => {
-      await atom.packages.activatePackage('language-property-list');
-      await atom.packages.activatePackage('language-coffee-script');
+      await core.packages.activatePackage('language-property-list');
+      await core.packages.activatePackage('language-coffee-script');
 
       let fileContent = 'first-line\n<html>';
       expect(
-        atom.grammars.selectGrammar('dummy.coffee', fileContent).name
+        core.grammars.selectGrammar('dummy.coffee', fileContent).name
       ).toBe('CoffeeScript');
 
       fileContent = '<?xml version="1.0" encoding="UTF-8"?>';
       expect(
-        atom.grammars.selectGrammar('grammar.tmLanguage', fileContent).name
+        core.grammars.selectGrammar('grammar.tmLanguage', fileContent).name
       ).toBe('Null Grammar');
 
       fileContent +=
         '\n<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">';
       expect(
-        atom.grammars.selectGrammar('grammar.tmLanguage', fileContent).name
+        core.grammars.selectGrammar('grammar.tmLanguage', fileContent).name
       ).toBe('Property List (XML)');
     });
 
     it("doesn't read the file when the file contents are specified", async () => {
-      await atom.packages.activatePackage('language-ruby');
+      await core.packages.activatePackage('language-ruby');
 
       const filePath = require.resolve('./fixtures/shebang');
       const filePathContents = fs.readFileSync(filePath, 'utf8');
       spyOn(fs, 'read').andCallThrough();
-      expect(atom.grammars.selectGrammar(filePath, filePathContents).name).toBe(
+      expect(core.grammars.selectGrammar(filePath, filePathContents).name).toBe(
         'Ruby'
       );
       expect(fs.read).not.toHaveBeenCalled();
@@ -445,8 +445,8 @@ describe('GrammarRegistry', () => {
             fileTypes: ['test']
           })
         );
-        const grammar1 = atom.grammars.loadGrammarSync(grammarPath1);
-        expect(atom.grammars.selectGrammar('more.test', '')).toBe(grammar1);
+        const grammar1 = core.grammars.loadGrammarSync(grammarPath1);
+        expect(core.grammars.selectGrammar('more.test', '')).toBe(grammar1);
         fs.removeSync(grammarPath1);
 
         const grammarPath2 = temp.path({ suffix: '.json' });
@@ -458,94 +458,94 @@ describe('GrammarRegistry', () => {
             fileTypes: ['test', 'more.test']
           })
         );
-        const grammar2 = atom.grammars.loadGrammarSync(grammarPath2);
-        expect(atom.grammars.selectGrammar('more.test', '')).toBe(grammar2);
+        const grammar2 = core.grammars.loadGrammarSync(grammarPath2);
+        expect(core.grammars.selectGrammar('more.test', '')).toBe(grammar2);
         return fs.removeSync(grammarPath2);
       });
     });
 
     it('favors non-bundled packages when breaking scoring ties', async () => {
-      await atom.packages.activatePackage('language-ruby');
-      await atom.packages.activatePackage(
+      await core.packages.activatePackage('language-ruby');
+      await core.packages.activatePackage(
         path.join(__dirname, 'fixtures', 'packages', 'package-with-rb-filetype')
       );
 
-      atom.grammars.grammarForScopeName('source.ruby').bundledPackage = true;
-      atom.grammars.grammarForScopeName('test.rb').bundledPackage = false;
+      core.grammars.grammarForScopeName('source.ruby').bundledPackage = true;
+      core.grammars.grammarForScopeName('test.rb').bundledPackage = false;
 
       expect(
-        atom.grammars.selectGrammar('test.rb', '#!/usr/bin/env ruby').scopeName
+        core.grammars.selectGrammar('test.rb', '#!/usr/bin/env ruby').scopeName
       ).toBe('source.ruby');
       expect(
-        atom.grammars.selectGrammar('test.rb', '#!/usr/bin/env testruby')
+        core.grammars.selectGrammar('test.rb', '#!/usr/bin/env testruby')
           .scopeName
       ).toBe('test.rb');
-      expect(atom.grammars.selectGrammar('test.rb').scopeName).toBe('test.rb');
+      expect(core.grammars.selectGrammar('test.rb').scopeName).toBe('test.rb');
     });
 
     describe('when there is no file path', () => {
       it('does not throw an exception (regression)', () => {
         expect(() =>
-          atom.grammars.selectGrammar(null, '#!/usr/bin/ruby')
+          core.grammars.selectGrammar(null, '#!/usr/bin/ruby')
         ).not.toThrow();
-        expect(() => atom.grammars.selectGrammar(null, '')).not.toThrow();
-        expect(() => atom.grammars.selectGrammar(null, null)).not.toThrow();
+        expect(() => core.grammars.selectGrammar(null, '')).not.toThrow();
+        expect(() => core.grammars.selectGrammar(null, null)).not.toThrow();
       });
     });
 
     describe('when the user has custom grammar file types', () => {
       it('considers the custom file types as well as those defined in the grammar', async () => {
-        await atom.packages.activatePackage('language-ruby');
-        atom.config.set('core.customFileTypes', {
+        await core.packages.activatePackage('language-ruby');
+        core.config.set('core.customFileTypes', {
           'source.ruby': ['Cheffile']
         });
         expect(
-          atom.grammars.selectGrammar('build/Cheffile', 'cookbook "postgres"')
+          core.grammars.selectGrammar('build/Cheffile', 'cookbook "postgres"')
             .scopeName
         ).toBe('source.ruby');
       });
 
       it('favors user-defined file types over built-in ones of equal length', async () => {
-        await atom.packages.activatePackage('language-ruby');
-        await atom.packages.activatePackage('language-coffee-script');
+        await core.packages.activatePackage('language-ruby');
+        await core.packages.activatePackage('language-coffee-script');
 
-        atom.config.set('core.customFileTypes', {
+        core.config.set('core.customFileTypes', {
           'source.coffee': ['Rakefile'],
           'source.ruby': ['Cakefile']
         });
-        expect(atom.grammars.selectGrammar('Rakefile', '').scopeName).toBe(
+        expect(core.grammars.selectGrammar('Rakefile', '').scopeName).toBe(
           'source.coffee'
         );
-        expect(atom.grammars.selectGrammar('Cakefile', '').scopeName).toBe(
+        expect(core.grammars.selectGrammar('Cakefile', '').scopeName).toBe(
           'source.ruby'
         );
       });
 
       it('favors user-defined file types over grammars with matching first-line-regexps', async () => {
-        await atom.packages.activatePackage('language-ruby');
-        await atom.packages.activatePackage('language-javascript');
+        await core.packages.activatePackage('language-ruby');
+        await core.packages.activatePackage('language-javascript');
 
-        atom.config.set('core.customFileTypes', {
+        core.config.set('core.customFileTypes', {
           'source.ruby': ['bootstrap']
         });
         expect(
-          atom.grammars.selectGrammar('bootstrap', '#!/usr/bin/env node')
+          core.grammars.selectGrammar('bootstrap', '#!/usr/bin/env node')
             .scopeName
         ).toBe('source.ruby');
       });
     });
 
     it('favors a grammar with a matching file type over one with m matching first line pattern', async () => {
-      await atom.packages.activatePackage('language-ruby');
-      await atom.packages.activatePackage('language-javascript');
+      await core.packages.activatePackage('language-ruby');
+      await core.packages.activatePackage('language-javascript');
       expect(
-        atom.grammars.selectGrammar('foo.rb', '#!/usr/bin/env node').scopeName
+        core.grammars.selectGrammar('foo.rb', '#!/usr/bin/env node').scopeName
       ).toBe('source.ruby');
     });
 
     describe('tree-sitter vs text-mate', () => {
       it('favors a text-mate grammar over a tree-sitter grammar when `core.useTreeSitterParsers` is false', () => {
-        atom.config.set('core.useTreeSitterParsers', false, {
+        core.config.set('core.useTreeSitterParsers', false, {
           scopeSelector: '.source.js'
         });
 
@@ -564,7 +564,7 @@ describe('GrammarRegistry', () => {
       });
 
       it('favors a tree-sitter grammar over a text-mate grammar when `core.useTreeSitterParsers` is true', () => {
-        atom.config.set('core.useTreeSitterParsers', true);
+        core.config.set('core.useTreeSitterParsers', true);
 
         grammarRegistry.loadGrammarSync(
           require.resolve('language-javascript/grammars/javascript.cson')
@@ -580,7 +580,7 @@ describe('GrammarRegistry', () => {
       });
 
       it('only favors a tree-sitter grammar if it actually matches in some way (regression)', () => {
-        atom.config.set('core.useTreeSitterParsers', true);
+        core.config.set('core.useTreeSitterParsers', true);
         grammarRegistry.loadGrammarSync(
           require.resolve(
             'language-javascript/grammars/tree-sitter-javascript.cson'
@@ -594,7 +594,7 @@ describe('GrammarRegistry', () => {
 
     describe('tree-sitter grammars with content regexes', () => {
       it('recognizes C++ header files', () => {
-        atom.config.set('core.useTreeSitterParsers', true);
+        core.config.set('core.useTreeSitterParsers', true);
         grammarRegistry.loadGrammarSync(
           require.resolve('language-c/grammars/tree-sitter-c.cson')
         );
@@ -643,7 +643,7 @@ describe('GrammarRegistry', () => {
       });
 
       it('recognizes C++ files that do not match the content regex (regression)', () => {
-        atom.config.set('core.useTreeSitterParsers', true);
+        core.config.set('core.useTreeSitterParsers', true);
         grammarRegistry.loadGrammarSync(
           require.resolve('language-c/grammars/tree-sitter-c.cson')
         );
@@ -664,7 +664,7 @@ describe('GrammarRegistry', () => {
       });
 
       it('does not apply content regexes from grammars without filetype or first line matches', () => {
-        atom.config.set('core.useTreeSitterParsers', true);
+        core.config.set('core.useTreeSitterParsers', true);
         grammarRegistry.loadGrammarSync(
           require.resolve('language-c/grammars/tree-sitter-cpp.cson')
         );
@@ -682,7 +682,7 @@ describe('GrammarRegistry', () => {
       });
 
       it('recognizes shell scripts with shebang lines', () => {
-        atom.config.set('core.useTreeSitterParsers', true);
+        core.config.set('core.useTreeSitterParsers', true);
         grammarRegistry.loadGrammarSync(
           require.resolve('language-shellscript/grammars/shell-unix-bash.cson')
         );
@@ -712,7 +712,7 @@ describe('GrammarRegistry', () => {
         expect(grammar.name).toBe('Shell Script');
         expect(grammar instanceof TreeSitterGrammar).toBeTruthy();
 
-        atom.config.set('core.useTreeSitterParsers', false);
+        core.config.set('core.useTreeSitterParsers', false);
         grammar = grammarRegistry.selectGrammar(
           'test.h',
           dedent`
@@ -726,7 +726,7 @@ describe('GrammarRegistry', () => {
       });
 
       it('recognizes JavaScript files that use Flow', () => {
-        atom.config.set('core.useTreeSitterParsers', true);
+        core.config.set('core.useTreeSitterParsers', true);
         grammarRegistry.loadGrammarSync(
           require.resolve(
             'language-javascript/grammars/tree-sitter-javascript.cson'
@@ -785,10 +785,10 @@ describe('GrammarRegistry', () => {
 
   describe('.removeGrammar(grammar)', () => {
     it("removes the grammar, so it won't be returned by selectGrammar", async () => {
-      await atom.packages.activatePackage('language-css');
-      const grammar = atom.grammars.selectGrammar('foo.css');
-      atom.grammars.removeGrammar(grammar);
-      expect(atom.grammars.selectGrammar('foo.css').name).not.toBe(
+      await core.packages.activatePackage('language-css');
+      const grammar = core.grammars.selectGrammar('foo.css');
+      core.grammars.removeGrammar(grammar);
+      expect(core.grammars.selectGrammar('foo.css').name).not.toBe(
         grammar.name
       );
     });
@@ -806,21 +806,21 @@ describe('GrammarRegistry', () => {
     };
 
     beforeEach(() => {
-      atom.config.set('core.useTreeSitterParsers', true);
+      core.config.set('core.useTreeSitterParsers', true);
     });
 
     it('adds an injection point to the grammar with the given id', async () => {
-      await atom.packages.activatePackage('language-javascript');
-      atom.grammars.addInjectionPoint('javascript', injectionPoint);
-      const grammar = atom.grammars.grammarForId('javascript');
+      await core.packages.activatePackage('language-javascript');
+      core.grammars.addInjectionPoint('javascript', injectionPoint);
+      const grammar = core.grammars.grammarForId('javascript');
       expect(grammar.injectionPoints).toContain(injectionPoint);
     });
 
     describe('when called before a grammar with the given id is loaded', () => {
       it('adds the injection point once the grammar is loaded', async () => {
-        atom.grammars.addInjectionPoint('javascript', injectionPoint);
-        await atom.packages.activatePackage('language-javascript');
-        const grammar = atom.grammars.grammarForId('javascript');
+        core.grammars.addInjectionPoint('javascript', injectionPoint);
+        await core.packages.activatePackage('language-javascript');
+        const grammar = core.grammars.grammarForId('javascript');
         expect(grammar.injectionPoints).toContain(injectionPoint);
       });
     });
@@ -849,7 +849,7 @@ describe('GrammarRegistry', () => {
       const buffer1Copy = await TextBuffer.deserialize(buffer1.serialize());
       const buffer2Copy = await TextBuffer.deserialize(buffer2.serialize());
 
-      const grammarRegistryCopy = new GrammarRegistry({ config: atom.config });
+      const grammarRegistryCopy = new GrammarRegistry({ config: core.config });
       grammarRegistryCopy.deserialize(
         JSON.parse(JSON.stringify(grammarRegistry.serialize()))
       );
@@ -879,23 +879,23 @@ describe('GrammarRegistry', () => {
 
   describe('when working with grammars', () => {
     beforeEach(async () => {
-      await atom.packages.activatePackage('language-javascript');
+      await core.packages.activatePackage('language-javascript');
     });
 
     it('returns only Tree-sitter grammars by default', async () => {
-      const tmGrammars = atom.grammars.getGrammars();
-      const allGrammars = atom.grammars.getGrammars({
+      const tmGrammars = core.grammars.getGrammars();
+      const allGrammars = core.grammars.getGrammars({
         includeTreeSitter: true
       });
       expect(allGrammars.length).toBeGreaterThan(tmGrammars.length);
     });
 
     it('executes the foreach callback on both Tree-sitter and TextMate grammars', async () => {
-      const numAllGrammars = atom.grammars.getGrammars({
+      const numAllGrammars = core.grammars.getGrammars({
         includeTreeSitter: true
       }).length;
       let i = 0;
-      atom.grammars.forEachGrammar(() => i++);
+      core.grammars.forEachGrammar(() => i++);
       expect(i).toBe(numAllGrammars);
     });
   });

--- a/spec/integration/helpers/start-atom.js
+++ b/spec/integration/helpers/start-atom.js
@@ -78,7 +78,7 @@ const buildAtomClient = async (args, env) => {
   client.addCommand('waitForPaneItemCount', async function(count, timeout) {
     await this.waitUntil(
       () =>
-        this.execute(() => atom.workspace.getActivePane().getItems().length),
+        this.execute(() => core.workspace.getActivePane().getItems().length),
       timeout
     );
   });
@@ -93,7 +93,7 @@ const buildAtomClient = async (args, env) => {
   });
   client.addCommand('dispatchCommand', async function(command) {
     return this.execute(
-      command => atom.commands.dispatch(document.activeElement, command),
+      command => core.commands.dispatch(document.activeElement, command),
       command
     );
   });

--- a/spec/integration/smoke-spec.js
+++ b/spec/integration/smoke-spec.js
@@ -38,7 +38,7 @@ describe('Smoke Test', () => {
       const roots = await client.treeViewRootDirectories();
       expect(roots).toEqual([tempDirPath]);
 
-      await client.execute(filePath => atom.workspace.open(filePath), filePath);
+      await client.execute(filePath => core.workspace.open(filePath), filePath);
 
       const textEditorElement = await client.$('atom-text-editor');
       await textEditorElement.waitForExist(5000);
@@ -55,7 +55,7 @@ describe('Smoke Test', () => {
       await client.keys('Hello!');
 
       const text = await client.execute(() =>
-        atom.workspace.getActiveTextEditor().getText()
+        core.workspace.getActiveTextEditor().getText()
       );
       expect(text).toBe('Hello!');
 

--- a/spec/jasmine-test-runner.js
+++ b/spec/jasmine-test-runner.js
@@ -60,11 +60,12 @@ module.exports = function({logFile, headless, testPaths, buildAtomEnvironment}) 
   const applicationDelegate = new ApplicationDelegate();
   applicationDelegate.setRepresentedFilename = function() {};
   applicationDelegate.setWindowDocumentEdited = function() {};
-  window.atom = buildAtomEnvironment({
+  window.core = buildAtomEnvironment({
     applicationDelegate, window, document,
     configDirPath: atomHome,
     enablePersistence: false
   });
+  window.atom = window.core;
 
   require('./spec-helper');
   if (process.env.JANKY_SHA1 || process.env.CI) { disableFocusMethods(); }

--- a/spec/keymap-extensions-spec.js
+++ b/spec/keymap-extensions-spec.js
@@ -3,21 +3,21 @@ const fs = require('fs-plus');
 
 describe('keymap-extensions', function() {
   beforeEach(function() {
-    atom.keymaps.configDirPath = temp.path('atom-spec-keymap-ext');
-    fs.writeFileSync(atom.keymaps.getUserKeymapPath(), '#');
+    core.keymaps.configDirPath = temp.path('atom-spec-keymap-ext');
+    fs.writeFileSync(core.keymaps.getUserKeymapPath(), '#');
     this.userKeymapLoaded = function() {};
-    atom.keymaps.onDidLoadUserKeymap(() => this.userKeymapLoaded());
+    core.keymaps.onDidLoadUserKeymap(() => this.userKeymapLoaded());
   });
 
   afterEach(function() {
-    fs.removeSync(atom.keymaps.configDirPath);
-    atom.keymaps.destroy();
+    fs.removeSync(core.keymaps.configDirPath);
+    core.keymaps.destroy();
   });
 
   describe('did-load-user-keymap', () =>
     it('fires when user keymap is loaded', function() {
       spyOn(this, 'userKeymapLoaded');
-      atom.keymaps.loadUserKeymap();
+      core.keymaps.loadUserKeymap();
       expect(this.userKeymapLoaded).toHaveBeenCalled();
     }));
 });

--- a/spec/main-process/atom-application.test.js
+++ b/spec/main-process/atom-application.test.js
@@ -796,7 +796,8 @@ describe('AtomApplication', function() {
         app = scenario.getApplication(0);
         app.removeWindow(w);
         sinon.stub(app, 'promptForPathToOpen');
-        global.atom = { workspace: { getActiveTextEditor() {} } };
+        global.core = { workspace: { getActiveTextEditor() {} } };
+        global.atom = global.core;
       });
 
       it('opens a new file', function() {
@@ -920,7 +921,7 @@ describe('AtomApplication', function() {
     // * choosing "open in new window" when adding a folder that has previously saved state
     // * drag and drop
     // * deprecated call links in deprecation-cop
-    // * other direct callers of `atom.open()`
+    // * other direct callers of `core.open()`
     it('"open" opens a fixed path by the standard opening rules', async function() {
       sinon.stub(app, 'atomWindowForEvent').callsFake(() => w1);
 

--- a/spec/menu-manager-spec.js
+++ b/spec/menu-manager-spec.js
@@ -6,11 +6,11 @@ describe('MenuManager', function() {
 
   beforeEach(function() {
     menu = new MenuManager({
-      keymapManager: atom.keymaps,
-      packageManager: atom.packages
+      keymapManager: core.keymaps,
+      packageManager: core.packages
     });
     spyOn(menu, 'sendToBrowserProcess'); // Do not modify Atom's actual menus
-    menu.initialize({ resourcePath: atom.getLoadSettings().resourcePath });
+    menu.initialize({ resourcePath: core.getLoadSettings().resourcePath });
   });
 
   describe('::add(items)', function() {
@@ -113,7 +113,7 @@ describe('MenuManager', function() {
 
     it('sends the current menu template and associated key bindings to the browser process', function() {
       menu.add([{ label: 'A', submenu: [{ label: 'B', command: 'b' }] }]);
-      atom.keymaps.add('test', { 'atom-workspace': { 'ctrl-b': 'b' } });
+      core.keymaps.add('test', { 'atom-workspace': { 'ctrl-b': 'b' } });
       menu.update();
       advanceClock(1);
       expect(menu.sendToBrowserProcess.argsForCall[0][1]['b']).toEqual([
@@ -125,8 +125,8 @@ describe('MenuManager', function() {
       // it would be nice to be smarter about omitting, but that would require a much
       // more dynamic interaction between the currently focused element and the menu
       menu.add([{ label: 'A', submenu: [{ label: 'B', command: 'b' }] }]);
-      atom.keymaps.add('test', { 'atom-workspace': { 'ctrl-b': 'b' } });
-      atom.keymaps.add('test', { 'atom-text-editor': { 'ctrl-b': 'unset!' } });
+      core.keymaps.add('test', { 'atom-workspace': { 'ctrl-b': 'b' } });
+      core.keymaps.add('test', { 'atom-text-editor': { 'ctrl-b': 'unset!' } });
       advanceClock(1);
       expect(menu.sendToBrowserProcess.argsForCall[0][1]['b']).toBeUndefined();
     });
@@ -144,7 +144,7 @@ describe('MenuManager', function() {
         }
       ]);
 
-      atom.keymaps.add('test', {
+      core.keymaps.add('test', {
         'atom-workspace': {
           'alt-b': 'b',
           'alt-shift-C': 'c',
@@ -200,7 +200,7 @@ describe('MenuManager', function() {
       'keymaps',
       'keymap-1.cson'
     );
-    atom.keymaps.reloadKeymap(keymapPath);
+    core.keymaps.reloadKeymap(keymapPath);
     expect(menu.update).toHaveBeenCalled();
   });
 });

--- a/spec/menu-manager-spec.js
+++ b/spec/menu-manager-spec.js
@@ -173,7 +173,7 @@ describe('MenuManager', function() {
         }
       ]);
 
-      atom.keymaps.add('test', {
+      core.keymaps.add('test', {
         'atom-workspace': {
           'ctrl-alt-b': 'b',
           'ctrl-alt-shift-C': 'c',

--- a/spec/module-cache-spec.js
+++ b/spec/module-cache-spec.js
@@ -27,7 +27,7 @@ describe('ModuleCache', function() {
   });
 
   it('resolves relative core paths without hitting the filesystem', function() {
-    ModuleCache.add(atom.getLoadSettings().resourcePath, {
+    ModuleCache.add(core.getLoadSettings().resourcePath, {
       _atomModuleCache: {
         extensions: {
           '.json': [path.join('spec', 'fixtures', 'module-cache', 'file.json')]
@@ -52,7 +52,7 @@ describe('ModuleCache', function() {
         ]
       }
     });
-    ModuleCache.add(atom.getLoadSettings().resourcePath, {
+    ModuleCache.add(core.getLoadSettings().resourcePath, {
       _atomModuleCache: {
         dependencies: [
           {
@@ -97,7 +97,7 @@ exports.load = function() { require('underscore-plus'); };\
         ]
       }
     });
-    ModuleCache.add(atom.getLoadSettings().resourcePath, {
+    ModuleCache.add(core.getLoadSettings().resourcePath, {
       _atomModuleCache: {
         dependencies: [
           {

--- a/spec/notification-manager-spec.js
+++ b/spec/notification-manager-spec.js
@@ -9,7 +9,7 @@ describe('NotificationManager', () => {
 
   describe('the atom global', () =>
     it('has a notifications instance', () => {
-      expect(atom.notifications instanceof NotificationManager).toBe(true);
+      expect(core.notifications instanceof NotificationManager).toBe(true);
     }));
 
   describe('adding events', () => {

--- a/spec/notification-manager-spec.js
+++ b/spec/notification-manager-spec.js
@@ -7,7 +7,7 @@ describe('NotificationManager', () => {
     manager = new NotificationManager();
   });
 
-  describe('the atom global', () =>
+  describe('the core global', () =>
     it('has a notifications instance', () => {
       expect(core.notifications instanceof NotificationManager).toBe(true);
     }));

--- a/spec/package-manager-spec.js
+++ b/spec/package-manager-spec.js
@@ -66,58 +66,58 @@ describe('PackageManager', () => {
       if (process.platform === 'win32') {
         apmPath += '.cmd';
       }
-      expect(atom.packages.getApmPath()).toBe(apmPath);
+      expect(core.packages.getApmPath()).toBe(apmPath);
     });
 
     describe('when the core.apmPath setting is set', () => {
-      beforeEach(() => atom.config.set('core.apmPath', '/path/to/apm'));
+      beforeEach(() => core.config.set('core.apmPath', '/path/to/apm'));
 
       it('returns the value of the core.apmPath config setting', () => {
-        expect(atom.packages.getApmPath()).toBe('/path/to/apm');
+        expect(core.packages.getApmPath()).toBe('/path/to/apm');
       });
     });
   });
 
   describe('::loadPackages()', () => {
-    beforeEach(() => spyOn(atom.packages, 'loadAvailablePackage'));
+    beforeEach(() => spyOn(core.packages, 'loadAvailablePackage'));
 
     afterEach(async () => {
-      await atom.packages.deactivatePackages();
-      atom.packages.unloadPackages();
+      await core.packages.deactivatePackages();
+      core.packages.unloadPackages();
     });
 
     it('sets hasLoadedInitialPackages', () => {
-      expect(atom.packages.hasLoadedInitialPackages()).toBe(false);
-      atom.packages.loadPackages();
-      expect(atom.packages.hasLoadedInitialPackages()).toBe(true);
+      expect(core.packages.hasLoadedInitialPackages()).toBe(false);
+      core.packages.loadPackages();
+      expect(core.packages.hasLoadedInitialPackages()).toBe(true);
     });
   });
 
   describe('::loadPackage(name)', () => {
-    beforeEach(() => atom.config.set('core.disabledPackages', []));
+    beforeEach(() => core.config.set('core.disabledPackages', []));
 
     it('returns the package', () => {
-      const pack = atom.packages.loadPackage('package-with-index');
+      const pack = core.packages.loadPackage('package-with-index');
       expect(pack instanceof Package).toBe(true);
       expect(pack.metadata.name).toBe('package-with-index');
     });
 
     it('returns the package if it has an invalid keymap', () => {
-      spyOn(atom, 'inSpecMode').andReturn(false);
-      const pack = atom.packages.loadPackage('package-with-broken-keymap');
+      spyOn(core, 'inSpecMode').andReturn(false);
+      const pack = core.packages.loadPackage('package-with-broken-keymap');
       expect(pack instanceof Package).toBe(true);
       expect(pack.metadata.name).toBe('package-with-broken-keymap');
     });
 
     it('returns the package if it has an invalid stylesheet', () => {
-      spyOn(atom, 'inSpecMode').andReturn(false);
-      const pack = atom.packages.loadPackage('package-with-invalid-styles');
+      spyOn(core, 'inSpecMode').andReturn(false);
+      const pack = core.packages.loadPackage('package-with-invalid-styles');
       expect(pack instanceof Package).toBe(true);
       expect(pack.metadata.name).toBe('package-with-invalid-styles');
       expect(pack.stylesheets.length).toBe(0);
 
       const addErrorHandler = jasmine.createSpy();
-      atom.notifications.onDidAddNotification(addErrorHandler);
+      core.notifications.onDidAddNotification(addErrorHandler);
       expect(() => pack.reloadStylesheets()).not.toThrow();
       expect(addErrorHandler.callCount).toBe(2);
       expect(addErrorHandler.argsForCall[1][0].message).toContain(
@@ -129,11 +129,11 @@ describe('PackageManager', () => {
     });
 
     it('returns null if the package has an invalid package.json', () => {
-      spyOn(atom, 'inSpecMode').andReturn(false);
+      spyOn(core, 'inSpecMode').andReturn(false);
       const addErrorHandler = jasmine.createSpy();
-      atom.notifications.onDidAddNotification(addErrorHandler);
+      core.notifications.onDidAddNotification(addErrorHandler);
       expect(
-        atom.packages.loadPackage('package-with-broken-package-json')
+        core.packages.loadPackage('package-with-broken-package-json')
       ).toBeNull();
       expect(addErrorHandler.callCount).toBe(1);
       expect(addErrorHandler.argsForCall[0][0].message).toContain(
@@ -146,17 +146,17 @@ describe('PackageManager', () => {
 
     it('returns null if the package name or path starts with a dot', () => {
       expect(
-        atom.packages.loadPackage('/Users/user/.atom/packages/.git')
+        core.packages.loadPackage('/Users/user/.atom/packages/.git')
       ).toBeNull();
     });
 
     it('normalizes short repository urls in package.json', () => {
-      let { metadata } = atom.packages.loadPackage(
+      let { metadata } = core.packages.loadPackage(
         'package-with-short-url-package-json'
       );
       expect(metadata.repository.type).toBe('git');
       expect(metadata.repository.url).toBe('https://github.com/example/repo');
-      ({ metadata } = atom.packages.loadPackage(
+      ({ metadata } = core.packages.loadPackage(
         'package-with-invalid-url-package-json'
       ));
       expect(metadata.repository.type).toBe('git');
@@ -164,7 +164,7 @@ describe('PackageManager', () => {
     });
 
     it('trims git+ from the beginning and .git from the end of repository URLs, even if npm already normalized them ', () => {
-      const { metadata } = atom.packages.loadPackage(
+      const { metadata } = core.packages.loadPackage(
         'package-with-prefixed-and-suffixed-repo-url'
       );
       expect(metadata.repository.type).toBe('git');
@@ -174,7 +174,7 @@ describe('PackageManager', () => {
     it('returns null if the package is not found in any package directory', () => {
       spyOn(console, 'warn');
       expect(
-        atom.packages.loadPackage('this-package-cannot-be-found')
+        core.packages.loadPackage('this-package-cannot-be-found')
       ).toBeNull();
       expect(console.warn.callCount).toBe(1);
       expect(console.warn.argsForCall[0][0]).toContain('Could not resolve');
@@ -184,21 +184,21 @@ describe('PackageManager', () => {
       it('returns null', () => {
         spyOn(console, 'warn');
         expect(
-          atom.packages.loadPackage(
+          core.packages.loadPackage(
             path.join(__dirname, 'fixtures', 'packages', 'wordcount')
           )
         ).toBeNull();
-        expect(atom.packages.isDeprecatedPackage('wordcount', '2.1.9')).toBe(
+        expect(core.packages.isDeprecatedPackage('wordcount', '2.1.9')).toBe(
           true
         );
-        expect(atom.packages.isDeprecatedPackage('wordcount', '2.2.0')).toBe(
+        expect(core.packages.isDeprecatedPackage('wordcount', '2.2.0')).toBe(
           true
         );
-        expect(atom.packages.isDeprecatedPackage('wordcount', '2.2.1')).toBe(
+        expect(core.packages.isDeprecatedPackage('wordcount', '2.2.1')).toBe(
           false
         );
         expect(
-          atom.packages.getDeprecatedPackageMetadata('wordcount').version
+          core.packages.getDeprecatedPackageMetadata('wordcount').version
         ).toBe('<=2.2.0');
       });
     });
@@ -206,26 +206,26 @@ describe('PackageManager', () => {
     it('invokes ::onDidLoadPackage listeners with the loaded package', () => {
       let loadedPackage = null;
 
-      atom.packages.onDidLoadPackage(pack => {
+      core.packages.onDidLoadPackage(pack => {
         loadedPackage = pack;
       });
 
-      atom.packages.loadPackage('package-with-main');
+      core.packages.loadPackage('package-with-main');
 
       expect(loadedPackage.name).toBe('package-with-main');
     });
 
     it("registers any deserializers specified in the package's package.json", () => {
-      atom.packages.loadPackage('package-with-deserializers');
+      core.packages.loadPackage('package-with-deserializers');
 
       const state1 = { deserializer: 'Deserializer1', a: 'b' };
-      expect(atom.deserializers.deserialize(state1)).toEqual({
+      expect(core.deserializers.deserialize(state1)).toEqual({
         wasDeserializedBy: 'deserializeMethod1',
         state: state1
       });
 
       const state2 = { deserializer: 'Deserializer2', c: 'd' };
-      expect(atom.deserializers.deserialize(state2)).toEqual({
+      expect(core.deserializers.deserialize(state2)).toEqual({
         wasDeserializedBy: 'deserializeMethod2',
         state: state2
       });
@@ -235,13 +235,13 @@ describe('PackageManager', () => {
       jasmine.useRealClock();
 
       const providers = [];
-      atom.packages.serviceHub.consume(
+      core.packages.serviceHub.consume(
         'atom.directory-provider',
         '^0.1.0',
         provider => providers.push(provider)
       );
 
-      atom.packages.loadPackage('package-with-directory-provider');
+      core.packages.loadPackage('package-with-directory-provider');
       expect(providers.map(p => p.name)).toEqual([
         'directory provider from package-with-directory-provider'
       ]);
@@ -252,61 +252,61 @@ describe('PackageManager', () => {
       const model2 = { worksWithViewProvider2: true };
 
       afterEach(async () => {
-        await atom.packages.deactivatePackage('package-with-view-providers');
-        atom.packages.unloadPackage('package-with-view-providers');
+        await core.packages.deactivatePackage('package-with-view-providers');
+        core.packages.unloadPackage('package-with-view-providers');
       });
 
       it('does not load the view providers immediately', () => {
-        const pack = atom.packages.loadPackage('package-with-view-providers');
+        const pack = core.packages.loadPackage('package-with-view-providers');
         expect(pack.mainModule).toBeNull();
 
-        expect(() => atom.views.getView(model1)).toThrow();
-        expect(() => atom.views.getView(model2)).toThrow();
+        expect(() => core.views.getView(model1)).toThrow();
+        expect(() => core.views.getView(model2)).toThrow();
       });
 
       it('registers the view providers when the package is activated', async () => {
-        atom.packages.loadPackage('package-with-view-providers');
+        core.packages.loadPackage('package-with-view-providers');
 
-        await atom.packages.activatePackage('package-with-view-providers');
+        await core.packages.activatePackage('package-with-view-providers');
 
-        const element1 = atom.views.getView(model1);
+        const element1 = core.views.getView(model1);
         expect(element1 instanceof HTMLDivElement).toBe(true);
         expect(element1.dataset.createdBy).toBe('view-provider-1');
 
-        const element2 = atom.views.getView(model2);
+        const element2 = core.views.getView(model2);
         expect(element2 instanceof HTMLDivElement).toBe(true);
         expect(element2.dataset.createdBy).toBe('view-provider-2');
       });
 
       it("registers the view providers when any of the package's deserializers are used", () => {
-        atom.packages.loadPackage('package-with-view-providers');
+        core.packages.loadPackage('package-with-view-providers');
 
-        spyOn(atom.views, 'addViewProvider').andCallThrough();
-        atom.deserializers.deserialize({
+        spyOn(core.views, 'addViewProvider').andCallThrough();
+        core.deserializers.deserialize({
           deserializer: 'DeserializerFromPackageWithViewProviders',
           a: 'b'
         });
-        expect(atom.views.addViewProvider.callCount).toBe(2);
+        expect(core.views.addViewProvider.callCount).toBe(2);
 
-        atom.deserializers.deserialize({
+        core.deserializers.deserialize({
           deserializer: 'DeserializerFromPackageWithViewProviders',
           a: 'b'
         });
-        expect(atom.views.addViewProvider.callCount).toBe(2);
+        expect(core.views.addViewProvider.callCount).toBe(2);
 
-        const element1 = atom.views.getView(model1);
+        const element1 = core.views.getView(model1);
         expect(element1 instanceof HTMLDivElement).toBe(true);
         expect(element1.dataset.createdBy).toBe('view-provider-1');
 
-        const element2 = atom.views.getView(model2);
+        const element2 = core.views.getView(model2);
         expect(element2 instanceof HTMLDivElement).toBe(true);
         expect(element2.dataset.createdBy).toBe('view-provider-2');
       });
     });
 
     it("registers the config schema in the package's metadata, if present", () => {
-      let pack = atom.packages.loadPackage('package-with-json-config-schema');
-      expect(atom.config.getSchema('package-with-json-config-schema')).toEqual({
+      let pack = core.packages.loadPackage('package-with-json-config-schema');
+      expect(core.config.getSchema('package-with-json-config-schema')).toEqual({
         type: 'object',
         properties: {
           a: { type: 'number', default: 5 },
@@ -316,11 +316,11 @@ describe('PackageManager', () => {
 
       expect(pack.mainModule).toBeNull();
 
-      atom.packages.unloadPackage('package-with-json-config-schema');
-      atom.config.clear();
+      core.packages.unloadPackage('package-with-json-config-schema');
+      core.config.clear();
 
-      pack = atom.packages.loadPackage('package-with-json-config-schema');
-      expect(atom.config.getSchema('package-with-json-config-schema')).toEqual({
+      pack = core.packages.loadPackage('package-with-json-config-schema');
+      expect(core.config.getSchema('package-with-json-config-schema')).toEqual({
         type: 'object',
         properties: {
           a: { type: 'number', default: 5 },
@@ -333,24 +333,24 @@ describe('PackageManager', () => {
       beforeEach(() => mockLocalStorage());
 
       it("defers loading the package's main module if the package previously used no Atom APIs when its main module was required", () => {
-        const pack1 = atom.packages.loadPackage('package-with-main');
+        const pack1 = core.packages.loadPackage('package-with-main');
         expect(pack1.mainModule).toBeDefined();
 
-        atom.packages.unloadPackage('package-with-main');
+        core.packages.unloadPackage('package-with-main');
 
-        const pack2 = atom.packages.loadPackage('package-with-main');
+        const pack2 = core.packages.loadPackage('package-with-main');
         expect(pack2.mainModule).toBeNull();
       });
 
       it("does not defer loading the package's main module if the package previously used Atom APIs when its main module was required", () => {
-        const pack1 = atom.packages.loadPackage(
+        const pack1 = core.packages.loadPackage(
           'package-with-eval-time-api-calls'
         );
         expect(pack1.mainModule).toBeDefined();
 
-        atom.packages.unloadPackage('package-with-eval-time-api-calls');
+        core.packages.unloadPackage('package-with-eval-time-api-calls');
 
-        const pack2 = atom.packages.loadPackage(
+        const pack2 = core.packages.loadPackage(
           'package-with-eval-time-api-calls'
         );
         expect(pack2.mainModule).not.toBeNull();
@@ -361,27 +361,27 @@ describe('PackageManager', () => {
   describe('::loadAvailablePackage(availablePackage)', () => {
     describe('if the package was preloaded', () => {
       it('adds the package path to the module cache', () => {
-        const availablePackage = atom.packages
+        const availablePackage = core.packages
           .getAvailablePackages()
           .find(p => p.name === 'spell-check');
         availablePackage.isBundled = true;
         expect(
-          atom.packages.preloadedPackages[availablePackage.name]
+          core.packages.preloadedPackages[availablePackage.name]
         ).toBeUndefined();
-        expect(atom.packages.isPackageLoaded(availablePackage.name)).toBe(
+        expect(core.packages.isPackageLoaded(availablePackage.name)).toBe(
           false
         );
 
-        const metadata = atom.packages.loadPackageMetadata(availablePackage);
-        atom.packages.preloadPackage(availablePackage.name, {
+        const metadata = core.packages.loadPackageMetadata(availablePackage);
+        core.packages.preloadPackage(availablePackage.name, {
           rootDirPath: path.relative(
-            atom.packages.resourcePath,
+            core.packages.resourcePath,
             availablePackage.path
           ),
           metadata
         });
-        atom.packages.loadAvailablePackage(availablePackage);
-        expect(atom.packages.isPackageLoaded(availablePackage.name)).toBe(true);
+        core.packages.loadAvailablePackage(availablePackage);
+        expect(core.packages.isPackageLoaded(availablePackage.name)).toBe(true);
         expect(ModuleCache.add).toHaveBeenCalledWith(
           availablePackage.path,
           metadata
@@ -389,23 +389,23 @@ describe('PackageManager', () => {
       });
 
       it('deactivates it if it had been disabled', () => {
-        const availablePackage = atom.packages
+        const availablePackage = core.packages
           .getAvailablePackages()
           .find(p => p.name === 'spell-check');
         availablePackage.isBundled = true;
         expect(
-          atom.packages.preloadedPackages[availablePackage.name]
+          core.packages.preloadedPackages[availablePackage.name]
         ).toBeUndefined();
-        expect(atom.packages.isPackageLoaded(availablePackage.name)).toBe(
+        expect(core.packages.isPackageLoaded(availablePackage.name)).toBe(
           false
         );
 
-        const metadata = atom.packages.loadPackageMetadata(availablePackage);
-        const preloadedPackage = atom.packages.preloadPackage(
+        const metadata = core.packages.loadPackageMetadata(availablePackage);
+        const preloadedPackage = core.packages.preloadPackage(
           availablePackage.name,
           {
             rootDirPath: path.relative(
-              atom.packages.resourcePath,
+              core.packages.resourcePath,
               availablePackage.path
             ),
             metadata
@@ -415,11 +415,11 @@ describe('PackageManager', () => {
         expect(preloadedPackage.settingsActivated).toBe(true);
         expect(preloadedPackage.menusActivated).toBe(true);
 
-        atom.packages.loadAvailablePackage(
+        core.packages.loadAvailablePackage(
           availablePackage,
           new Set([availablePackage.name])
         );
-        expect(atom.packages.isPackageLoaded(availablePackage.name)).toBe(
+        expect(core.packages.isPackageLoaded(availablePackage.name)).toBe(
           false
         );
         expect(preloadedPackage.keymapActivated).toBe(false);
@@ -428,23 +428,23 @@ describe('PackageManager', () => {
       });
 
       it('deactivates it and reloads the new one if trying to load the same package outside of the bundle', () => {
-        const availablePackage = atom.packages
+        const availablePackage = core.packages
           .getAvailablePackages()
           .find(p => p.name === 'spell-check');
         availablePackage.isBundled = true;
         expect(
-          atom.packages.preloadedPackages[availablePackage.name]
+          core.packages.preloadedPackages[availablePackage.name]
         ).toBeUndefined();
-        expect(atom.packages.isPackageLoaded(availablePackage.name)).toBe(
+        expect(core.packages.isPackageLoaded(availablePackage.name)).toBe(
           false
         );
 
-        const metadata = atom.packages.loadPackageMetadata(availablePackage);
-        const preloadedPackage = atom.packages.preloadPackage(
+        const metadata = core.packages.loadPackageMetadata(availablePackage);
+        const preloadedPackage = core.packages.preloadPackage(
           availablePackage.name,
           {
             rootDirPath: path.relative(
-              atom.packages.resourcePath,
+              core.packages.resourcePath,
               availablePackage.path
             ),
             metadata
@@ -455,8 +455,8 @@ describe('PackageManager', () => {
         expect(preloadedPackage.menusActivated).toBe(true);
 
         availablePackage.isBundled = false;
-        atom.packages.loadAvailablePackage(availablePackage);
-        expect(atom.packages.isPackageLoaded(availablePackage.name)).toBe(true);
+        core.packages.loadAvailablePackage(availablePackage);
+        expect(core.packages.isPackageLoaded(availablePackage.name)).toBe(true);
         expect(preloadedPackage.keymapActivated).toBe(false);
         expect(preloadedPackage.settingsActivated).toBe(false);
         expect(preloadedPackage.menusActivated).toBe(false);
@@ -465,12 +465,12 @@ describe('PackageManager', () => {
 
     describe('if the package was not preloaded', () => {
       it('adds the package path to the module cache', () => {
-        const availablePackage = atom.packages
+        const availablePackage = core.packages
           .getAvailablePackages()
           .find(p => p.name === 'spell-check');
         availablePackage.isBundled = true;
-        const metadata = atom.packages.loadPackageMetadata(availablePackage);
-        atom.packages.loadAvailablePackage(availablePackage);
+        const metadata = core.packages.loadPackageMetadata(availablePackage);
+        core.packages.loadAvailablePackage(availablePackage);
         expect(ModuleCache.add).toHaveBeenCalledWith(
           availablePackage.path,
           metadata
@@ -481,26 +481,26 @@ describe('PackageManager', () => {
 
   describe('preloading', () => {
     it('requires the main module, loads the config schema and activates keymaps, menus and settings without reactivating them during package activation', () => {
-      const availablePackage = atom.packages
+      const availablePackage = core.packages
         .getAvailablePackages()
         .find(p => p.name === 'spell-check');
       availablePackage.isBundled = true;
-      const metadata = atom.packages.loadPackageMetadata(availablePackage);
+      const metadata = core.packages.loadPackageMetadata(availablePackage);
       expect(
-        atom.packages.preloadedPackages[availablePackage.name]
+        core.packages.preloadedPackages[availablePackage.name]
       ).toBeUndefined();
-      expect(atom.packages.isPackageLoaded(availablePackage.name)).toBe(false);
+      expect(core.packages.isPackageLoaded(availablePackage.name)).toBe(false);
 
-      atom.packages.packagesCache = {};
-      atom.packages.packagesCache[availablePackage.name] = {
+      core.packages.packagesCache = {};
+      core.packages.packagesCache[availablePackage.name] = {
         main: path.join(availablePackage.path, metadata.main),
         grammarPaths: []
       };
-      const preloadedPackage = atom.packages.preloadPackage(
+      const preloadedPackage = core.packages.preloadPackage(
         availablePackage.name,
         {
           rootDirPath: path.relative(
-            atom.packages.resourcePath,
+            core.packages.resourcePath,
             availablePackage.path
           ),
           metadata
@@ -512,21 +512,21 @@ describe('PackageManager', () => {
       expect(preloadedPackage.mainModule).toBeTruthy();
       expect(preloadedPackage.configSchemaRegisteredOnLoad).toBeTruthy();
 
-      spyOn(atom.keymaps, 'add');
-      spyOn(atom.menu, 'add');
-      spyOn(atom.contextMenu, 'add');
-      spyOn(atom.config, 'setSchema');
+      spyOn(core.keymaps, 'add');
+      spyOn(core.menu, 'add');
+      spyOn(core.contextMenu, 'add');
+      spyOn(core.config, 'setSchema');
 
-      atom.packages.loadAvailablePackage(availablePackage);
+      core.packages.loadAvailablePackage(availablePackage);
       expect(preloadedPackage.getMainModulePath()).toBe(
         path.join(availablePackage.path, metadata.main)
       );
 
-      atom.packages.activatePackage(availablePackage.name);
-      expect(atom.keymaps.add).not.toHaveBeenCalled();
-      expect(atom.menu.add).not.toHaveBeenCalled();
-      expect(atom.contextMenu.add).not.toHaveBeenCalled();
-      expect(atom.config.setSchema).not.toHaveBeenCalled();
+      core.packages.activatePackage(availablePackage.name);
+      expect(core.keymaps.add).not.toHaveBeenCalled();
+      expect(core.menu.add).not.toHaveBeenCalled();
+      expect(core.contextMenu.add).not.toHaveBeenCalled();
+      expect(core.config.setSchema).not.toHaveBeenCalled();
       expect(preloadedPackage.keymapActivated).toBe(true);
       expect(preloadedPackage.settingsActivated).toBe(true);
       expect(preloadedPackage.menusActivated).toBe(true);
@@ -535,26 +535,26 @@ describe('PackageManager', () => {
     });
 
     it('deactivates disabled keymaps during package activation', () => {
-      const availablePackage = atom.packages
+      const availablePackage = core.packages
         .getAvailablePackages()
         .find(p => p.name === 'spell-check');
       availablePackage.isBundled = true;
-      const metadata = atom.packages.loadPackageMetadata(availablePackage);
+      const metadata = core.packages.loadPackageMetadata(availablePackage);
       expect(
-        atom.packages.preloadedPackages[availablePackage.name]
+        core.packages.preloadedPackages[availablePackage.name]
       ).toBeUndefined();
-      expect(atom.packages.isPackageLoaded(availablePackage.name)).toBe(false);
+      expect(core.packages.isPackageLoaded(availablePackage.name)).toBe(false);
 
-      atom.packages.packagesCache = {};
-      atom.packages.packagesCache[availablePackage.name] = {
+      core.packages.packagesCache = {};
+      core.packages.packagesCache[availablePackage.name] = {
         main: path.join(availablePackage.path, metadata.main),
         grammarPaths: []
       };
-      const preloadedPackage = atom.packages.preloadPackage(
+      const preloadedPackage = core.packages.preloadPackage(
         availablePackage.name,
         {
           rootDirPath: path.relative(
-            atom.packages.resourcePath,
+            core.packages.resourcePath,
             availablePackage.path
           ),
           metadata
@@ -564,11 +564,11 @@ describe('PackageManager', () => {
       expect(preloadedPackage.settingsActivated).toBe(true);
       expect(preloadedPackage.menusActivated).toBe(true);
 
-      atom.packages.loadAvailablePackage(availablePackage);
-      atom.config.set('core.packagesWithKeymapsDisabled', [
+      core.packages.loadAvailablePackage(availablePackage);
+      core.config.set('core.packagesWithKeymapsDisabled', [
         availablePackage.name
       ]);
-      atom.packages.activatePackage(availablePackage.name);
+      core.packages.activatePackage(availablePackage.name);
 
       expect(preloadedPackage.keymapActivated).toBe(false);
       expect(preloadedPackage.settingsActivated).toBe(true);
@@ -579,40 +579,40 @@ describe('PackageManager', () => {
   describe('::unloadPackage(name)', () => {
     describe('when the package is active', () => {
       it('throws an error', async () => {
-        const pack = await atom.packages.activatePackage('package-with-main');
-        expect(atom.packages.isPackageLoaded(pack.name)).toBeTruthy();
-        expect(atom.packages.isPackageActive(pack.name)).toBeTruthy();
+        const pack = await core.packages.activatePackage('package-with-main');
+        expect(core.packages.isPackageLoaded(pack.name)).toBeTruthy();
+        expect(core.packages.isPackageActive(pack.name)).toBeTruthy();
 
-        expect(() => atom.packages.unloadPackage(pack.name)).toThrow();
-        expect(atom.packages.isPackageLoaded(pack.name)).toBeTruthy();
-        expect(atom.packages.isPackageActive(pack.name)).toBeTruthy();
+        expect(() => core.packages.unloadPackage(pack.name)).toThrow();
+        expect(core.packages.isPackageLoaded(pack.name)).toBeTruthy();
+        expect(core.packages.isPackageActive(pack.name)).toBeTruthy();
       });
     });
 
     describe('when the package is not loaded', () => {
       it('throws an error', () => {
-        expect(atom.packages.isPackageLoaded('unloaded')).toBeFalsy();
-        expect(() => atom.packages.unloadPackage('unloaded')).toThrow();
-        expect(atom.packages.isPackageLoaded('unloaded')).toBeFalsy();
+        expect(core.packages.isPackageLoaded('unloaded')).toBeFalsy();
+        expect(() => core.packages.unloadPackage('unloaded')).toThrow();
+        expect(core.packages.isPackageLoaded('unloaded')).toBeFalsy();
       });
     });
 
     describe('when the package is loaded', () => {
       it('no longers reports it as being loaded', () => {
-        const pack = atom.packages.loadPackage('package-with-main');
-        expect(atom.packages.isPackageLoaded(pack.name)).toBeTruthy();
-        atom.packages.unloadPackage(pack.name);
-        expect(atom.packages.isPackageLoaded(pack.name)).toBeFalsy();
+        const pack = core.packages.loadPackage('package-with-main');
+        expect(core.packages.isPackageLoaded(pack.name)).toBeTruthy();
+        core.packages.unloadPackage(pack.name);
+        expect(core.packages.isPackageLoaded(pack.name)).toBeFalsy();
       });
     });
 
     it('invokes ::onDidUnloadPackage listeners with the unloaded package', () => {
-      atom.packages.loadPackage('package-with-main');
+      core.packages.loadPackage('package-with-main');
       let unloadedPackage;
-      atom.packages.onDidUnloadPackage(pack => {
+      core.packages.onDidUnloadPackage(pack => {
         unloadedPackage = pack;
       });
-      atom.packages.unloadPackage('package-with-main');
+      core.packages.unloadPackage('package-with-main');
       expect(unloadedPackage.name).toBe('package-with-main');
     });
   });
@@ -621,9 +621,9 @@ describe('PackageManager', () => {
     describe('when called multiple times', () => {
       it('it only calls activate on the package once', async () => {
         spyOn(Package.prototype, 'activateNow').andCallThrough();
-        await atom.packages.activatePackage('package-with-index');
-        await atom.packages.activatePackage('package-with-index');
-        await atom.packages.activatePackage('package-with-index');
+        await core.packages.activatePackage('package-with-index');
+        await core.packages.activatePackage('package-with-index');
+        await core.packages.activatePackage('package-with-index');
 
         expect(Package.prototype.activateNow.callCount).toBe(1);
       });
@@ -639,7 +639,7 @@ describe('PackageManager', () => {
           const mainModule = require('./fixtures/packages/package-with-main/main-module');
           spyOn(mainModule, 'activate');
 
-          const pack = await atom.packages.activatePackage('package-with-main');
+          const pack = await core.packages.activatePackage('package-with-main');
           expect(mainModule.activate).toHaveBeenCalled();
           expect(pack.mainModule).toBe(mainModule);
         });
@@ -650,7 +650,7 @@ describe('PackageManager', () => {
           const indexModule = require('./fixtures/packages/package-with-index/index');
           spyOn(indexModule, 'activate');
 
-          const pack = await atom.packages.activatePackage(
+          const pack = await core.packages.activatePackage(
             'package-with-index'
           );
           expect(indexModule.activate).toHaveBeenCalled();
@@ -660,23 +660,23 @@ describe('PackageManager', () => {
 
       it('assigns config schema, including defaults when package contains a schema', async () => {
         expect(
-          atom.config.get('package-with-config-schema.numbers.one')
+          core.config.get('package-with-config-schema.numbers.one')
         ).toBeUndefined();
 
-        await atom.packages.activatePackage('package-with-config-schema');
-        expect(atom.config.get('package-with-config-schema.numbers.one')).toBe(
+        await core.packages.activatePackage('package-with-config-schema');
+        expect(core.config.get('package-with-config-schema.numbers.one')).toBe(
           1
         );
-        expect(atom.config.get('package-with-config-schema.numbers.two')).toBe(
+        expect(core.config.get('package-with-config-schema.numbers.two')).toBe(
           2
         );
         expect(
-          atom.config.set('package-with-config-schema.numbers.one', 'nope')
+          core.config.set('package-with-config-schema.numbers.one', 'nope')
         ).toBe(false);
         expect(
-          atom.config.set('package-with-config-schema.numbers.one', '10')
+          core.config.set('package-with-config-schema.numbers.one', '10')
         ).toBe(true);
-        expect(atom.config.get('package-with-config-schema.numbers.one')).toBe(
+        expect(core.config.get('package-with-config-schema.numbers.one')).toBe(
           10
         );
       });
@@ -685,7 +685,7 @@ describe('PackageManager', () => {
         let mainModule, promise, workspaceCommandListener, registration;
 
         beforeEach(() => {
-          jasmine.attachToDOM(atom.workspace.getElement());
+          jasmine.attachToDOM(core.workspace.getElement());
           mainModule = require('./fixtures/packages/package-with-activation-commands/index');
           mainModule.activationCommandCallCount = 0;
           spyOn(mainModule, 'activate').andCallThrough();
@@ -693,13 +693,13 @@ describe('PackageManager', () => {
           workspaceCommandListener = jasmine.createSpy(
             'workspaceCommandListener'
           );
-          registration = atom.commands.add(
+          registration = core.commands.add(
             'atom-workspace',
             'activation-command',
             workspaceCommandListener
           );
 
-          promise = atom.packages.activatePackage(
+          promise = core.packages.activatePackage(
             'package-with-activation-commands'
           );
         });
@@ -714,7 +714,7 @@ describe('PackageManager', () => {
         it('defers requiring/activating the main module until an activation event bubbles to the root view', async () => {
           expect(Package.prototype.requireMainModule.callCount).toBe(0);
 
-          atom.workspace
+          core.workspace
             .getElement()
             .dispatchEvent(
               new CustomEvent('activation-command', { bubbles: true })
@@ -725,27 +725,27 @@ describe('PackageManager', () => {
         });
 
         it('triggers the activation event on all handlers registered during activation', async () => {
-          await atom.workspace.open();
+          await core.workspace.open();
 
-          const editorElement = atom.workspace
+          const editorElement = core.workspace
             .getActiveTextEditor()
             .getElement();
           const editorCommandListener = jasmine.createSpy(
             'editorCommandListener'
           );
-          atom.commands.add(
+          core.commands.add(
             'atom-text-editor',
             'activation-command',
             editorCommandListener
           );
 
-          atom.commands.dispatch(editorElement, 'activation-command');
+          core.commands.dispatch(editorElement, 'activation-command');
           expect(mainModule.activate.callCount).toBe(1);
           expect(mainModule.activationCommandCallCount).toBe(1);
           expect(editorCommandListener.callCount).toBe(1);
           expect(workspaceCommandListener.callCount).toBe(1);
 
-          atom.commands.dispatch(editorElement, 'activation-command');
+          core.commands.dispatch(editorElement, 'activation-command');
           expect(mainModule.activationCommandCallCount).toBe(2);
           expect(editorCommandListener.callCount).toBe(2);
           expect(workspaceCommandListener.callCount).toBe(2);
@@ -756,7 +756,7 @@ describe('PackageManager', () => {
           mainModule = require('./fixtures/packages/package-with-empty-activation-commands/index');
           spyOn(mainModule, 'activate').andCallThrough();
 
-          atom.packages.activatePackage(
+          core.packages.activatePackage(
             'package-with-empty-activation-commands'
           );
 
@@ -764,11 +764,11 @@ describe('PackageManager', () => {
         });
 
         it('adds a notification when the activation commands are invalid', () => {
-          spyOn(atom, 'inSpecMode').andReturn(false);
+          spyOn(core, 'inSpecMode').andReturn(false);
           const addErrorHandler = jasmine.createSpy();
-          atom.notifications.onDidAddNotification(addErrorHandler);
+          core.notifications.onDidAddNotification(addErrorHandler);
           expect(() =>
-            atom.packages.activatePackage(
+            core.packages.activatePackage(
               'package-with-invalid-activation-commands'
             )
           ).not.toThrow();
@@ -782,11 +782,11 @@ describe('PackageManager', () => {
         });
 
         it('adds a notification when the context menu is invalid', () => {
-          spyOn(atom, 'inSpecMode').andReturn(false);
+          spyOn(core, 'inSpecMode').andReturn(false);
           const addErrorHandler = jasmine.createSpy();
-          atom.notifications.onDidAddNotification(addErrorHandler);
+          core.notifications.onDidAddNotification(addErrorHandler);
           expect(() =>
-            atom.packages.activatePackage('package-with-invalid-context-menu')
+            core.packages.activatePackage('package-with-invalid-context-menu')
           ).not.toThrow();
           expect(addErrorHandler.callCount).toBe(1);
           expect(addErrorHandler.argsForCall[0][0].message).toContain(
@@ -801,7 +801,7 @@ describe('PackageManager', () => {
           let notificationEvent;
 
           await new Promise(resolve => {
-            const subscription = atom.notifications.onDidAddNotification(
+            const subscription = core.notifications.onDidAddNotification(
               event => {
                 notificationEvent = event;
                 subscription.dispose();
@@ -809,7 +809,7 @@ describe('PackageManager', () => {
               }
             );
 
-            atom.packages.activatePackage('package-with-invalid-grammar');
+            core.packages.activatePackage('package-with-invalid-grammar');
           });
 
           expect(notificationEvent.message).toContain(
@@ -824,7 +824,7 @@ describe('PackageManager', () => {
           let notificationEvent;
 
           await new Promise(resolve => {
-            const subscription = atom.notifications.onDidAddNotification(
+            const subscription = core.notifications.onDidAddNotification(
               event => {
                 notificationEvent = event;
                 subscription.dispose();
@@ -832,7 +832,7 @@ describe('PackageManager', () => {
               }
             );
 
-            atom.packages.activatePackage('package-with-invalid-settings');
+            core.packages.activatePackage('package-with-invalid-settings');
           });
 
           expect(notificationEvent.message).toContain(
@@ -848,21 +848,21 @@ describe('PackageManager', () => {
         let mainModule, promise, workspaceCommandListener, registration;
 
         beforeEach(() => {
-          jasmine.attachToDOM(atom.workspace.getElement());
-          spyOn(atom.packages, 'hasActivatedInitialPackages').andReturn(true);
+          jasmine.attachToDOM(core.workspace.getElement());
+          spyOn(core.packages, 'hasActivatedInitialPackages').andReturn(true);
           mainModule = require('./fixtures/packages/package-with-activation-commands-and-deserializers/index');
           mainModule.activationCommandCallCount = 0;
           spyOn(mainModule, 'activate').andCallThrough();
           workspaceCommandListener = jasmine.createSpy(
             'workspaceCommandListener'
           );
-          registration = atom.commands.add(
+          registration = core.commands.add(
             '.workspace',
             'activation-command-2',
             workspaceCommandListener
           );
 
-          promise = atom.packages.activatePackage(
+          promise = core.packages.activatePackage(
             'package-with-activation-commands-and-deserializers'
           );
         });
@@ -878,7 +878,7 @@ describe('PackageManager', () => {
           expect(Package.prototype.requireMainModule.callCount).toBe(0);
 
           const state1 = { deserializer: 'Deserializer1', a: 'b' };
-          expect(atom.deserializers.deserialize(state1, atom)).toEqual({
+          expect(core.deserializers.deserialize(state1, core)).toEqual({
             wasDeserializedBy: 'deserializeMethod1',
             state: state1
           });
@@ -890,7 +890,7 @@ describe('PackageManager', () => {
         it('defers requiring/activating the main module until an activation event bubbles to the root view', async () => {
           expect(Package.prototype.requireMainModule.callCount).toBe(0);
 
-          atom.workspace
+          core.workspace
             .getElement()
             .dispatchEvent(
               new CustomEvent('activation-command-2', { bubbles: true })
@@ -912,43 +912,43 @@ describe('PackageManager', () => {
         });
 
         it('defers requiring/activating the main module until an triggering of an activation hook occurs', async () => {
-          promise = atom.packages.activatePackage(
+          promise = core.packages.activatePackage(
             'package-with-activation-hooks'
           );
           expect(Package.prototype.requireMainModule.callCount).toBe(0);
-          atom.packages.triggerActivationHook(
+          core.packages.triggerActivationHook(
             'language-fictitious:grammar-used'
           );
-          atom.packages.triggerDeferredActivationHooks();
+          core.packages.triggerDeferredActivationHooks();
 
           await promise;
           expect(Package.prototype.requireMainModule.callCount).toBe(1);
         });
 
         it('does not double register activation hooks when deactivating and reactivating', async () => {
-          promise = atom.packages.activatePackage(
+          promise = core.packages.activatePackage(
             'package-with-activation-hooks'
           );
           expect(mainModule.activate.callCount).toBe(0);
-          atom.packages.triggerActivationHook(
+          core.packages.triggerActivationHook(
             'language-fictitious:grammar-used'
           );
-          atom.packages.triggerDeferredActivationHooks();
+          core.packages.triggerDeferredActivationHooks();
 
           await promise;
           expect(mainModule.activate.callCount).toBe(1);
 
-          await atom.packages.deactivatePackage(
+          await core.packages.deactivatePackage(
             'package-with-activation-hooks'
           );
 
-          promise = atom.packages.activatePackage(
+          promise = core.packages.activatePackage(
             'package-with-activation-hooks'
           );
-          atom.packages.triggerActivationHook(
+          core.packages.triggerActivationHook(
             'language-fictitious:grammar-used'
           );
-          atom.packages.triggerDeferredActivationHooks();
+          core.packages.triggerDeferredActivationHooks();
 
           await promise;
           expect(mainModule.activate.callCount).toBe(2);
@@ -960,7 +960,7 @@ describe('PackageManager', () => {
 
           expect(Package.prototype.requireMainModule.callCount).toBe(0);
 
-          await atom.packages.activatePackage(
+          await core.packages.activatePackage(
             'package-with-empty-activation-hooks'
           );
           expect(mainModule.activate.callCount).toBe(1);
@@ -968,13 +968,13 @@ describe('PackageManager', () => {
         });
 
         it('activates the package immediately if the activation hook had already been triggered', async () => {
-          atom.packages.triggerActivationHook(
+          core.packages.triggerActivationHook(
             'language-fictitious:grammar-used'
           );
-          atom.packages.triggerDeferredActivationHooks();
+          core.packages.triggerDeferredActivationHooks();
           expect(Package.prototype.requireMainModule.callCount).toBe(0);
 
-          await atom.packages.activatePackage('package-with-activation-hooks');
+          await core.packages.activatePackage('package-with-activation-hooks');
           expect(mainModule.activate.callCount).toBe(1);
           expect(Package.prototype.requireMainModule.callCount).toBe(1);
         });
@@ -989,11 +989,11 @@ describe('PackageManager', () => {
         });
 
         it('defers requiring/activating the main module until a registered opener is called', async () => {
-          promise = atom.packages.activatePackage(
+          promise = core.packages.activatePackage(
             'package-with-workspace-openers'
           );
           expect(Package.prototype.requireMainModule.callCount).toBe(0);
-          atom.workspace.open('atom://fictitious');
+          core.workspace.open('atom://fictitious');
 
           await promise;
           expect(Package.prototype.requireMainModule.callCount).toBe(1);
@@ -1004,7 +1004,7 @@ describe('PackageManager', () => {
           mainModule = require('./fixtures/packages/package-with-empty-workspace-openers/index');
           spyOn(mainModule, 'activate').andCallThrough();
 
-          atom.packages.activatePackage('package-with-empty-workspace-openers');
+          core.packages.activatePackage('package-with-empty-workspace-openers');
 
           expect(mainModule.activate.callCount).toBe(1);
         });
@@ -1016,7 +1016,7 @@ describe('PackageManager', () => {
         spyOn(console, 'error');
         spyOn(console, 'warn').andCallThrough();
         expect(() =>
-          atom.packages.activatePackage('package-without-module')
+          core.packages.activatePackage('package-without-module')
         ).not.toThrow();
         expect(console.error).not.toHaveBeenCalled();
         expect(console.warn).not.toHaveBeenCalled();
@@ -1026,43 +1026,43 @@ describe('PackageManager', () => {
     describe('when the package does not export an activate function', () => {
       it('activates the package and does not throw an exception or log a warning', async () => {
         spyOn(console, 'warn');
-        await atom.packages.activatePackage('package-with-no-activate');
+        await core.packages.activatePackage('package-with-no-activate');
         expect(console.warn).not.toHaveBeenCalled();
       });
     });
 
     it("passes the activate method the package's previously serialized state if it exists", async () => {
-      const pack = await atom.packages.activatePackage(
+      const pack = await core.packages.activatePackage(
         'package-with-serialization'
       );
       expect(pack.mainModule.someNumber).not.toBe(77);
       pack.mainModule.someNumber = 77;
-      atom.packages.serializePackage('package-with-serialization');
-      await atom.packages.deactivatePackage('package-with-serialization');
+      core.packages.serializePackage('package-with-serialization');
+      await core.packages.deactivatePackage('package-with-serialization');
 
       spyOn(pack.mainModule, 'activate').andCallThrough();
-      await atom.packages.activatePackage('package-with-serialization');
+      await core.packages.activatePackage('package-with-serialization');
       expect(pack.mainModule.activate).toHaveBeenCalledWith({ someNumber: 77 });
     });
 
     it('invokes ::onDidActivatePackage listeners with the activated package', async () => {
       let activatedPackage;
-      atom.packages.onDidActivatePackage(pack => {
+      core.packages.onDidActivatePackage(pack => {
         activatedPackage = pack;
       });
 
-      await atom.packages.activatePackage('package-with-main');
+      await core.packages.activatePackage('package-with-main');
       expect(activatedPackage.name).toBe('package-with-main');
     });
 
     describe("when the package's main module throws an error on load", () => {
       it('adds a notification instead of throwing an exception', () => {
-        spyOn(atom, 'inSpecMode').andReturn(false);
-        atom.config.set('core.disabledPackages', []);
+        spyOn(core, 'inSpecMode').andReturn(false);
+        core.config.set('core.disabledPackages', []);
         const addErrorHandler = jasmine.createSpy();
-        atom.notifications.onDidAddNotification(addErrorHandler);
+        core.notifications.onDidAddNotification(addErrorHandler);
         expect(() =>
-          atom.packages.activatePackage('package-that-throws-an-exception')
+          core.packages.activatePackage('package-that-throws-an-exception')
         ).not.toThrow();
         expect(addErrorHandler.callCount).toBe(1);
         expect(addErrorHandler.argsForCall[0][0].message).toContain(
@@ -1074,9 +1074,9 @@ describe('PackageManager', () => {
       });
 
       it('re-throws the exception in test mode', () => {
-        atom.config.set('core.disabledPackages', []);
+        core.config.set('core.disabledPackages', []);
         expect(() =>
-          atom.packages.activatePackage('package-that-throws-an-exception')
+          core.packages.activatePackage('package-that-throws-an-exception')
         ).toThrow('This package throws an exception');
       });
     });
@@ -1084,10 +1084,10 @@ describe('PackageManager', () => {
     describe('when the package is not found', () => {
       it('rejects the promise', async () => {
         spyOn(console, 'warn');
-        atom.config.set('core.disabledPackages', []);
+        core.config.set('core.disabledPackages', []);
 
         try {
-          await atom.packages.activatePackage('this-doesnt-exist');
+          await core.packages.activatePackage('this-doesnt-exist');
           expect('Error to be thrown').toBe('');
         } catch (error) {
           expect(console.warn.callCount).toBe(1);
@@ -1105,39 +1105,39 @@ describe('PackageManager', () => {
           const element2 = createTestElement('test-2');
           const element3 = createTestElement('test-3');
           expect(
-            atom.keymaps.findKeyBindings({
+            core.keymaps.findKeyBindings({
               keystrokes: 'ctrl-z',
               target: element1
             })
           ).toHaveLength(0);
           expect(
-            atom.keymaps.findKeyBindings({
+            core.keymaps.findKeyBindings({
               keystrokes: 'ctrl-z',
               target: element2
             })
           ).toHaveLength(0);
           expect(
-            atom.keymaps.findKeyBindings({
+            core.keymaps.findKeyBindings({
               keystrokes: 'ctrl-z',
               target: element3
             })
           ).toHaveLength(0);
 
-          await atom.packages.activatePackage('package-with-keymaps');
+          await core.packages.activatePackage('package-with-keymaps');
           expect(
-            atom.keymaps.findKeyBindings({
+            core.keymaps.findKeyBindings({
               keystrokes: 'ctrl-z',
               target: element1
             })[0].command
           ).toBe('test-1');
           expect(
-            atom.keymaps.findKeyBindings({
+            core.keymaps.findKeyBindings({
               keystrokes: 'ctrl-z',
               target: element2
             })[0].command
           ).toBe('test-2');
           expect(
-            atom.keymaps.findKeyBindings({
+            core.keymaps.findKeyBindings({
               keystrokes: 'ctrl-z',
               target: element3
             })
@@ -1150,27 +1150,27 @@ describe('PackageManager', () => {
           const element1 = createTestElement('test-1');
           const element3 = createTestElement('test-3');
           expect(
-            atom.keymaps.findKeyBindings({
+            core.keymaps.findKeyBindings({
               keystrokes: 'ctrl-z',
               target: element1
             })
           ).toHaveLength(0);
 
-          await atom.packages.activatePackage('package-with-keymaps-manifest');
+          await core.packages.activatePackage('package-with-keymaps-manifest');
           expect(
-            atom.keymaps.findKeyBindings({
+            core.keymaps.findKeyBindings({
               keystrokes: 'ctrl-z',
               target: element1
             })[0].command
           ).toBe('keymap-1');
           expect(
-            atom.keymaps.findKeyBindings({
+            core.keymaps.findKeyBindings({
               keystrokes: 'ctrl-n',
               target: element1
             })[0].command
           ).toBe('keymap-2');
           expect(
-            atom.keymaps.findKeyBindings({
+            core.keymaps.findKeyBindings({
               keystrokes: 'ctrl-y',
               target: element3
             })
@@ -1180,9 +1180,9 @@ describe('PackageManager', () => {
 
       describe('when the keymap file is empty', () => {
         it('does not throw an error on activation', async () => {
-          await atom.packages.activatePackage('package-with-empty-keymap');
+          await core.packages.activatePackage('package-with-empty-keymap');
           expect(
-            atom.packages.isPackageActive('package-with-empty-keymap')
+            core.packages.isPackageActive('package-with-empty-keymap')
           ).toBe(true);
         });
       });
@@ -1191,18 +1191,18 @@ describe('PackageManager', () => {
         it('does not add the keymaps', async () => {
           const element1 = createTestElement('test-1');
           expect(
-            atom.keymaps.findKeyBindings({
+            core.keymaps.findKeyBindings({
               keystrokes: 'ctrl-z',
               target: element1
             })
           ).toHaveLength(0);
 
-          atom.config.set('core.packagesWithKeymapsDisabled', [
+          core.config.set('core.packagesWithKeymapsDisabled', [
             'package-with-keymaps-manifest'
           ]);
-          await atom.packages.activatePackage('package-with-keymaps-manifest');
+          await core.packages.activatePackage('package-with-keymaps-manifest');
           expect(
-            atom.keymaps.findKeyBindings({
+            core.keymaps.findKeyBindings({
               keystrokes: 'ctrl-z',
               target: element1
             })
@@ -1212,15 +1212,15 @@ describe('PackageManager', () => {
 
       describe('when setting core.packagesWithKeymapsDisabled', () => {
         it("ignores package names in the array that aren't loaded", () => {
-          atom.packages.observePackagesWithKeymapsDisabled();
+          core.packages.observePackagesWithKeymapsDisabled();
 
           expect(() =>
-            atom.config.set('core.packagesWithKeymapsDisabled', [
+            core.config.set('core.packagesWithKeymapsDisabled', [
               'package-does-not-exist'
             ])
           ).not.toThrow();
           expect(() =>
-            atom.config.set('core.packagesWithKeymapsDisabled', [])
+            core.config.set('core.packagesWithKeymapsDisabled', [])
           ).not.toThrow();
         });
       });
@@ -1228,23 +1228,23 @@ describe('PackageManager', () => {
       describe("when the package's keymaps are disabled and re-enabled after it is activated", () => {
         it('removes and re-adds the keymaps', async () => {
           const element1 = createTestElement('test-1');
-          atom.packages.observePackagesWithKeymapsDisabled();
+          core.packages.observePackagesWithKeymapsDisabled();
 
-          await atom.packages.activatePackage('package-with-keymaps-manifest');
+          await core.packages.activatePackage('package-with-keymaps-manifest');
 
-          atom.config.set('core.packagesWithKeymapsDisabled', [
+          core.config.set('core.packagesWithKeymapsDisabled', [
             'package-with-keymaps-manifest'
           ]);
           expect(
-            atom.keymaps.findKeyBindings({
+            core.keymaps.findKeyBindings({
               keystrokes: 'ctrl-z',
               target: element1
             })
           ).toHaveLength(0);
 
-          atom.config.set('core.packagesWithKeymapsDisabled', []);
+          core.config.set('core.packagesWithKeymapsDisabled', []);
           expect(
-            atom.keymaps.findKeyBindings({
+            core.keymaps.findKeyBindings({
               keystrokes: 'ctrl-z',
               target: element1
             })[0].command
@@ -1257,7 +1257,7 @@ describe('PackageManager', () => {
 
         beforeEach(() => {
           userKeymapPath = path.join(temp.mkdirSync(), 'user-keymaps.cson');
-          spyOn(atom.keymaps, 'getUserKeymapPath').andReturn(userKeymapPath);
+          spyOn(core.keymaps, 'getUserKeymapPath').andReturn(userKeymapPath);
 
           element = createTestElement('test-1');
           jasmine.attachToDOM(element);
@@ -1271,8 +1271,8 @@ describe('PackageManager', () => {
           element.remove();
 
           // Avoid leaking user keymap subscription
-          atom.keymaps.watchSubscriptions[userKeymapPath].dispose();
-          delete atom.keymaps.watchSubscriptions[userKeymapPath];
+          core.keymaps.watchSubscriptions[userKeymapPath].dispose();
+          delete core.keymaps.watchSubscriptions[userKeymapPath];
 
           temp.cleanupSync();
         });
@@ -1282,18 +1282,18 @@ describe('PackageManager', () => {
             userKeymapPath,
             `".test-1": {"ctrl-z": "user-command"}`
           );
-          atom.keymaps.loadUserKeymap();
+          core.keymaps.loadUserKeymap();
 
-          await atom.packages.activatePackage('package-with-keymaps');
-          atom.keymaps.handleKeyboardEvent(
+          await core.packages.activatePackage('package-with-keymaps');
+          core.keymaps.handleKeyboardEvent(
             buildKeydownEvent('z', { ctrl: true, target: element })
           );
           expect(events.length).toBe(1);
           expect(events[0].type).toBe('user-command');
 
-          await atom.packages.deactivatePackage('package-with-keymaps');
-          await atom.packages.activatePackage('package-with-keymaps');
-          atom.keymaps.handleKeyboardEvent(
+          await core.packages.deactivatePackage('package-with-keymaps');
+          await core.packages.activatePackage('package-with-keymaps');
+          core.keymaps.handleKeyboardEvent(
             buildKeydownEvent('z', { ctrl: true, target: element })
           );
           expect(events.length).toBe(2);
@@ -1304,26 +1304,26 @@ describe('PackageManager', () => {
 
     describe('menu loading', () => {
       beforeEach(() => {
-        atom.contextMenu.definitions = [];
-        atom.menu.template = [];
+        core.contextMenu.definitions = [];
+        core.menu.template = [];
       });
 
       describe("when the metadata does not contain a 'menus' manifest", () => {
         it('loads all the .cson/.json files in the menus directory', async () => {
           const element = createTestElement('test-1');
-          expect(atom.contextMenu.templateForElement(element)).toEqual([]);
+          expect(core.contextMenu.templateForElement(element)).toEqual([]);
 
-          await atom.packages.activatePackage('package-with-menus');
-          expect(atom.menu.template.length).toBe(2);
-          expect(atom.menu.template[0].label).toBe('Second to Last');
-          expect(atom.menu.template[1].label).toBe('Last');
-          expect(atom.contextMenu.templateForElement(element)[0].label).toBe(
+          await core.packages.activatePackage('package-with-menus');
+          expect(core.menu.template.length).toBe(2);
+          expect(core.menu.template[0].label).toBe('Second to Last');
+          expect(core.menu.template[1].label).toBe('Last');
+          expect(core.contextMenu.templateForElement(element)[0].label).toBe(
             'Menu item 1'
           );
-          expect(atom.contextMenu.templateForElement(element)[1].label).toBe(
+          expect(core.contextMenu.templateForElement(element)[1].label).toBe(
             'Menu item 2'
           );
-          expect(atom.contextMenu.templateForElement(element)[2].label).toBe(
+          expect(core.contextMenu.templateForElement(element)[2].label).toBe(
             'Menu item 3'
           );
         });
@@ -1332,27 +1332,27 @@ describe('PackageManager', () => {
       describe("when the metadata contains a 'menus' manifest", () => {
         it('loads only the menus specified by the manifest, in the specified order', async () => {
           const element = createTestElement('test-1');
-          expect(atom.contextMenu.templateForElement(element)).toEqual([]);
+          expect(core.contextMenu.templateForElement(element)).toEqual([]);
 
-          await atom.packages.activatePackage('package-with-menus-manifest');
-          expect(atom.menu.template[0].label).toBe('Second to Last');
-          expect(atom.menu.template[1].label).toBe('Last');
-          expect(atom.contextMenu.templateForElement(element)[0].label).toBe(
+          await core.packages.activatePackage('package-with-menus-manifest');
+          expect(core.menu.template[0].label).toBe('Second to Last');
+          expect(core.menu.template[1].label).toBe('Last');
+          expect(core.contextMenu.templateForElement(element)[0].label).toBe(
             'Menu item 2'
           );
-          expect(atom.contextMenu.templateForElement(element)[1].label).toBe(
+          expect(core.contextMenu.templateForElement(element)[1].label).toBe(
             'Menu item 1'
           );
           expect(
-            atom.contextMenu.templateForElement(element)[2]
+            core.contextMenu.templateForElement(element)[2]
           ).toBeUndefined();
         });
       });
 
       describe('when the menu file is empty', () => {
         it('does not throw an error on activation', async () => {
-          await atom.packages.activatePackage('package-with-empty-menu');
-          expect(atom.packages.isPackageActive('package-with-empty-menu')).toBe(
+          await core.packages.activatePackage('package-with-empty-menu');
+          expect(core.packages.isPackageActive('package-with-empty-menu')).toBe(
             true
           );
         });
@@ -1372,16 +1372,16 @@ describe('PackageManager', () => {
             './fixtures/packages/package-with-style-sheets-manifest/styles/3.css'
           );
 
-          expect(atom.themes.stylesheetElementForId(one)).toBeNull();
-          expect(atom.themes.stylesheetElementForId(two)).toBeNull();
-          expect(atom.themes.stylesheetElementForId(three)).toBeNull();
+          expect(core.themes.stylesheetElementForId(one)).toBeNull();
+          expect(core.themes.stylesheetElementForId(two)).toBeNull();
+          expect(core.themes.stylesheetElementForId(three)).toBeNull();
 
-          await atom.packages.activatePackage(
+          await core.packages.activatePackage(
             'package-with-style-sheets-manifest'
           );
-          expect(atom.themes.stylesheetElementForId(one)).not.toBeNull();
-          expect(atom.themes.stylesheetElementForId(two)).not.toBeNull();
-          expect(atom.themes.stylesheetElementForId(three)).toBeNull();
+          expect(core.themes.stylesheetElementForId(one)).not.toBeNull();
+          expect(core.themes.stylesheetElementForId(two)).not.toBeNull();
+          expect(core.themes.stylesheetElementForId(three)).toBeNull();
           expect(
             getComputedStyle(document.querySelector('#jasmine-content'))
               .fontSize
@@ -1404,16 +1404,16 @@ describe('PackageManager', () => {
             './fixtures/packages/package-with-styles/styles/4.css'
           );
 
-          expect(atom.themes.stylesheetElementForId(one)).toBeNull();
-          expect(atom.themes.stylesheetElementForId(two)).toBeNull();
-          expect(atom.themes.stylesheetElementForId(three)).toBeNull();
-          expect(atom.themes.stylesheetElementForId(four)).toBeNull();
+          expect(core.themes.stylesheetElementForId(one)).toBeNull();
+          expect(core.themes.stylesheetElementForId(two)).toBeNull();
+          expect(core.themes.stylesheetElementForId(three)).toBeNull();
+          expect(core.themes.stylesheetElementForId(four)).toBeNull();
 
-          await atom.packages.activatePackage('package-with-styles');
-          expect(atom.themes.stylesheetElementForId(one)).not.toBeNull();
-          expect(atom.themes.stylesheetElementForId(two)).not.toBeNull();
-          expect(atom.themes.stylesheetElementForId(three)).not.toBeNull();
-          expect(atom.themes.stylesheetElementForId(four)).not.toBeNull();
+          await core.packages.activatePackage('package-with-styles');
+          expect(core.themes.stylesheetElementForId(one)).not.toBeNull();
+          expect(core.themes.stylesheetElementForId(two)).not.toBeNull();
+          expect(core.themes.stylesheetElementForId(three)).not.toBeNull();
+          expect(core.themes.stylesheetElementForId(four)).not.toBeNull();
           expect(
             getComputedStyle(document.querySelector('#jasmine-content'))
               .fontSize
@@ -1422,10 +1422,10 @@ describe('PackageManager', () => {
       });
 
       it("assigns the stylesheet's context based on the filename", async () => {
-        await atom.packages.activatePackage('package-with-styles');
+        await core.packages.activatePackage('package-with-styles');
 
         let count = 0;
-        for (let styleElement of atom.styles.getStyleElements()) {
+        for (let styleElement of core.styles.getStyleElements()) {
           if (styleElement.sourcePath.match(/1.css/)) {
             expect(styleElement.context).toBe(undefined);
             count++;
@@ -1453,15 +1453,15 @@ describe('PackageManager', () => {
 
     describe('grammar loading', () => {
       it("loads the package's grammars", async () => {
-        await atom.packages.activatePackage('package-with-grammars');
-        expect(atom.grammars.selectGrammar('a.alot').name).toBe('Alot');
-        expect(atom.grammars.selectGrammar('a.alittle').name).toBe('Alittle');
+        await core.packages.activatePackage('package-with-grammars');
+        expect(core.grammars.selectGrammar('a.alot').name).toBe('Alot');
+        expect(core.grammars.selectGrammar('a.alittle').name).toBe('Alittle');
       });
 
       it('loads any tree-sitter grammars defined in the package', async () => {
-        atom.config.set('core.useTreeSitterParsers', true);
-        await atom.packages.activatePackage('package-with-tree-sitter-grammar');
-        const grammar = atom.grammars.selectGrammar('test.somelang');
+        core.config.set('core.useTreeSitterParsers', true);
+        await core.packages.activatePackage('package-with-tree-sitter-grammar');
+        const grammar = core.grammars.selectGrammar('test.somelang');
         expect(grammar.name).toBe('Some Language');
         expect(grammar.languageModule.isFakeTreeSitterParser).toBe(true);
       });
@@ -1469,9 +1469,9 @@ describe('PackageManager', () => {
 
     describe('scoped-property loading', () => {
       it('loads the scoped properties', async () => {
-        await atom.packages.activatePackage('package-with-settings');
+        await core.packages.activatePackage('package-with-settings');
         expect(
-          atom.config.get('editor.increaseIndentPattern', {
+          core.config.get('editor.increaseIndentPattern', {
             scope: ['.source.omg']
           })
         ).toBe('^a');
@@ -1483,11 +1483,11 @@ describe('PackageManager', () => {
         const uri = 'atom://package-with-uri-handler/some/url?with=args';
         const mod = require('./fixtures/packages/package-with-uri-handler');
         spyOn(mod, 'handleURI');
-        spyOn(atom.packages, 'hasLoadedInitialPackages').andReturn(true);
-        const activationPromise = atom.packages.activatePackage(
+        spyOn(core.packages, 'hasLoadedInitialPackages').andReturn(true);
+        const activationPromise = core.packages.activatePackage(
           'package-with-uri-handler'
         );
-        atom.dispatchURIMessage(uri);
+        core.dispatchURIMessage(uri);
         await activationPromise;
         expect(mod.handleURI).toHaveBeenCalledWith(url.parse(uri, true), uri);
       });
@@ -1516,8 +1516,8 @@ describe('PackageManager', () => {
           })
         );
 
-        await atom.packages.activatePackage('package-with-consumed-services');
-        await atom.packages.activatePackage('package-with-provided-services');
+        await core.packages.activatePackage('package-with-consumed-services');
+        await core.packages.activatePackage('package-with-provided-services');
         expect(consumerModule.consumeFirstServiceV3.callCount).toBe(1);
         expect(consumerModule.consumeFirstServiceV3).toHaveBeenCalledWith(
           'first-service-v3'
@@ -1533,13 +1533,13 @@ describe('PackageManager', () => {
         consumerModule.consumeFirstServiceV4.reset();
         consumerModule.consumeSecondService.reset();
 
-        await atom.packages.deactivatePackage('package-with-provided-services');
+        await core.packages.deactivatePackage('package-with-provided-services');
         expect(firstServiceV3Disposed).toBe(true);
         expect(firstServiceV4Disposed).toBe(true);
         expect(secondServiceDisposed).toBe(true);
 
-        await atom.packages.deactivatePackage('package-with-consumed-services');
-        await atom.packages.activatePackage('package-with-provided-services');
+        await core.packages.deactivatePackage('package-with-consumed-services');
+        await core.packages.activatePackage('package-with-provided-services');
         expect(consumerModule.consumeFirstServiceV3).not.toHaveBeenCalled();
         expect(consumerModule.consumeFirstServiceV4).not.toHaveBeenCalled();
         expect(consumerModule.consumeSecondService).not.toHaveBeenCalled();
@@ -1547,21 +1547,21 @@ describe('PackageManager', () => {
 
       it('ignores provided and consumed services that do not exist', async () => {
         const addErrorHandler = jasmine.createSpy();
-        atom.notifications.onDidAddNotification(addErrorHandler);
+        core.notifications.onDidAddNotification(addErrorHandler);
 
-        await atom.packages.activatePackage(
+        await core.packages.activatePackage(
           'package-with-missing-consumed-services'
         );
-        await atom.packages.activatePackage(
+        await core.packages.activatePackage(
           'package-with-missing-provided-services'
         );
         expect(
-          atom.packages.isPackageActive(
+          core.packages.isPackageActive(
             'package-with-missing-consumed-services'
           )
         ).toBe(true);
         expect(
-          atom.packages.isPackageActive(
+          core.packages.isPackageActive(
             'package-with-missing-provided-services'
           )
         ).toBe(true);
@@ -1572,28 +1572,28 @@ describe('PackageManager', () => {
 
   describe('::serialize', () => {
     it('does not serialize packages that threw an error during activation', async () => {
-      spyOn(atom, 'inSpecMode').andReturn(false);
+      spyOn(core, 'inSpecMode').andReturn(false);
       spyOn(console, 'warn');
 
-      const badPack = await atom.packages.activatePackage(
+      const badPack = await core.packages.activatePackage(
         'package-that-throws-on-activate'
       );
       spyOn(badPack.mainModule, 'serialize').andCallThrough();
 
-      atom.packages.serialize();
+      core.packages.serialize();
       expect(badPack.mainModule.serialize).not.toHaveBeenCalled();
     });
 
     it("absorbs exceptions that are thrown by the package module's serialize method", async () => {
       spyOn(console, 'error');
 
-      await atom.packages.activatePackage('package-with-serialize-error');
-      await atom.packages.activatePackage('package-with-serialization');
-      atom.packages.serialize();
+      await core.packages.activatePackage('package-with-serialize-error');
+      await core.packages.activatePackage('package-with-serialization');
+      core.packages.serialize();
       expect(
-        atom.packages.packageStates['package-with-serialize-error']
+        core.packages.packageStates['package-with-serialize-error']
       ).toBeUndefined();
-      expect(atom.packages.packageStates['package-with-serialization']).toEqual(
+      expect(core.packages.packageStates['package-with-serialization']).toEqual(
         { someNumber: 1 }
       );
       expect(console.error).toHaveBeenCalled();
@@ -1602,84 +1602,84 @@ describe('PackageManager', () => {
 
   describe('::deactivatePackages()', () => {
     it('deactivates all packages but does not serialize them', async () => {
-      const pack1 = await atom.packages.activatePackage(
+      const pack1 = await core.packages.activatePackage(
         'package-with-deactivate'
       );
-      const pack2 = await atom.packages.activatePackage(
+      const pack2 = await core.packages.activatePackage(
         'package-with-serialization'
       );
 
       spyOn(pack1.mainModule, 'deactivate');
       spyOn(pack2.mainModule, 'serialize');
-      await atom.packages.deactivatePackages();
+      await core.packages.deactivatePackages();
       expect(pack1.mainModule.deactivate).toHaveBeenCalled();
       expect(pack2.mainModule.serialize).not.toHaveBeenCalled();
     });
   });
 
   describe('::deactivatePackage(id)', () => {
-    afterEach(() => atom.packages.unloadPackages());
+    afterEach(() => core.packages.unloadPackages());
 
     it("calls `deactivate` on the package's main module if activate was successful", async () => {
-      spyOn(atom, 'inSpecMode').andReturn(false);
+      spyOn(core, 'inSpecMode').andReturn(false);
 
-      const pack = await atom.packages.activatePackage(
+      const pack = await core.packages.activatePackage(
         'package-with-deactivate'
       );
       expect(
-        atom.packages.isPackageActive('package-with-deactivate')
+        core.packages.isPackageActive('package-with-deactivate')
       ).toBeTruthy();
       spyOn(pack.mainModule, 'deactivate').andCallThrough();
 
-      await atom.packages.deactivatePackage('package-with-deactivate');
+      await core.packages.deactivatePackage('package-with-deactivate');
       expect(pack.mainModule.deactivate).toHaveBeenCalled();
-      expect(atom.packages.isPackageActive('package-with-module')).toBeFalsy();
+      expect(core.packages.isPackageActive('package-with-module')).toBeFalsy();
 
       spyOn(console, 'warn');
-      const badPack = await atom.packages.activatePackage(
+      const badPack = await core.packages.activatePackage(
         'package-that-throws-on-activate'
       );
       expect(
-        atom.packages.isPackageActive('package-that-throws-on-activate')
+        core.packages.isPackageActive('package-that-throws-on-activate')
       ).toBeTruthy();
       spyOn(badPack.mainModule, 'deactivate').andCallThrough();
 
-      await atom.packages.deactivatePackage('package-that-throws-on-activate');
+      await core.packages.deactivatePackage('package-that-throws-on-activate');
       expect(badPack.mainModule.deactivate).not.toHaveBeenCalled();
       expect(
-        atom.packages.isPackageActive('package-that-throws-on-activate')
+        core.packages.isPackageActive('package-that-throws-on-activate')
       ).toBeFalsy();
     });
 
     it("absorbs exceptions that are thrown by the package module's deactivate method", async () => {
       spyOn(console, 'error');
-      await atom.packages.activatePackage('package-that-throws-on-deactivate');
-      await atom.packages.deactivatePackage(
+      await core.packages.activatePackage('package-that-throws-on-deactivate');
+      await core.packages.deactivatePackage(
         'package-that-throws-on-deactivate'
       );
       expect(console.error).toHaveBeenCalled();
     });
 
     it("removes the package's grammars", async () => {
-      await atom.packages.activatePackage('package-with-grammars');
-      await atom.packages.deactivatePackage('package-with-grammars');
-      expect(atom.grammars.selectGrammar('a.alot').name).toBe('Null Grammar');
-      expect(atom.grammars.selectGrammar('a.alittle').name).toBe(
+      await core.packages.activatePackage('package-with-grammars');
+      await core.packages.deactivatePackage('package-with-grammars');
+      expect(core.grammars.selectGrammar('a.alot').name).toBe('Null Grammar');
+      expect(core.grammars.selectGrammar('a.alittle').name).toBe(
         'Null Grammar'
       );
     });
 
     it("removes the package's keymaps", async () => {
-      await atom.packages.activatePackage('package-with-keymaps');
-      await atom.packages.deactivatePackage('package-with-keymaps');
+      await core.packages.activatePackage('package-with-keymaps');
+      await core.packages.deactivatePackage('package-with-keymaps');
       expect(
-        atom.keymaps.findKeyBindings({
+        core.keymaps.findKeyBindings({
           keystrokes: 'ctrl-z',
           target: createTestElement('test-1')
         })
       ).toHaveLength(0);
       expect(
-        atom.keymaps.findKeyBindings({
+        core.keymaps.findKeyBindings({
           keystrokes: 'ctrl-z',
           target: createTestElement('test-2')
         })
@@ -1687,8 +1687,8 @@ describe('PackageManager', () => {
     });
 
     it("removes the package's stylesheets", async () => {
-      await atom.packages.activatePackage('package-with-styles');
-      await atom.packages.deactivatePackage('package-with-styles');
+      await core.packages.activatePackage('package-with-styles');
+      await core.packages.deactivatePackage('package-with-styles');
 
       const one = require.resolve(
         './fixtures/packages/package-with-style-sheets-manifest/styles/1.css'
@@ -1699,71 +1699,71 @@ describe('PackageManager', () => {
       const three = require.resolve(
         './fixtures/packages/package-with-style-sheets-manifest/styles/3.css'
       );
-      expect(atom.themes.stylesheetElementForId(one)).not.toExist();
-      expect(atom.themes.stylesheetElementForId(two)).not.toExist();
-      expect(atom.themes.stylesheetElementForId(three)).not.toExist();
+      expect(core.themes.stylesheetElementForId(one)).not.toExist();
+      expect(core.themes.stylesheetElementForId(two)).not.toExist();
+      expect(core.themes.stylesheetElementForId(three)).not.toExist();
     });
 
     it("removes the package's scoped-properties", async () => {
-      await atom.packages.activatePackage('package-with-settings');
+      await core.packages.activatePackage('package-with-settings');
       expect(
-        atom.config.get('editor.increaseIndentPattern', {
+        core.config.get('editor.increaseIndentPattern', {
           scope: ['.source.omg']
         })
       ).toBe('^a');
 
-      await atom.packages.deactivatePackage('package-with-settings');
+      await core.packages.deactivatePackage('package-with-settings');
       expect(
-        atom.config.get('editor.increaseIndentPattern', {
+        core.config.get('editor.increaseIndentPattern', {
           scope: ['.source.omg']
         })
       ).toBeUndefined();
     });
 
     it('invokes ::onDidDeactivatePackage listeners with the deactivated package', async () => {
-      await atom.packages.activatePackage('package-with-main');
+      await core.packages.activatePackage('package-with-main');
 
       let deactivatedPackage;
-      atom.packages.onDidDeactivatePackage(pack => {
+      core.packages.onDidDeactivatePackage(pack => {
         deactivatedPackage = pack;
       });
 
-      await atom.packages.deactivatePackage('package-with-main');
+      await core.packages.deactivatePackage('package-with-main');
       expect(deactivatedPackage.name).toBe('package-with-main');
     });
   });
 
   describe('::activate()', () => {
     beforeEach(() => {
-      spyOn(atom, 'inSpecMode').andReturn(false);
+      spyOn(core, 'inSpecMode').andReturn(false);
       jasmine.snapshotDeprecations();
       spyOn(console, 'warn');
-      atom.packages.loadPackages();
+      core.packages.loadPackages();
 
-      const loadedPackages = atom.packages.getLoadedPackages();
+      const loadedPackages = core.packages.getLoadedPackages();
       expect(loadedPackages.length).toBeGreaterThan(0);
     });
 
     afterEach(async () => {
-      await atom.packages.deactivatePackages();
-      atom.packages.unloadPackages();
+      await core.packages.deactivatePackages();
+      core.packages.unloadPackages();
       jasmine.restoreDeprecationsSnapshot();
     });
 
     it('sets hasActivatedInitialPackages', async () => {
-      spyOn(atom.styles, 'getUserStyleSheetPath').andReturn(null);
-      spyOn(atom.packages, 'activatePackages');
-      expect(atom.packages.hasActivatedInitialPackages()).toBe(false);
+      spyOn(core.styles, 'getUserStyleSheetPath').andReturn(null);
+      spyOn(core.packages, 'activatePackages');
+      expect(core.packages.hasActivatedInitialPackages()).toBe(false);
 
-      await atom.packages.activate();
-      expect(atom.packages.hasActivatedInitialPackages()).toBe(true);
+      await core.packages.activate();
+      expect(core.packages.hasActivatedInitialPackages()).toBe(true);
     });
 
     it('activates all the packages, and none of the themes', () => {
-      const packageActivator = spyOn(atom.packages, 'activatePackages');
-      const themeActivator = spyOn(atom.themes, 'activatePackages');
+      const packageActivator = spyOn(core.packages, 'activatePackages');
+      const themeActivator = spyOn(core.themes, 'activatePackages');
 
-      atom.packages.activate();
+      core.packages.activate();
 
       expect(packageActivator).toHaveBeenCalled();
       expect(themeActivator).toHaveBeenCalled();
@@ -1778,27 +1778,27 @@ describe('PackageManager', () => {
     });
 
     it('calls callbacks registered with ::onDidActivateInitialPackages', async () => {
-      const package1 = atom.packages.loadPackage('package-with-main');
-      const package2 = atom.packages.loadPackage('package-with-index');
-      const package3 = atom.packages.loadPackage(
+      const package1 = core.packages.loadPackage('package-with-main');
+      const package2 = core.packages.loadPackage('package-with-index');
+      const package3 = core.packages.loadPackage(
         'package-with-activation-commands'
       );
-      spyOn(atom.packages, 'getLoadedPackages').andReturn([
+      spyOn(core.packages, 'getLoadedPackages').andReturn([
         package1,
         package2,
         package3
       ]);
-      spyOn(atom.themes, 'activatePackages');
+      spyOn(core.themes, 'activatePackages');
 
-      atom.packages.activate();
+      core.packages.activate();
       await new Promise(resolve =>
-        atom.packages.onDidActivateInitialPackages(resolve)
+        core.packages.onDidActivateInitialPackages(resolve)
       );
 
-      jasmine.unspy(atom.packages, 'getLoadedPackages');
-      expect(atom.packages.getActivePackages().includes(package1)).toBe(true);
-      expect(atom.packages.getActivePackages().includes(package2)).toBe(true);
-      expect(atom.packages.getActivePackages().includes(package3)).toBe(false);
+      jasmine.unspy(core.packages, 'getLoadedPackages');
+      expect(core.packages.getActivePackages().includes(package1)).toBe(true);
+      expect(core.packages.getActivePackages().includes(package2)).toBe(true);
+      expect(core.packages.getActivePackages().includes(package3)).toBe(false);
     });
   });
 
@@ -1806,53 +1806,53 @@ describe('PackageManager', () => {
     describe('with packages', () => {
       it('enables a disabled package', async () => {
         const packageName = 'package-with-main';
-        atom.config.pushAtKeyPath('core.disabledPackages', packageName);
-        atom.packages.observeDisabledPackages();
-        expect(atom.config.get('core.disabledPackages')).toContain(packageName);
+        core.config.pushAtKeyPath('core.disabledPackages', packageName);
+        core.packages.observeDisabledPackages();
+        expect(core.config.get('core.disabledPackages')).toContain(packageName);
 
-        const pack = atom.packages.enablePackage(packageName);
+        const pack = core.packages.enablePackage(packageName);
         await new Promise(resolve =>
-          atom.packages.onDidActivatePackage(resolve)
+          core.packages.onDidActivatePackage(resolve)
         );
 
-        expect(atom.packages.getLoadedPackages()).toContain(pack);
-        expect(atom.packages.getActivePackages()).toContain(pack);
-        expect(atom.config.get('core.disabledPackages')).not.toContain(
+        expect(core.packages.getLoadedPackages()).toContain(pack);
+        expect(core.packages.getActivePackages()).toContain(pack);
+        expect(core.config.get('core.disabledPackages')).not.toContain(
           packageName
         );
       });
 
       it('disables an enabled package', async () => {
         const packageName = 'package-with-main';
-        const pack = await atom.packages.activatePackage(packageName);
+        const pack = await core.packages.activatePackage(packageName);
 
-        atom.packages.observeDisabledPackages();
-        expect(atom.config.get('core.disabledPackages')).not.toContain(
+        core.packages.observeDisabledPackages();
+        expect(core.config.get('core.disabledPackages')).not.toContain(
           packageName
         );
         await new Promise(resolve => {
-          atom.packages.onDidDeactivatePackage(resolve);
-          atom.packages.disablePackage(packageName);
+          core.packages.onDidDeactivatePackage(resolve);
+          core.packages.disablePackage(packageName);
         });
 
-        expect(atom.packages.getActivePackages()).not.toContain(pack);
-        expect(atom.config.get('core.disabledPackages')).toContain(packageName);
+        expect(core.packages.getActivePackages()).not.toContain(pack);
+        expect(core.config.get('core.disabledPackages')).toContain(packageName);
       });
 
       it('returns null if the package cannot be loaded', () => {
         spyOn(console, 'warn');
-        expect(atom.packages.enablePackage('this-doesnt-exist')).toBeNull();
+        expect(core.packages.enablePackage('this-doesnt-exist')).toBeNull();
         expect(console.warn.callCount).toBe(1);
       });
 
       it('does not disable an already disabled package', () => {
         const packageName = 'package-with-main';
-        atom.config.pushAtKeyPath('core.disabledPackages', packageName);
-        atom.packages.observeDisabledPackages();
-        expect(atom.config.get('core.disabledPackages')).toContain(packageName);
+        core.config.pushAtKeyPath('core.disabledPackages', packageName);
+        core.packages.observeDisabledPackages();
+        expect(core.config.get('core.disabledPackages')).toContain(packageName);
 
-        atom.packages.disablePackage(packageName);
-        const packagesDisabled = atom.config
+        core.packages.disablePackage(packageName);
+        const packagesDisabled = core.config
           .get('core.disabledPackages')
           .filter(pack => pack === packageName);
         expect(packagesDisabled.length).toEqual(1);
@@ -1860,36 +1860,36 @@ describe('PackageManager', () => {
     });
 
     describe('with themes', () => {
-      beforeEach(() => atom.themes.activateThemes());
-      afterEach(() => atom.themes.deactivateThemes());
+      beforeEach(() => core.themes.activateThemes());
+      afterEach(() => core.themes.deactivateThemes());
 
       it('enables and disables a theme', async () => {
         const packageName = 'theme-with-package-file';
-        expect(atom.config.get('core.themes')).not.toContain(packageName);
-        expect(atom.config.get('core.disabledPackages')).not.toContain(
+        expect(core.config.get('core.themes')).not.toContain(packageName);
+        expect(core.config.get('core.disabledPackages')).not.toContain(
           packageName
         );
 
         // enabling of theme
-        const pack = atom.packages.enablePackage(packageName);
+        const pack = core.packages.enablePackage(packageName);
         await new Promise(resolve =>
-          atom.packages.onDidActivatePackage(resolve)
+          core.packages.onDidActivatePackage(resolve)
         );
-        expect(atom.packages.isPackageActive(packageName)).toBe(true);
-        expect(atom.config.get('core.themes')).toContain(packageName);
-        expect(atom.config.get('core.disabledPackages')).not.toContain(
+        expect(core.packages.isPackageActive(packageName)).toBe(true);
+        expect(core.config.get('core.themes')).toContain(packageName);
+        expect(core.config.get('core.disabledPackages')).not.toContain(
           packageName
         );
 
         await new Promise(resolve => {
-          atom.themes.onDidChangeActiveThemes(resolve);
-          atom.packages.disablePackage(packageName);
+          core.themes.onDidChangeActiveThemes(resolve);
+          core.packages.disablePackage(packageName);
         });
 
-        expect(atom.packages.getActivePackages()).not.toContain(pack);
-        expect(atom.config.get('core.themes')).not.toContain(packageName);
-        expect(atom.config.get('core.themes')).not.toContain(packageName);
-        expect(atom.config.get('core.disabledPackages')).not.toContain(
+        expect(core.packages.getActivePackages()).not.toContain(pack);
+        expect(core.config.get('core.themes')).not.toContain(packageName);
+        expect(core.config.get('core.themes')).not.toContain(packageName);
+        expect(core.config.get('core.disabledPackages')).not.toContain(
           packageName
         );
       });
@@ -1906,13 +1906,13 @@ describe('PackageManager', () => {
         'package-symlinked'
       );
       const destination = path.join(
-        atom.packages.getPackageDirPaths()[0],
+        core.packages.getPackageDirPaths()[0],
         'package-symlinked'
       );
       if (!fs.isDirectorySync(destination)) {
         fs.symlinkSync(packageSymLinkedSource, destination, 'junction');
       }
-      const availablePackages = atom.packages.getAvailablePackageNames();
+      const availablePackages = core.packages.getAvailablePackageNames();
       expect(availablePackages.includes('package-symlinked')).toBe(true);
       fs.removeSync(destination);
     });

--- a/spec/package-spec.js
+++ b/spec/package-spec.js
@@ -7,18 +7,18 @@ describe('Package', function() {
   const build = (constructor, packagePath) =>
     new constructor({
       path: packagePath,
-      packageManager: atom.packages,
-      config: atom.config,
-      styleManager: atom.styles,
-      notificationManager: atom.notifications,
-      keymapManager: atom.keymaps,
-      commandRegistry: atom.command,
-      grammarRegistry: atom.grammars,
-      themeManager: atom.themes,
-      menuManager: atom.menu,
-      contextMenuManager: atom.contextMenu,
-      deserializerManager: atom.deserializers,
-      viewRegistry: atom.views
+      packageManager: core.packages,
+      config: core.config,
+      styleManager: core.styles,
+      notificationManager: core.notifications,
+      keymapManager: core.keymaps,
+      commandRegistry: core.command,
+      grammarRegistry: core.grammars,
+      themeManager: core.themes,
+      menuManager: core.menu,
+      contextMenuManager: core.contextMenu,
+      deserializerManager: core.deserializers,
+      viewRegistry: core.views
     });
 
   const buildPackage = packagePath => build(Package, packagePath);
@@ -27,14 +27,14 @@ describe('Package', function() {
 
   describe('when the package contains incompatible native modules', function() {
     beforeEach(function() {
-      atom.packages.devMode = false;
+      core.packages.devMode = false;
       mockLocalStorage();
     });
 
-    afterEach(() => (atom.packages.devMode = true));
+    afterEach(() => (core.packages.devMode = true));
 
     it('does not activate it', function() {
-      const packagePath = atom.project
+      const packagePath = core.project
         .getDirectories()[0]
         .resolve('packages/package-with-incompatible-native-module');
       const pack = buildPackage(packagePath);
@@ -46,7 +46,7 @@ describe('Package', function() {
     });
 
     it('detects the package as incompatible even if .node file is loaded conditionally', function() {
-      const packagePath = atom.project
+      const packagePath = core.project
         .getDirectories()[0]
         .resolve(
           'packages/package-with-incompatible-native-module-loaded-conditionally'
@@ -60,14 +60,14 @@ describe('Package', function() {
     });
 
     it("utilizes _atomModuleCache if present to determine the package's native dependencies", function() {
-      let packagePath = atom.project
+      let packagePath = core.project
         .getDirectories()[0]
         .resolve('packages/package-with-ignored-incompatible-native-module');
       let pack = buildPackage(packagePath);
       expect(pack.getNativeModuleDependencyPaths().length).toBe(1); // doesn't see the incompatible module
       expect(pack.isCompatible()).toBe(true);
 
-      packagePath = __guard__(atom.project.getDirectories()[0], x =>
+      packagePath = __guard__(core.project.getDirectories()[0], x =>
         x.resolve('packages/package-with-cached-incompatible-native-module')
       );
       pack = buildPackage(packagePath);
@@ -75,7 +75,7 @@ describe('Package', function() {
     });
 
     it('caches the incompatible native modules in local storage', function() {
-      const packagePath = atom.project
+      const packagePath = core.project
         .getDirectories()[0]
         .resolve('packages/package-with-incompatible-native-module');
       expect(buildPackage(packagePath).isCompatible()).toBe(false);
@@ -88,16 +88,16 @@ describe('Package', function() {
     });
 
     it('logs an error to the console describing the problem', function() {
-      const packagePath = atom.project
+      const packagePath = core.project
         .getDirectories()[0]
         .resolve('packages/package-with-incompatible-native-module');
 
       spyOn(console, 'warn');
-      spyOn(atom.notifications, 'addFatalError');
+      spyOn(core.notifications, 'addFatalError');
 
       buildPackage(packagePath).activateNow();
 
-      expect(atom.notifications.addFatalError).not.toHaveBeenCalled();
+      expect(core.notifications.addFatalError).not.toHaveBeenCalled();
       expect(console.warn.callCount).toBe(1);
       expect(console.warn.mostRecentCall.args[0]).toContain(
         'it requires one or more incompatible native modules (native-module)'
@@ -107,14 +107,14 @@ describe('Package', function() {
 
   describe('::rebuild()', function() {
     beforeEach(function() {
-      atom.packages.devMode = false;
+      core.packages.devMode = false;
       mockLocalStorage();
     });
 
-    afterEach(() => (atom.packages.devMode = true));
+    afterEach(() => (core.packages.devMode = true));
 
     it('returns a promise resolving to the results of `apm rebuild`', function() {
-      const packagePath = __guard__(atom.project.getDirectories()[0], x =>
+      const packagePath = __guard__(core.project.getDirectories()[0], x =>
         x.resolve('packages/package-with-index')
       );
       const pack = buildPackage(packagePath);
@@ -143,7 +143,7 @@ describe('Package', function() {
     });
 
     it('persists build failures in local storage', function() {
-      const packagePath = __guard__(atom.project.getDirectories()[0], x =>
+      const packagePath = __guard__(core.project.getDirectories()[0], x =>
         x.resolve('packages/package-with-index')
       );
       const pack = buildPackage(packagePath);
@@ -177,7 +177,7 @@ describe('Package', function() {
     });
 
     it('sets cached incompatible modules to an empty array when the rebuild completes (there may be a build error, but rebuilding *deletes* native modules)', function() {
-      const packagePath = __guard__(atom.project.getDirectories()[0], x =>
+      const packagePath = __guard__(core.project.getDirectories()[0], x =>
         x.resolve('packages/package-with-incompatible-native-module')
       );
       const pack = buildPackage(packagePath);
@@ -217,7 +217,7 @@ describe('Package', function() {
         expect(getComputedStyle(editorElement).paddingBottom).not.toBe(
           '1234px'
         );
-        const themePath = __guard__(atom.project.getDirectories()[0], x =>
+        const themePath = __guard__(core.project.getDirectories()[0], x =>
           x.resolve('packages/theme-with-index-css')
         );
         theme = buildThemePackage(themePath);
@@ -229,7 +229,7 @@ describe('Package', function() {
         expect(getComputedStyle(editorElement).paddingBottom).not.toBe(
           '1234px'
         );
-        const themePath = __guard__(atom.project.getDirectories()[0], x =>
+        const themePath = __guard__(core.project.getDirectories()[0], x =>
           x.resolve('packages/theme-with-index-less')
         );
         theme = buildThemePackage(themePath);
@@ -244,7 +244,7 @@ describe('Package', function() {
         expect(getComputedStyle(editorElement).paddingRight).not.toBe('102px');
         expect(getComputedStyle(editorElement).paddingBottom).not.toBe('103px');
 
-        const themePath = __guard__(atom.project.getDirectories()[0], x =>
+        const themePath = __guard__(core.project.getDirectories()[0], x =>
           x.resolve('packages/theme-with-package-file')
         );
         theme = buildThemePackage(themePath);
@@ -260,7 +260,7 @@ describe('Package', function() {
         expect(getComputedStyle(editorElement).paddingRight).not.toBe('20px');
         expect(getComputedStyle(editorElement).paddingBottom).not.toBe('30px');
 
-        const themePath = __guard__(atom.project.getDirectories()[0], x =>
+        const themePath = __guard__(core.project.getDirectories()[0], x =>
           x.resolve('packages/theme-without-package-file')
         );
         theme = buildThemePackage(themePath);
@@ -272,7 +272,7 @@ describe('Package', function() {
 
     describe('reloading a theme', function() {
       beforeEach(function() {
-        const themePath = __guard__(atom.project.getDirectories()[0], x =>
+        const themePath = __guard__(core.project.getDirectories()[0], x =>
           x.resolve('packages/theme-with-package-file')
         );
         theme = buildThemePackage(themePath);
@@ -288,7 +288,7 @@ describe('Package', function() {
 
     describe('events', function() {
       beforeEach(function() {
-        const themePath = __guard__(atom.project.getDirectories()[0], x =>
+        const themePath = __guard__(core.project.getDirectories()[0], x =>
           x.resolve('packages/theme-with-package-file')
         );
         theme = buildThemePackage(themePath);
@@ -308,10 +308,10 @@ describe('Package', function() {
     let [packagePath, metadata] = [];
 
     beforeEach(function() {
-      packagePath = __guard__(atom.project.getDirectories()[0], x =>
+      packagePath = __guard__(core.project.getDirectories()[0], x =>
         x.resolve('packages/package-with-different-directory-name')
       );
-      metadata = atom.packages.loadPackageMetadata(packagePath, true);
+      metadata = core.packages.loadPackageMetadata(packagePath, true);
     });
 
     it('uses the package name defined in package.json', () =>
@@ -320,7 +320,7 @@ describe('Package', function() {
 
   describe('the initialize() hook', function() {
     it('gets called when the package is activated', function() {
-      const packagePath = atom.project
+      const packagePath = core.project
         .getDirectories()[0]
         .resolve('packages/package-with-deserializers');
       const pack = buildPackage(packagePath);
@@ -334,7 +334,7 @@ describe('Package', function() {
     });
 
     it('gets called when a deserializer is used', function() {
-      const packagePath = atom.project
+      const packagePath = core.project
         .getDirectories()[0]
         .resolve('packages/package-with-deserializers');
       const pack = buildPackage(packagePath);
@@ -343,7 +343,7 @@ describe('Package', function() {
       spyOn(mainModule, 'initialize');
       pack.load();
       expect(mainModule.initialize).not.toHaveBeenCalled();
-      atom.deserializers.deserialize({ deserializer: 'Deserializer1', a: 'b' });
+      core.deserializers.deserialize({ deserializer: 'Deserializer1', a: 'b' });
       expect(mainModule.initialize).toHaveBeenCalled();
     });
   });

--- a/spec/pane-axis-element-spec.js
+++ b/spec/pane-axis-element-spec.js
@@ -4,21 +4,21 @@ const Pane = require('../src/pane');
 
 const buildPane = () =>
   new Pane({
-    applicationDelegate: atom.applicationDelegate,
-    config: atom.config,
-    deserializerManager: atom.deserializers,
-    notificationManager: atom.notifications,
-    viewRegistry: atom.views
+    applicationDelegate: core.applicationDelegate,
+    config: core.config,
+    deserializerManager: core.deserializers,
+    notificationManager: core.notifications,
+    viewRegistry: core.views
   });
 
 describe('PaneAxisElement', () =>
   it('correctly subscribes and unsubscribes to the underlying model events on attach/detach', function() {
     const container = new PaneContainer({
-      config: atom.config,
-      applicationDelegate: atom.applicationDelegate,
-      viewRegistry: atom.views
+      config: core.config,
+      applicationDelegate: core.applicationDelegate,
+      viewRegistry: core.views
     });
-    const axis = new PaneAxis({}, atom.views);
+    const axis = new PaneAxis({}, core.views);
     axis.setContainer(container);
     const axisElement = axis.getElement();
 

--- a/spec/pane-container-element-spec.js
+++ b/spec/pane-container-element-spec.js
@@ -3,10 +3,10 @@ const PaneAxis = require('../src/pane-axis');
 
 const params = {
   location: 'center',
-  config: atom.config,
-  confirm: atom.confirm.bind(atom),
-  viewRegistry: atom.views,
-  applicationDelegate: atom.applicationDelegate
+  config: core.config,
+  confirm: core.confirm.bind(core),
+  viewRegistry: core.views,
+  applicationDelegate: core.applicationDelegate
 };
 
 describe('PaneContainerElement', function() {
@@ -17,22 +17,22 @@ describe('PaneContainerElement', function() {
           child.nodeName.toLowerCase()
         );
 
-      const paneAxis = new PaneAxis({}, atom.views);
+      const paneAxis = new PaneAxis({}, core.views);
       var paneAxisElement = paneAxis.getElement();
 
       expect(childTagNames()).toEqual([]);
 
-      paneAxis.addChild(new PaneAxis({}, atom.views));
+      paneAxis.addChild(new PaneAxis({}, core.views));
       expect(childTagNames()).toEqual(['atom-pane-axis']);
 
-      paneAxis.addChild(new PaneAxis({}, atom.views));
+      paneAxis.addChild(new PaneAxis({}, core.views));
       expect(childTagNames()).toEqual([
         'atom-pane-axis',
         'atom-pane-resize-handle',
         'atom-pane-axis'
       ]);
 
-      paneAxis.addChild(new PaneAxis({}, atom.views));
+      paneAxis.addChild(new PaneAxis({}, core.views));
       expect(childTagNames()).toEqual([
         'atom-pane-axis',
         'atom-pane-resize-handle',
@@ -255,11 +255,11 @@ describe('PaneContainerElement', function() {
         expect(leftPane.getFlexScale()).toBe(1);
         expect(rightPane.getFlexScale()).toBe(1);
 
-        atom.commands.dispatch(leftPane.getElement(), 'pane:increase-size');
+        core.commands.dispatch(leftPane.getElement(), 'pane:increase-size');
         expect(leftPane.getFlexScale()).toBe(1.1);
         expect(rightPane.getFlexScale()).toBe(1);
 
-        atom.commands.dispatch(rightPane.getElement(), 'pane:increase-size');
+        core.commands.dispatch(rightPane.getElement(), 'pane:increase-size');
         expect(leftPane.getFlexScale()).toBe(1.1);
         expect(rightPane.getFlexScale()).toBe(1.1);
       }));
@@ -269,11 +269,11 @@ describe('PaneContainerElement', function() {
         expect(leftPane.getFlexScale()).toBe(1);
         expect(rightPane.getFlexScale()).toBe(1);
 
-        atom.commands.dispatch(leftPane.getElement(), 'pane:decrease-size');
+        core.commands.dispatch(leftPane.getElement(), 'pane:decrease-size');
         expect(leftPane.getFlexScale()).toBe(1 / 1.1);
         expect(rightPane.getFlexScale()).toBe(1);
 
-        atom.commands.dispatch(rightPane.getElement(), 'pane:decrease-size');
+        core.commands.dispatch(rightPane.getElement(), 'pane:decrease-size');
         expect(leftPane.getFlexScale()).toBe(1 / 1.1);
         expect(rightPane.getFlexScale()).toBe(1 / 1.1);
       }));
@@ -291,10 +291,10 @@ describe('PaneContainerElement', function() {
       it('does not increases the size of the pane', function() {
         expect(singlePane.getFlexScale()).toBe(1);
 
-        atom.commands.dispatch(singlePane.getElement(), 'pane:increase-size');
+        core.commands.dispatch(singlePane.getElement(), 'pane:increase-size');
         expect(singlePane.getFlexScale()).toBe(1);
 
-        atom.commands.dispatch(singlePane.getElement(), 'pane:increase-size');
+        core.commands.dispatch(singlePane.getElement(), 'pane:increase-size');
         expect(singlePane.getFlexScale()).toBe(1);
       }));
 
@@ -302,10 +302,10 @@ describe('PaneContainerElement', function() {
       it('does not decreases the size of the pane', function() {
         expect(singlePane.getFlexScale()).toBe(1);
 
-        atom.commands.dispatch(singlePane.getElement(), 'pane:decrease-size');
+        core.commands.dispatch(singlePane.getElement(), 'pane:decrease-size');
         expect(singlePane.getFlexScale()).toBe(1);
 
-        atom.commands.dispatch(singlePane.getElement(), 'pane:decrease-size');
+        core.commands.dispatch(singlePane.getElement(), 'pane:decrease-size');
         expect(singlePane.getFlexScale()).toBe(1);
       }));
   });

--- a/spec/pane-container-spec.js
+++ b/spec/pane-container-spec.js
@@ -4,15 +4,15 @@ describe('PaneContainer', () => {
   let confirm, params;
 
   beforeEach(() => {
-    confirm = spyOn(atom.applicationDelegate, 'confirm').andCallFake(
+    confirm = spyOn(core.applicationDelegate, 'confirm').andCallFake(
       (options, callback) => callback(0)
     );
     params = {
       location: 'center',
-      config: atom.config,
-      deserializerManager: atom.deserializers,
-      applicationDelegate: atom.applicationDelegate,
-      viewRegistry: atom.views
+      config: core.config,
+      deserializerManager: core.deserializers,
+      applicationDelegate: core.applicationDelegate,
+      viewRegistry: core.views
     };
   });
 
@@ -29,7 +29,7 @@ describe('PaneContainer', () => {
           return { deserializer: 'Item' };
         }
       }
-      atom.deserializers.add(Item);
+      core.deserializers.add(Item);
 
       containerA = new PaneContainer(params);
       pane1A = containerA.getActivePane();
@@ -43,7 +43,7 @@ describe('PaneContainer', () => {
       expect(pane3A.focused).toBe(true);
 
       const containerB = new PaneContainer(params);
-      containerB.deserialize(containerA.serialize(), atom.deserializers);
+      containerB.deserialize(containerA.serialize(), core.deserializers);
       const pane3B = containerB.getPanes()[2];
       expect(pane3B.focused).toBe(true);
     });
@@ -53,7 +53,7 @@ describe('PaneContainer', () => {
       expect(containerA.getActivePane()).toBe(pane3A);
 
       const containerB = new PaneContainer(params);
-      containerB.deserialize(containerA.serialize(), atom.deserializers);
+      containerB.deserialize(containerA.serialize(), core.deserializers);
       const pane3B = containerB.getPanes()[2];
       expect(containerB.getActivePane()).toBe(pane3B);
     });
@@ -63,7 +63,7 @@ describe('PaneContainer', () => {
       const state = containerA.serialize();
       state.activePaneId = -22;
       const containerB = new PaneContainer(params);
-      containerB.deserialize(state, atom.deserializers);
+      containerB.deserialize(state, core.deserializers);
       expect(containerB.getActivePane()).toBe(containerB.getPanes()[0]);
     });
 
@@ -76,7 +76,7 @@ describe('PaneContainer', () => {
         it('leaves the empty panes intact', () => {
           const state = containerA.serialize();
           const containerB = new PaneContainer(params);
-          containerB.deserialize(state, atom.deserializers);
+          containerB.deserialize(state, core.deserializers);
           const [leftPane, column] = containerB.getRoot().getChildren();
           const [topPane, bottomPane] = column.getChildren();
 
@@ -87,11 +87,11 @@ describe('PaneContainer', () => {
 
       describe("if the 'core.destroyEmptyPanes' config option is true", () =>
         it('removes empty panes on deserialization', () => {
-          atom.config.set('core.destroyEmptyPanes', true);
+          core.config.set('core.destroyEmptyPanes', true);
 
           const state = containerA.serialize();
           const containerB = new PaneContainer(params);
-          containerB.deserialize(state, atom.deserializers);
+          containerB.deserialize(state, core.deserializers);
           const [leftPane, rightPane] = containerB.getRoot().getChildren();
 
           expect(leftPane.getItems().length).toBe(1);

--- a/spec/pane-element-spec.js
+++ b/spec/pane-element-spec.js
@@ -4,14 +4,14 @@ describe('PaneElement', function() {
   let [paneElement, container, containerElement, pane] = [];
 
   beforeEach(function() {
-    spyOn(atom.applicationDelegate, 'open');
+    spyOn(core.applicationDelegate, 'open');
 
     container = new PaneContainer({
       location: 'center',
-      config: atom.config,
-      confirm: atom.confirm.bind(atom),
-      viewRegistry: atom.views,
-      applicationDelegate: atom.applicationDelegate
+      config: core.config,
+      confirm: core.confirm.bind(core),
+      viewRegistry: core.views,
+      applicationDelegate: core.applicationDelegate
     });
     containerElement = container.getElement();
     pane = container.getActivePane();
@@ -74,10 +74,10 @@ describe('PaneElement', function() {
     });
 
     describe('if the active item is a model object', () =>
-      it('retrieves the associated view from atom.views and appends it to the itemViews div', function() {
+      it('retrieves the associated view from core.views and appends it to the itemViews div', function() {
         class TestModel {}
 
-        atom.views.addViewProvider(TestModel, function(model) {
+        core.views.addViewProvider(TestModel, function(model) {
           const view = document.createElement('div');
           view.model = model;
           return view;
@@ -203,7 +203,7 @@ describe('PaneElement', function() {
       it("removes the model's associated view", function() {
         class TestModel {}
 
-        atom.views.addViewProvider(TestModel, function(model) {
+        core.views.addViewProvider(TestModel, function(model) {
           const view = document.createElement('div');
           model.element = view;
           view.model = model;
@@ -301,8 +301,8 @@ describe('PaneElement', function() {
           { path: '/fake2' }
         ]);
         paneElement.dispatchEvent(event);
-        expect(atom.applicationDelegate.open.callCount).toBe(1);
-        expect(atom.applicationDelegate.open.argsForCall[0][0]).toEqual({
+        expect(core.applicationDelegate.open.callCount).toBe(1);
+        expect(core.applicationDelegate.open.argsForCall[0][0]).toEqual({
           pathsToOpen: ['/fake1', '/fake2'],
           here: true
         });
@@ -312,7 +312,7 @@ describe('PaneElement', function() {
       it('does nothing', function() {
         const event = buildDragEvent('drop', []);
         paneElement.dispatchEvent(event);
-        expect(atom.applicationDelegate.open).not.toHaveBeenCalled();
+        expect(core.applicationDelegate.open).not.toHaveBeenCalled();
       }));
   });
 

--- a/spec/pane-spec.js
+++ b/spec/pane-spec.js
@@ -63,9 +63,9 @@ describe('Pane', () => {
   }
 
   beforeEach(() => {
-    confirm = spyOn(atom.applicationDelegate, 'confirm');
-    showSaveDialog = spyOn(atom.applicationDelegate, 'showSaveDialog');
-    deserializerDisposable = atom.deserializers.add(Item);
+    confirm = spyOn(core.applicationDelegate, 'confirm');
+    showSaveDialog = spyOn(core.applicationDelegate, 'showSaveDialog');
+    deserializerDisposable = core.deserializers.add(Item);
   });
 
   afterEach(() => {
@@ -75,10 +75,10 @@ describe('Pane', () => {
   function paneParams(params) {
     return extend(
       {
-        applicationDelegate: atom.applicationDelegate,
-        config: atom.config,
-        deserializerManager: atom.deserializers,
-        notificationManager: atom.notifications
+        applicationDelegate: core.applicationDelegate,
+        config: core.config,
+        deserializerManager: core.deserializers,
+        notificationManager: core.notifications
       },
       params
     );
@@ -107,8 +107,8 @@ describe('Pane', () => {
     beforeEach(() => {
       container = new PaneContainer({
         location: 'center',
-        config: atom.config,
-        applicationDelegate: atom.applicationDelegate
+        config: core.config,
+        applicationDelegate: core.applicationDelegate
       });
       container.getActivePane().splitRight();
       [pane1, pane2] = container.getPanes();
@@ -195,8 +195,8 @@ describe('Pane', () => {
     it('throws an exception if the item is already present on a pane', () => {
       const item = new Item('A');
       const container = new PaneContainer({
-        config: atom.config,
-        applicationDelegate: atom.applicationDelegate
+        config: core.config,
+        applicationDelegate: core.applicationDelegate
       });
       const pane1 = container.getActivePane();
       pane1.addItem(item);
@@ -355,7 +355,7 @@ describe('Pane', () => {
     let pane = null;
 
     beforeEach(() => {
-      pane = atom.workspace.getActivePane();
+      pane = core.workspace.getActivePane();
     });
 
     it('changes the pending item', () => {
@@ -370,7 +370,7 @@ describe('Pane', () => {
     let callbackCalled = false;
 
     beforeEach(() => {
-      pane = atom.workspace.getActivePane();
+      pane = core.workspace.getActivePane();
       callbackCalled = false;
     });
 
@@ -399,13 +399,13 @@ describe('Pane', () => {
       const pendingSpy = jasmine.createSpy('onItemDidTerminatePendingState');
       const destroySpy = jasmine.createSpy('onWillDestroyItem');
 
-      await atom.workspace.open('sample.txt', { pending: true });
-      pane = atom.workspace.getActivePane();
+      await core.workspace.open('sample.txt', { pending: true });
+      pane = core.workspace.getActivePane();
 
       pane.onItemDidTerminatePendingState(pendingSpy);
       pane.onWillDestroyItem(destroySpy);
 
-      await atom.workspace.open('sample.js', { pending: true });
+      await core.workspace.open('sample.js', { pending: true });
 
       expect(destroySpy).toHaveBeenCalled();
       expect(pendingSpy).not.toHaveBeenCalled();
@@ -570,9 +570,9 @@ describe('Pane', () => {
 
     it('does nothing if prevented', () => {
       const container = new PaneContainer({
-        config: atom.config,
-        deserializerManager: atom.deserializers,
-        applicationDelegate: atom.applicationDelegate
+        config: core.config,
+        deserializerManager: core.deserializers,
+        applicationDelegate: core.applicationDelegate
       });
 
       pane.setContainer(container);
@@ -596,7 +596,7 @@ describe('Pane', () => {
 
     it('invokes ::onWillDestroyItem() and PaneContainer::onWillDestroyPaneItem observers before destroying the item', async () => {
       jasmine.useRealClock();
-      pane.container = new PaneContainer({ config: atom.config, confirm });
+      pane.container = new PaneContainer({ config: core.config, confirm });
       const events = [];
 
       pane.onWillDestroyItem(async event => {
@@ -748,7 +748,7 @@ describe('Pane', () => {
     describe('when the last item is destroyed', () => {
       describe("when the 'core.destroyEmptyPanes' config option is false (the default)", () => {
         it('does not destroy the pane, but leaves it in place with empty items', () => {
-          expect(atom.config.get('core.destroyEmptyPanes')).toBe(false);
+          expect(core.config.get('core.destroyEmptyPanes')).toBe(false);
           for (let item of pane.getItems()) {
             pane.destroyItem(item);
           }
@@ -761,7 +761,7 @@ describe('Pane', () => {
 
       describe("when the 'core.destroyEmptyPanes' config option is true", () => {
         it('destroys the pane', () => {
-          atom.config.set('core.destroyEmptyPanes', true);
+          core.config.set('core.destroyEmptyPanes', true);
           for (let item of pane.getItems()) {
             pane.destroyItem(item);
           }
@@ -928,7 +928,7 @@ describe('Pane', () => {
         };
 
         waitsFor(done => {
-          const subscription = atom.notifications.onDidAddNotification(function(
+          const subscription = core.notifications.onDidAddNotification(function(
             notification
           ) {
             expect(notification.getType()).toBe('warning');
@@ -952,7 +952,7 @@ describe('Pane', () => {
         };
 
         waitsFor(done => {
-          const subscription = atom.notifications.onDidAddNotification(function(
+          const subscription = core.notifications.onDidAddNotification(function(
             notification
           ) {
             expect(notification.getType()).toBe('warning');
@@ -1015,7 +1015,7 @@ describe('Pane', () => {
         };
 
         waitsFor(done => {
-          const subscription = atom.notifications.onDidAddNotification(function(
+          const subscription = core.notifications.onDidAddNotification(function(
             notification
           ) {
             expect(notification.getType()).toBe('warning');
@@ -1087,7 +1087,7 @@ describe('Pane', () => {
     let item1, item2, item3, item4, item5;
 
     beforeEach(() => {
-      container = new PaneContainer({ config: atom.config, confirm });
+      container = new PaneContainer({ config: core.config, confirm });
       pane1 = container.getActivePane();
       pane1.addItems([new Item('A'), new Item('B'), new Item('C')]);
       pane2 = pane1.splitRight({ items: [new Item('D'), new Item('E')] });
@@ -1141,7 +1141,7 @@ describe('Pane', () => {
 
       describe("when the 'core.destroyEmptyPanes' config option is true", () => {
         it('destroys the pane, but not the item', () => {
-          atom.config.set('core.destroyEmptyPanes', true);
+          core.config.set('core.destroyEmptyPanes', true);
           pane2.moveItemToPane(item4, pane1, 0);
           expect(pane2.isDestroyed()).toBe(true);
           expect(item4.isDestroyed()).toBe(false);
@@ -1175,9 +1175,9 @@ describe('Pane', () => {
 
     beforeEach(() => {
       container = new PaneContainer({
-        config: atom.config,
+        config: core.config,
         confirm,
-        deserializerManager: atom.deserializers
+        deserializerManager: core.deserializers
       });
       pane1 = container.getActivePane();
       item1 = new Item('A');
@@ -1421,7 +1421,7 @@ describe('Pane', () => {
       showSaveDialog.andCallFake((options, callback) => callback(undefined));
 
       await pane.close();
-      expect(atom.applicationDelegate.confirm).toHaveBeenCalled();
+      expect(core.applicationDelegate.confirm).toHaveBeenCalled();
       expect(confirm.callCount).toBe(1);
       expect(item1.saveAs).not.toHaveBeenCalled();
       expect(pane.isDestroyed()).toBe(false);
@@ -1433,8 +1433,8 @@ describe('Pane', () => {
       beforeEach(() => {
         pane = new Pane({
           items: [new Item('A'), new Item('B')],
-          applicationDelegate: atom.applicationDelegate,
-          config: atom.config
+          applicationDelegate: core.applicationDelegate,
+          config: core.config
         });
         [item1] = pane.getItems();
 
@@ -1461,7 +1461,7 @@ describe('Pane', () => {
         }); // click cancel
 
         await pane.close();
-        expect(atom.applicationDelegate.confirm).toHaveBeenCalled();
+        expect(core.applicationDelegate.confirm).toHaveBeenCalled();
         expect(confirmations).toBe(2);
         expect(item1.save).toHaveBeenCalled();
         expect(pane.isDestroyed()).toBe(false);
@@ -1479,10 +1479,10 @@ describe('Pane', () => {
         showSaveDialog.andCallFake((options, callback) => callback('new/path'));
 
         await pane.close();
-        expect(atom.applicationDelegate.confirm).toHaveBeenCalled();
+        expect(core.applicationDelegate.confirm).toHaveBeenCalled();
         expect(confirmations).toBe(2);
         expect(
-          atom.applicationDelegate.showSaveDialog.mostRecentCall.args[0]
+          core.applicationDelegate.showSaveDialog.mostRecentCall.args[0]
         ).toEqual({});
         expect(item1.save).toHaveBeenCalled();
         expect(item1.saveAs).toHaveBeenCalled();
@@ -1510,10 +1510,10 @@ describe('Pane', () => {
         showSaveDialog.andCallFake((options, callback) => callback('new/path'));
 
         await pane.close();
-        expect(atom.applicationDelegate.confirm).toHaveBeenCalled();
+        expect(core.applicationDelegate.confirm).toHaveBeenCalled();
         expect(confirmations).toBe(3);
         expect(
-          atom.applicationDelegate.showSaveDialog.mostRecentCall.args[0]
+          core.applicationDelegate.showSaveDialog.mostRecentCall.args[0]
         ).toEqual({});
         expect(item1.save).toHaveBeenCalled();
         expect(item1.saveAs).toHaveBeenCalled();
@@ -1526,7 +1526,7 @@ describe('Pane', () => {
     let container, pane1, pane2;
 
     beforeEach(() => {
-      container = new PaneContainer({ config: atom.config, confirm });
+      container = new PaneContainer({ config: core.config, confirm });
       pane1 = container.root;
       pane1.addItems([new Item('A'), new Item('B')]);
       pane2 = pane1.splitRight();
@@ -1584,14 +1584,14 @@ describe('Pane', () => {
     let editor1, pane, eventCount;
 
     beforeEach(async () => {
-      editor1 = await atom.workspace.open('sample.txt', { pending: true });
-      pane = atom.workspace.getActivePane();
+      editor1 = await core.workspace.open('sample.txt', { pending: true });
+      pane = core.workspace.getActivePane();
       eventCount = 0;
       editor1.onDidTerminatePendingState(() => eventCount++);
     });
 
     it('does not open file in pending state by default', async () => {
-      await atom.workspace.open('sample.js');
+      await core.workspace.open('sample.js');
       expect(pane.getPendingItem()).toBeNull();
     });
 
@@ -1656,20 +1656,20 @@ describe('Pane', () => {
     });
 
     it('can serialize and deserialize the pane and all its items', () => {
-      const newPane = Pane.deserialize(pane.serialize(), atom);
+      const newPane = Pane.deserialize(pane.serialize(), core);
       expect(newPane.getItems()).toEqual(pane.getItems());
     });
 
     it('restores the active item on deserialization', () => {
       pane.activateItemAtIndex(1);
-      const newPane = Pane.deserialize(pane.serialize(), atom);
+      const newPane = Pane.deserialize(pane.serialize(), core);
       expect(newPane.getActiveItem()).toEqual(newPane.itemAtIndex(1));
     });
 
     it("restores the active item when it doesn't implement getURI()", () => {
       pane.items[1].getURI = null;
       pane.activateItemAtIndex(1);
-      const newPane = Pane.deserialize(pane.serialize(), atom);
+      const newPane = Pane.deserialize(pane.serialize(), core);
       expect(newPane.getActiveItem()).toEqual(newPane.itemAtIndex(1));
     });
 
@@ -1678,7 +1678,7 @@ describe('Pane', () => {
       pane.addItem(unserializable, { index: 0 });
       pane.items[2].getURI = null;
       pane.activateItemAtIndex(2);
-      const newPane = Pane.deserialize(pane.serialize(), atom);
+      const newPane = Pane.deserialize(pane.serialize(), core);
       expect(newPane.getActiveItem()).toEqual(newPane.itemAtIndex(1));
     });
 
@@ -1687,34 +1687,34 @@ describe('Pane', () => {
       const unserializable = {};
       pane.activateItem(unserializable);
 
-      const newPane = Pane.deserialize(pane.serialize(), atom);
+      const newPane = Pane.deserialize(pane.serialize(), core);
       expect(newPane.getActiveItem()).toEqual(pane.itemAtIndex(0));
       expect(newPane.getItems().length).toBe(pane.getItems().length - 1);
     });
 
     it("includes the pane's focus state in the serialized state", () => {
       pane.focus();
-      const newPane = Pane.deserialize(pane.serialize(), atom);
+      const newPane = Pane.deserialize(pane.serialize(), core);
       expect(newPane.focused).toBe(true);
     });
 
     it('can serialize and deserialize the order of the items in the itemStack', () => {
       const [item1, item2, item3] = pane.getItems();
       pane.itemStack = [item3, item1, item2];
-      const newPane = Pane.deserialize(pane.serialize(), atom);
+      const newPane = Pane.deserialize(pane.serialize(), core);
       expect(newPane.itemStack).toEqual(pane.itemStack);
       expect(newPane.itemStack[2]).toEqual(item2);
     });
 
     it('builds the itemStack if the itemStack is not serialized', () => {
-      const newPane = Pane.deserialize(pane.serialize(), atom);
+      const newPane = Pane.deserialize(pane.serialize(), core);
       expect(newPane.getItems()).toEqual(newPane.itemStack);
     });
 
     it('rebuilds the itemStack if items.length does not match itemStack.length', () => {
       const [, item2, item3] = pane.getItems();
       pane.itemStack = [item2, item3];
-      const newPane = Pane.deserialize(pane.serialize(), atom);
+      const newPane = Pane.deserialize(pane.serialize(), core);
       expect(newPane.getItems()).toEqual(newPane.itemStack);
     });
 
@@ -1724,7 +1724,7 @@ describe('Pane', () => {
       const unserializable = {};
       pane.activateItem(unserializable);
 
-      const newPane = Pane.deserialize(pane.serialize(), atom);
+      const newPane = Pane.deserialize(pane.serialize(), core);
       expect(newPane.itemStack).toEqual([item2, item1, item3]);
     });
   });

--- a/spec/panel-container-element-spec.js
+++ b/spec/panel-container-element-spec.js
@@ -31,12 +31,12 @@ describe('PanelContainerElement', () => {
   beforeEach(() => {
     jasmineContent = document.body.querySelector('#jasmine-content');
 
-    atom.views.addViewProvider(TestPanelContainerItem, model =>
+    core.views.addViewProvider(TestPanelContainerItem, model =>
       TestPanelContainerItemElement.initialize(model)
     );
 
     container = new PanelContainer({
-      viewRegistry: atom.views,
+      viewRegistry: core.views,
       location: 'left'
     });
     element = container.getElement();
@@ -57,15 +57,15 @@ describe('PanelContainerElement', () => {
     it('allows panels to be inserted at any position', () => {
       const panel1 = new Panel(
         { item: new TestPanelContainerItem(), priority: 10 },
-        atom.views
+        core.views
       );
       const panel2 = new Panel(
         { item: new TestPanelContainerItem(), priority: 5 },
-        atom.views
+        core.views
       );
       const panel3 = new Panel(
         { item: new TestPanelContainerItem(), priority: 8 },
-        atom.views
+        core.views
       );
 
       container.addPanel(panel1);
@@ -83,7 +83,7 @@ describe('PanelContainerElement', () => {
 
         const panel1 = new Panel(
           { item: new TestPanelContainerItem() },
-          atom.views
+          core.views
         );
         container.addPanel(panel1);
         expect(element.childNodes.length).toBe(1);
@@ -95,7 +95,7 @@ describe('PanelContainerElement', () => {
 
         const panel2 = new Panel(
           { item: new TestPanelContainerItem() },
-          atom.views
+          core.views
         );
         container.addPanel(panel2);
         expect(element.childNodes.length).toBe(2);
@@ -113,7 +113,7 @@ describe('PanelContainerElement', () => {
     describe('when the container is at the bottom location', () => {
       beforeEach(() => {
         container = new PanelContainer({
-          viewRegistry: atom.views,
+          viewRegistry: core.views,
           location: 'bottom'
         });
         element = container.getElement();
@@ -125,7 +125,7 @@ describe('PanelContainerElement', () => {
 
         const panel1 = new Panel(
           { item: new TestPanelContainerItem(), className: 'one' },
-          atom.views
+          core.views
         );
         container.addPanel(panel1);
         expect(element.childNodes.length).toBe(1);
@@ -137,7 +137,7 @@ describe('PanelContainerElement', () => {
 
         const panel2 = new Panel(
           { item: new TestPanelContainerItem(), className: 'two' },
-          atom.views
+          core.views
         );
         container.addPanel(panel2);
         expect(element.childNodes.length).toBe(2);
@@ -155,7 +155,7 @@ describe('PanelContainerElement', () => {
   describe('when the container is modal', () => {
     beforeEach(() => {
       container = new PanelContainer({
-        viewRegistry: atom.views,
+        viewRegistry: core.views,
         location: 'modal'
       });
       element = container.getElement();
@@ -165,7 +165,7 @@ describe('PanelContainerElement', () => {
     it('allows only one panel to be visible at a time', () => {
       const panel1 = new Panel(
         { item: new TestPanelContainerItem() },
-        atom.views
+        core.views
       );
       container.addPanel(panel1);
 
@@ -173,7 +173,7 @@ describe('PanelContainerElement', () => {
 
       const panel2 = new Panel(
         { item: new TestPanelContainerItem() },
-        atom.views
+        core.views
       );
       container.addPanel(panel2);
 
@@ -189,7 +189,7 @@ describe('PanelContainerElement', () => {
     it("adds the 'modal' class to panels", () => {
       const panel1 = new Panel(
         { item: new TestPanelContainerItem() },
-        atom.views
+        core.views
       );
       container.addPanel(panel1);
 
@@ -209,7 +209,7 @@ describe('PanelContainerElement', () => {
             autoFocus: autoFocus,
             visible: false
           },
-          atom.views
+          core.views
         );
 
         container.addPanel(panel);

--- a/spec/panel-container-spec.js
+++ b/spec/panel-container-spec.js
@@ -9,7 +9,7 @@ describe('PanelContainer', () => {
   class TestPanelItem {}
 
   beforeEach(() => {
-    container = new PanelContainer({ viewRegistry: atom.views });
+    container = new PanelContainer({ viewRegistry: core.views });
   });
 
   describe('::addPanel(panel)', () => {
@@ -17,11 +17,11 @@ describe('PanelContainer', () => {
       const addPanelSpy = jasmine.createSpy();
       container.onDidAddPanel(addPanelSpy);
 
-      const panel1 = new Panel({ item: new TestPanelItem() }, atom.views);
+      const panel1 = new Panel({ item: new TestPanelItem() }, core.views);
       container.addPanel(panel1);
       expect(addPanelSpy).toHaveBeenCalledWith({ panel: panel1, index: 0 });
 
-      const panel2 = new Panel({ item: new TestPanelItem() }, atom.views);
+      const panel2 = new Panel({ item: new TestPanelItem() }, core.views);
       container.addPanel(panel2);
       expect(addPanelSpy).toHaveBeenCalledWith({ panel: panel2, index: 1 });
     });
@@ -32,9 +32,9 @@ describe('PanelContainer', () => {
       const removePanelSpy = jasmine.createSpy();
       container.onDidRemovePanel(removePanelSpy);
 
-      const panel1 = new Panel({ item: new TestPanelItem() }, atom.views);
+      const panel1 = new Panel({ item: new TestPanelItem() }, core.views);
       container.addPanel(panel1);
-      const panel2 = new Panel({ item: new TestPanelItem() }, atom.views);
+      const panel2 = new Panel({ item: new TestPanelItem() }, core.views);
       container.addPanel(panel2);
 
       expect(removePanelSpy).not.toHaveBeenCalled();
@@ -51,13 +51,13 @@ describe('PanelContainer', () => {
     it('destroys the container and all of its panels', () => {
       const destroyedPanels = [];
 
-      const panel1 = new Panel({ item: new TestPanelItem() }, atom.views);
+      const panel1 = new Panel({ item: new TestPanelItem() }, core.views);
       panel1.onDidDestroy(() => {
         destroyedPanels.push(panel1);
       });
       container.addPanel(panel1);
 
-      const panel2 = new Panel({ item: new TestPanelItem() }, atom.views);
+      const panel2 = new Panel({ item: new TestPanelItem() }, core.views);
       panel2.onDidDestroy(() => {
         destroyedPanels.push(panel2);
       });
@@ -76,7 +76,7 @@ describe('PanelContainer', () => {
       beforeEach(() => {
         // 'left' logic is the same as 'top'
         container = new PanelContainer({ location: 'left' });
-        initialPanel = new Panel({ item: new TestPanelItem() }, atom.views);
+        initialPanel = new Panel({ item: new TestPanelItem() }, core.views);
         container.addPanel(initialPanel);
       });
 
@@ -86,7 +86,7 @@ describe('PanelContainer', () => {
           container.onDidAddPanel(addPanelSpy);
           const panel = new Panel(
             { item: new TestPanelItem(), priority: 0 },
-            atom.views
+            core.views
           );
           container.addPanel(panel);
 
@@ -100,14 +100,14 @@ describe('PanelContainer', () => {
           const addPanelSpy = jasmine.createSpy();
           let panel = new Panel(
             { item: new TestPanelItem(), priority: 1000 },
-            atom.views
+            core.views
           );
           container.addPanel(panel);
 
           container.onDidAddPanel(addPanelSpy);
           panel = new Panel(
             { item: new TestPanelItem(), priority: 101 },
-            atom.views
+            core.views
           );
           container.addPanel(panel);
 
@@ -122,7 +122,7 @@ describe('PanelContainer', () => {
       beforeEach(() => {
         // 'bottom' logic is the same as 'right'
         container = new PanelContainer({ location: 'right' });
-        initialPanel = new Panel({ item: new TestPanelItem() }, atom.views);
+        initialPanel = new Panel({ item: new TestPanelItem() }, core.views);
         container.addPanel(initialPanel);
       });
 
@@ -132,7 +132,7 @@ describe('PanelContainer', () => {
           container.onDidAddPanel(addPanelSpy);
           const panel = new Panel(
             { item: new TestPanelItem(), priority: 1000 },
-            atom.views
+            core.views
           );
           container.addPanel(panel);
 
@@ -147,7 +147,7 @@ describe('PanelContainer', () => {
           container.onDidAddPanel(addPanelSpy);
           const panel = new Panel(
             { item: new TestPanelItem(), priority: 0 },
-            atom.views
+            core.views
           );
           container.addPanel(panel);
 

--- a/spec/panel-spec.js
+++ b/spec/panel-spec.js
@@ -13,7 +13,7 @@ describe('Panel', () => {
   }
 
   it("adds the item's element as a child of the panel", () => {
-    const panel = new Panel({ item: new TestPanelItem() }, atom.views);
+    const panel = new Panel({ item: new TestPanelItem() }, core.views);
     const element = panel.getElement();
     expect(element.tagName.toLowerCase()).toBe('atom-panel');
     expect(element.firstChild).toBe(panel.getItem().getElement());
@@ -21,7 +21,7 @@ describe('Panel', () => {
 
   describe('destroying the panel', () => {
     it('removes the element when the panel is destroyed', () => {
-      const panel = new Panel({ item: new TestPanelItem() }, atom.views);
+      const panel = new Panel({ item: new TestPanelItem() }, core.views);
       const element = panel.getElement();
       const jasmineContent = document.getElementById('jasmine-content');
       jasmineContent.appendChild(element);
@@ -33,7 +33,7 @@ describe('Panel', () => {
 
     it('does not try to remove the element twice', () => {
       const item = new TestPanelItem();
-      const panel = new Panel({ item }, atom.views);
+      const panel = new Panel({ item }, core.views);
       const element = panel.getElement();
       const jasmineContent = document.getElementById('jasmine-content');
       jasmineContent.appendChild(element);
@@ -52,7 +52,7 @@ describe('Panel', () => {
 
   describe('changing panel visibility', () => {
     it('notifies observers added with onDidChangeVisible', () => {
-      const panel = new Panel({ item: new TestPanelItem() }, atom.views);
+      const panel = new Panel({ item: new TestPanelItem() }, core.views);
 
       const spy = jasmine.createSpy();
       panel.onDidChangeVisible(spy);
@@ -74,14 +74,14 @@ describe('Panel', () => {
     it('initially renders panel created with visible: false', () => {
       const panel = new Panel(
         { visible: false, item: new TestPanelItem() },
-        atom.views
+        core.views
       );
       const element = panel.getElement();
       expect(element.style.display).toBe('none');
     });
 
     it('hides and shows the panel element when Panel::hide() and Panel::show() are called', () => {
-      const panel = new Panel({ item: new TestPanelItem() }, atom.views);
+      const panel = new Panel({ item: new TestPanelItem() }, core.views);
       const element = panel.getElement();
       expect(element.style.display).not.toBe('none');
 
@@ -97,7 +97,7 @@ describe('Panel', () => {
     it('initially renders panel created with visible: false', () => {
       const panel = new Panel(
         { className: 'some classes', item: new TestPanelItem() },
-        atom.views
+        core.views
       );
       const element = panel.getElement();
 

--- a/spec/project-spec.js
+++ b/spec/project-spec.js
@@ -9,9 +9,9 @@ const GitRepository = require('../src/git-repository');
 
 describe('Project', () => {
   beforeEach(() => {
-    const directory = atom.project.getDirectories()[0];
+    const directory = core.project.getDirectories()[0];
     const paths = directory ? [directory.resolve('dir')] : [null];
-    atom.project.setPaths(paths);
+    core.project.setPaths(paths);
 
     // Wait for project's service consumers to be asynchronously added
     waits(1);
@@ -36,23 +36,23 @@ describe('Project', () => {
 
     it("does not deserialize paths to directories that don't exist", () => {
       deserializedProject = new Project({
-        notificationManager: atom.notifications,
-        packageManager: atom.packages,
-        confirm: atom.confirm,
-        grammarRegistry: atom.grammars
+        notificationManager: core.notifications,
+        packageManager: core.packages,
+        confirm: core.confirm,
+        grammarRegistry: core.grammars
       });
-      const state = atom.project.serialize();
+      const state = core.project.serialize();
       state.paths.push('/directory/that/does/not/exist');
 
       let err = null;
       waitsForPromise(() =>
-        deserializedProject.deserialize(state, atom.deserializers).catch(e => {
+        deserializedProject.deserialize(state, core.deserializers).catch(e => {
           err = e;
         })
       );
 
       runs(() => {
-        expect(deserializedProject.getPaths()).toEqual(atom.project.getPaths());
+        expect(deserializedProject.getPaths()).toEqual(core.project.getPaths());
         expect(err.missingProjectPaths).toEqual([
           '/directory/that/does/not/exist'
         ]);
@@ -64,20 +64,20 @@ describe('Project', () => {
       fs.mkdirSync(childPath);
 
       deserializedProject = new Project({
-        notificationManager: atom.notifications,
-        packageManager: atom.packages,
-        confirm: atom.confirm,
-        grammarRegistry: atom.grammars
+        notificationManager: core.notifications,
+        packageManager: core.packages,
+        confirm: core.confirm,
+        grammarRegistry: core.grammars
       });
-      atom.project.setPaths([childPath]);
-      const state = atom.project.serialize();
+      core.project.setPaths([childPath]);
+      const state = core.project.serialize();
 
       fs.rmdirSync(childPath);
       fs.writeFileSync(childPath, 'surprise!\n');
 
       let err = null;
       waitsForPromise(() =>
-        deserializedProject.deserialize(state, atom.deserializers).catch(e => {
+        deserializedProject.deserialize(state, core.deserializers).catch(e => {
           err = e;
         })
       );
@@ -89,22 +89,22 @@ describe('Project', () => {
     });
 
     it('does not include unretained buffers in the serialized state', () => {
-      waitsForPromise(() => atom.project.bufferForPath('a'));
+      waitsForPromise(() => core.project.bufferForPath('a'));
 
       runs(() => {
-        expect(atom.project.getBuffers().length).toBe(1);
+        expect(core.project.getBuffers().length).toBe(1);
 
         deserializedProject = new Project({
-          notificationManager: atom.notifications,
-          packageManager: atom.packages,
-          confirm: atom.confirm,
-          grammarRegistry: atom.grammars
+          notificationManager: core.notifications,
+          packageManager: core.packages,
+          confirm: core.confirm,
+          grammarRegistry: core.grammars
         });
       });
 
       waitsForPromise(() =>
         deserializedProject.deserialize(
-          atom.project.serialize({ isUnloading: false })
+          core.project.serialize({ isUnloading: false })
         )
       );
 
@@ -112,21 +112,21 @@ describe('Project', () => {
     });
 
     it('listens for destroyed events on deserialized buffers and removes them when they are destroyed', () => {
-      waitsForPromise(() => atom.workspace.open('a'));
+      waitsForPromise(() => core.workspace.open('a'));
 
       runs(() => {
-        expect(atom.project.getBuffers().length).toBe(1);
+        expect(core.project.getBuffers().length).toBe(1);
         deserializedProject = new Project({
-          notificationManager: atom.notifications,
-          packageManager: atom.packages,
-          confirm: atom.confirm,
-          grammarRegistry: atom.grammars
+          notificationManager: core.notifications,
+          packageManager: core.packages,
+          confirm: core.confirm,
+          grammarRegistry: core.grammars
         });
       });
 
       waitsForPromise(() =>
         deserializedProject.deserialize(
-          atom.project.serialize({ isUnloading: false })
+          core.project.serialize({ isUnloading: false })
         )
       );
 
@@ -143,22 +143,22 @@ describe('Project', () => {
         'file.txt'
       );
 
-      waitsForPromise(() => atom.workspace.open(pathToOpen));
+      waitsForPromise(() => core.workspace.open(pathToOpen));
 
       runs(() => {
-        expect(atom.project.getBuffers().length).toBe(1);
+        expect(core.project.getBuffers().length).toBe(1);
         fs.mkdirSync(pathToOpen);
         deserializedProject = new Project({
-          notificationManager: atom.notifications,
-          packageManager: atom.packages,
-          confirm: atom.confirm,
-          grammarRegistry: atom.grammars
+          notificationManager: core.notifications,
+          packageManager: core.packages,
+          confirm: core.confirm,
+          grammarRegistry: core.grammars
         });
       });
 
       waitsForPromise(() =>
         deserializedProject.deserialize(
-          atom.project.serialize({ isUnloading: false })
+          core.project.serialize({ isUnloading: false })
         )
       );
 
@@ -175,22 +175,22 @@ describe('Project', () => {
       );
       fs.writeFileSync(pathToOpen, '');
 
-      waitsForPromise(() => atom.workspace.open(pathToOpen));
+      waitsForPromise(() => core.workspace.open(pathToOpen));
 
       runs(() => {
-        expect(atom.project.getBuffers().length).toBe(1);
+        expect(core.project.getBuffers().length).toBe(1);
         fs.chmodSync(pathToOpen, '000');
         deserializedProject = new Project({
-          notificationManager: atom.notifications,
-          packageManager: atom.packages,
-          confirm: atom.confirm,
-          grammarRegistry: atom.grammars
+          notificationManager: core.notifications,
+          packageManager: core.packages,
+          confirm: core.confirm,
+          grammarRegistry: core.grammars
         });
       });
 
       waitsForPromise(() =>
         deserializedProject.deserialize(
-          atom.project.serialize({ isUnloading: false })
+          core.project.serialize({ isUnloading: false })
         )
       );
 
@@ -204,22 +204,22 @@ describe('Project', () => {
       );
       fs.writeFileSync(pathToOpen, '');
 
-      waitsForPromise(() => atom.workspace.open(pathToOpen));
+      waitsForPromise(() => core.workspace.open(pathToOpen));
 
       runs(() => {
-        expect(atom.project.getBuffers().length).toBe(1);
+        expect(core.project.getBuffers().length).toBe(1);
         fs.unlinkSync(pathToOpen);
         deserializedProject = new Project({
-          notificationManager: atom.notifications,
-          packageManager: atom.packages,
-          confirm: atom.confirm,
-          grammarRegistry: atom.grammars
+          notificationManager: core.notifications,
+          packageManager: core.packages,
+          confirm: core.confirm,
+          grammarRegistry: core.grammars
         });
       });
 
       waitsForPromise(() =>
         deserializedProject.deserialize(
-          atom.project.serialize({ isUnloading: false })
+          core.project.serialize({ isUnloading: false })
         )
       );
 
@@ -232,23 +232,23 @@ describe('Project', () => {
         'file.txt'
       );
 
-      waitsForPromise(() => atom.workspace.open(pathToOpen));
+      waitsForPromise(() => core.workspace.open(pathToOpen));
 
       runs(() => {
-        atom.workspace.getActiveTextEditor().setText('unsaved\n');
-        expect(atom.project.getBuffers().length).toBe(1);
+        core.workspace.getActiveTextEditor().setText('unsaved\n');
+        expect(core.project.getBuffers().length).toBe(1);
 
         deserializedProject = new Project({
-          notificationManager: atom.notifications,
-          packageManager: atom.packages,
-          confirm: atom.confirm,
-          grammarRegistry: atom.grammars
+          notificationManager: core.notifications,
+          packageManager: core.packages,
+          confirm: core.confirm,
+          grammarRegistry: core.grammars
         });
       });
 
       waitsForPromise(() =>
         deserializedProject.deserialize(
-          atom.project.serialize({ isUnloading: false })
+          core.project.serialize({ isUnloading: false })
         )
       );
 
@@ -260,28 +260,28 @@ describe('Project', () => {
     });
 
     it('serializes marker layers and history only if Atom is quitting', () => {
-      waitsForPromise(() => atom.workspace.open('a'));
+      waitsForPromise(() => core.workspace.open('a'));
 
       let bufferA = null;
       let layerA = null;
       let markerA = null;
 
       runs(() => {
-        bufferA = atom.project.getBuffers()[0];
+        bufferA = core.project.getBuffers()[0];
         layerA = bufferA.addMarkerLayer({ persistent: true });
         markerA = layerA.markPosition([0, 3]);
         bufferA.append('!');
         notQuittingProject = new Project({
-          notificationManager: atom.notifications,
-          packageManager: atom.packages,
-          confirm: atom.confirm,
-          grammarRegistry: atom.grammars
+          notificationManager: core.notifications,
+          packageManager: core.packages,
+          confirm: core.confirm,
+          grammarRegistry: core.grammars
         });
       });
 
       waitsForPromise(() =>
         notQuittingProject.deserialize(
-          atom.project.serialize({ isUnloading: false })
+          core.project.serialize({ isUnloading: false })
         )
       );
 
@@ -292,16 +292,16 @@ describe('Project', () => {
         ).toBeUndefined();
         expect(notQuittingProject.getBuffers()[0].undo()).toBe(false);
         quittingProject = new Project({
-          notificationManager: atom.notifications,
-          packageManager: atom.packages,
-          confirm: atom.confirm,
-          grammarRegistry: atom.grammars
+          notificationManager: core.notifications,
+          packageManager: core.packages,
+          confirm: core.confirm,
+          grammarRegistry: core.grammars
         });
       });
 
       waitsForPromise(() =>
         quittingProject.deserialize(
-          atom.project.serialize({ isUnloading: true })
+          core.project.serialize({ isUnloading: true })
         )
       );
 
@@ -317,12 +317,12 @@ describe('Project', () => {
   describe('when an editor is saved and the project has no path', () => {
     it("sets the project's path to the saved file's parent directory", () => {
       const tempFile = temp.openSync().path;
-      atom.project.setPaths([]);
-      expect(atom.project.getPaths()[0]).toBeUndefined();
+      core.project.setPaths([]);
+      expect(core.project.getPaths()[0]).toBeUndefined();
       let editor = null;
 
       waitsForPromise(() =>
-        atom.workspace.open().then(o => {
+        core.workspace.open().then(o => {
           editor = o;
         })
       );
@@ -330,7 +330,7 @@ describe('Project', () => {
       waitsForPromise(() => editor.saveAs(tempFile));
 
       runs(() =>
-        expect(atom.project.getPaths()[0]).toBe(path.dirname(tempFile))
+        expect(core.project.getPaths()[0]).toBe(path.dirname(tempFile))
       );
     });
   });
@@ -338,7 +338,7 @@ describe('Project', () => {
   describe('.replace', () => {
     let projectSpecification, projectPath1, projectPath2;
     beforeEach(() => {
-      atom.project.replace(null);
+      core.project.replace(null);
       projectPath1 = temp.mkdirSync('project-path1');
       projectPath2 = temp.mkdirSync('project-path2');
       projectSpecification = {
@@ -350,20 +350,20 @@ describe('Project', () => {
       };
     });
     it('sets a project specification', () => {
-      expect(atom.config.get('baz')).toBeUndefined();
-      atom.project.replace(projectSpecification);
-      expect(atom.project.getPaths()).toEqual([projectPath1, projectPath2]);
-      expect(atom.config.get('baz')).toBe('buzz');
+      expect(core.config.get('baz')).toBeUndefined();
+      core.project.replace(projectSpecification);
+      expect(core.project.getPaths()).toEqual([projectPath1, projectPath2]);
+      expect(core.config.get('baz')).toBe('buzz');
     });
 
     it('clears a project through replace with no params', () => {
-      expect(atom.config.get('baz')).toBeUndefined();
-      atom.project.replace(projectSpecification);
-      expect(atom.config.get('baz')).toBe('buzz');
-      expect(atom.project.getPaths()).toEqual([projectPath1, projectPath2]);
-      atom.project.replace();
-      expect(atom.config.get('baz')).toBeUndefined();
-      expect(atom.project.getPaths()).toEqual([]);
+      expect(core.config.get('baz')).toBeUndefined();
+      core.project.replace(projectSpecification);
+      expect(core.config.get('baz')).toBe('buzz');
+      expect(core.project.getPaths()).toEqual([projectPath1, projectPath2]);
+      core.project.replace();
+      expect(core.config.get('baz')).toBeUndefined();
+      expect(core.project.getPaths()).toEqual([]);
     });
 
     it('responds to change of project specification', () => {
@@ -371,11 +371,11 @@ describe('Project', () => {
       const callback = () => {
         wasCalled = true;
       };
-      atom.project.onDidReplace(callback);
-      atom.project.replace(projectSpecification);
+      core.project.onDidReplace(callback);
+      core.project.replace(projectSpecification);
       expect(wasCalled).toBe(true);
       wasCalled = false;
-      atom.project.replace();
+      core.project.replace();
       expect(wasCalled).toBe(true);
     });
   });
@@ -384,7 +384,7 @@ describe('Project', () => {
     let buffer;
     beforeEach(() =>
       waitsForPromise(() =>
-        atom.project
+        core.project
           .bufferForPath(path.join(__dirname, 'fixtures', 'sample.js'))
           .then(o => {
             buffer = o;
@@ -396,23 +396,23 @@ describe('Project', () => {
     afterEach(() => buffer.release());
 
     it('emits save events on the main process', () => {
-      spyOn(atom.project.applicationDelegate, 'emitDidSavePath');
-      spyOn(atom.project.applicationDelegate, 'emitWillSavePath');
+      spyOn(core.project.applicationDelegate, 'emitDidSavePath');
+      spyOn(core.project.applicationDelegate, 'emitWillSavePath');
 
       waitsForPromise(() => buffer.save());
 
       runs(() => {
         expect(
-          atom.project.applicationDelegate.emitDidSavePath.calls.length
+          core.project.applicationDelegate.emitDidSavePath.calls.length
         ).toBe(1);
         expect(
-          atom.project.applicationDelegate.emitDidSavePath
+          core.project.applicationDelegate.emitDidSavePath
         ).toHaveBeenCalledWith(buffer.getPath());
         expect(
-          atom.project.applicationDelegate.emitWillSavePath.calls.length
+          core.project.applicationDelegate.emitWillSavePath.calls.length
         ).toBe(1);
         expect(
-          atom.project.applicationDelegate.emitWillSavePath
+          core.project.applicationDelegate.emitWillSavePath
         ).toHaveBeenCalledWith(buffer.getPath());
       });
     });
@@ -422,7 +422,7 @@ describe('Project', () => {
     let editor = null;
     beforeEach(() =>
       waitsForPromise(() =>
-        atom.workspace.open(require.resolve('./fixtures/dir/a')).then(o => {
+        core.workspace.open(require.resolve('./fixtures/dir/a')).then(o => {
           editor = o;
         })
       )
@@ -430,7 +430,7 @@ describe('Project', () => {
 
     it('creates a warning notification', () => {
       let noteSpy;
-      atom.notifications.onDidAddNotification((noteSpy = jasmine.createSpy()));
+      core.notifications.onDidAddNotification((noteSpy = jasmine.createSpy()));
 
       const error = new Error('SomeError');
       error.eventType = 'resurrect';
@@ -472,45 +472,45 @@ describe('Project', () => {
 
     it('uses it to create repositories for any directories that need one', () => {
       const projectPath = temp.mkdirSync('atom-project');
-      atom.project.setPaths([projectPath]);
-      expect(atom.project.getRepositories()).toEqual([null]);
+      core.project.setPaths([projectPath]);
+      expect(core.project.getRepositories()).toEqual([null]);
 
-      atom.packages.serviceHub.provide(
+      core.packages.serviceHub.provide(
         'atom.repository-provider',
         '0.1.0',
         fakeRepositoryProvider
       );
-      waitsFor(() => atom.project.repositoryProviders.length > 1);
-      runs(() => atom.project.getRepositories()[0] === fakeRepository);
+      waitsFor(() => core.project.repositoryProviders.length > 1);
+      runs(() => core.project.getRepositories()[0] === fakeRepository);
     });
 
     it('does not create any new repositories if every directory has a repository', () => {
-      const repositories = atom.project.getRepositories();
+      const repositories = core.project.getRepositories();
       expect(repositories.length).toEqual(1);
       expect(repositories[0]).toBeTruthy();
 
-      atom.packages.serviceHub.provide(
+      core.packages.serviceHub.provide(
         'atom.repository-provider',
         '0.1.0',
         fakeRepositoryProvider
       );
-      waitsFor(() => atom.project.repositoryProviders.length > 1);
-      runs(() => expect(atom.project.getRepositories()).toBe(repositories));
+      waitsFor(() => core.project.repositoryProviders.length > 1);
+      runs(() => expect(core.project.getRepositories()).toBe(repositories));
     });
 
     it('stops using it to create repositories when the service is removed', () => {
-      atom.project.setPaths([]);
+      core.project.setPaths([]);
 
-      const disposable = atom.packages.serviceHub.provide(
+      const disposable = core.packages.serviceHub.provide(
         'atom.repository-provider',
         '0.1.0',
         fakeRepositoryProvider
       );
-      waitsFor(() => atom.project.repositoryProviders.length > 1);
+      waitsFor(() => core.project.repositoryProviders.length > 1);
       runs(() => {
         disposable.dispose();
-        atom.project.addPath(temp.mkdirSync('atom-project'));
-        expect(atom.project.getRepositories()).toEqual([null]);
+        core.project.addPath(temp.mkdirSync('atom-project'));
+        expect(core.project.getRepositories()).toEqual([null]);
       });
     });
   });
@@ -556,7 +556,7 @@ describe('Project', () => {
     let onDidChangeFilesCallback = null;
 
     beforeEach(() => {
-      serviceDisposable = atom.packages.serviceHub.provide(
+      serviceDisposable = core.packages.serviceHub.provide(
         'atom.directory-provider',
         '0.1.0',
         {
@@ -571,16 +571,16 @@ describe('Project', () => {
       );
       onDidChangeFilesCallback = null;
 
-      waitsFor(() => atom.project.directoryProviders.length > 0);
+      waitsFor(() => core.project.directoryProviders.length > 0);
     });
 
     it("uses the provider's custom directories for any paths that it handles", () => {
       const localPath = temp.mkdirSync('local-path');
       const remotePath = 'ssh://foreign-directory:8080/does-exist';
 
-      atom.project.setPaths([localPath, remotePath]);
+      core.project.setPaths([localPath, remotePath]);
 
-      let directories = atom.project.getDirectories();
+      let directories = core.project.getDirectories();
       expect(directories[0].getPath()).toBe(localPath);
       expect(directories[0] instanceof Directory).toBe(true);
       expect(directories[1].getPath()).toBe(remotePath);
@@ -589,21 +589,21 @@ describe('Project', () => {
       // It does not add new remote paths that do not exist
       const nonExistentRemotePath =
         'ssh://another-directory:8080/does-not-exist';
-      atom.project.addPath(nonExistentRemotePath);
-      expect(atom.project.getDirectories().length).toBe(2);
+      core.project.addPath(nonExistentRemotePath);
+      expect(core.project.getDirectories().length).toBe(2);
 
       // It adds new remote paths if their directories exist.
       const newRemotePath = 'ssh://another-directory:8080/does-exist';
-      atom.project.addPath(newRemotePath);
-      directories = atom.project.getDirectories();
+      core.project.addPath(newRemotePath);
+      directories = core.project.getDirectories();
       expect(directories[2].getPath()).toBe(newRemotePath);
       expect(directories[2] instanceof DummyDirectory).toBe(true);
     });
 
     it('stops using the provider when the service is removed', () => {
       serviceDisposable.dispose();
-      atom.project.setPaths(['ssh://foreign-directory:8080/does-exist']);
-      expect(atom.project.getDirectories().length).toBe(0);
+      core.project.setPaths(['ssh://foreign-directory:8080/does-exist']);
+      expect(core.project.getDirectories().length).toBe(0);
     });
 
     it('uses the custom onDidChangeFiles as the watcher if available', () => {
@@ -611,14 +611,14 @@ describe('Project', () => {
       waitsForPromise(() => stopAllWatchers());
 
       const remotePath = 'ssh://another-directory:8080/does-exist';
-      runs(() => atom.project.setPaths([remotePath]));
-      waitsForPromise(() => atom.project.getWatcherPromise(remotePath));
+      runs(() => core.project.setPaths([remotePath]));
+      waitsForPromise(() => core.project.getWatcherPromise(remotePath));
 
       runs(() => {
         expect(onDidChangeFilesCallback).not.toBeNull();
 
         const changeSpy = jasmine.createSpy('atom.project.onDidChangeFiles');
-        const disposable = atom.project.onDidChangeFiles(changeSpy);
+        const disposable = core.project.onDidChangeFiles(changeSpy);
 
         const events = [{ action: 'created', path: remotePath + '/test.txt' }];
         onDidChangeFilesCallback(events);
@@ -635,14 +635,14 @@ describe('Project', () => {
     beforeEach(() => {
       absolutePath = require.resolve('./fixtures/dir/a');
       newBufferHandler = jasmine.createSpy('newBufferHandler');
-      atom.project.onDidAddBuffer(newBufferHandler);
+      core.project.onDidAddBuffer(newBufferHandler);
     });
 
     describe("when given an absolute path that isn't currently open", () => {
       it("returns a new edit session for the given path and emits 'buffer-created'", () => {
         let editor = null;
         waitsForPromise(() =>
-          atom.workspace.open(absolutePath).then(o => {
+          core.workspace.open(absolutePath).then(o => {
             editor = o;
           })
         );
@@ -658,7 +658,7 @@ describe('Project', () => {
       it("returns a new edit session for the given path (relative to the project root) and emits 'buffer-created'", () => {
         let editor = null;
         waitsForPromise(() =>
-          atom.workspace.open(absolutePath).then(o => {
+          core.workspace.open(absolutePath).then(o => {
             editor = o;
           })
         );
@@ -675,7 +675,7 @@ describe('Project', () => {
         let editor = null;
 
         waitsForPromise(() =>
-          atom.workspace.open(absolutePath).then(o => {
+          core.workspace.open(absolutePath).then(o => {
             editor = o;
           })
         );
@@ -683,13 +683,13 @@ describe('Project', () => {
         runs(() => newBufferHandler.reset());
 
         waitsForPromise(() =>
-          atom.workspace
+          core.workspace
             .open(absolutePath)
             .then(({ buffer }) => expect(buffer).toBe(editor.buffer))
         );
 
         waitsForPromise(() =>
-          atom.workspace.open('a').then(({ buffer }) => {
+          core.workspace.open('a').then(({ buffer }) => {
             expect(buffer).toBe(editor.buffer);
             expect(newBufferHandler).not.toHaveBeenCalled();
           })
@@ -701,7 +701,7 @@ describe('Project', () => {
       it("returns a new edit session and emits 'buffer-created'", () => {
         let editor = null;
         waitsForPromise(() =>
-          atom.workspace.open().then(o => {
+          core.workspace.open().then(o => {
             editor = o;
           })
         );
@@ -719,7 +719,7 @@ describe('Project', () => {
 
     beforeEach(() =>
       waitsForPromise(() =>
-        atom.project.bufferForPath('a').then(o => {
+        core.project.bufferForPath('a').then(o => {
           buffer = o;
           buffer.retain();
         })
@@ -731,21 +731,21 @@ describe('Project', () => {
     describe('when opening a previously opened path', () => {
       it('does not create a new buffer', () => {
         waitsForPromise(() =>
-          atom.project
+          core.project
             .bufferForPath('a')
             .then(anotherBuffer => expect(anotherBuffer).toBe(buffer))
         );
 
         waitsForPromise(() =>
-          atom.project
+          core.project
             .bufferForPath('b')
             .then(anotherBuffer => expect(anotherBuffer).not.toBe(buffer))
         );
 
         waitsForPromise(() =>
           Promise.all([
-            atom.project.bufferForPath('c'),
-            atom.project.bufferForPath('c')
+            core.project.bufferForPath('c'),
+            core.project.bufferForPath('c')
           ]).then(([buffer1, buffer2]) => {
             expect(buffer1).toBe(buffer2);
           })
@@ -757,12 +757,12 @@ describe('Project', () => {
           spyOn(TextBuffer, 'load').andCallFake(() =>
             Promise.reject(new Error('Could not open file'))
           );
-          return atom.project.bufferForPath('b');
+          return core.project.bufferForPath('b');
         });
 
         waitsForPromise({ shouldReject: false }, () => {
           TextBuffer.load.andCallThrough();
-          return atom.project.bufferForPath('b');
+          return core.project.bufferForPath('b');
         });
       });
 
@@ -770,7 +770,7 @@ describe('Project', () => {
         buffer.release();
 
         waitsForPromise(() =>
-          atom.project
+          core.project
             .bufferForPath('b')
             .then(anotherBuffer => expect(anotherBuffer).not.toBe(buffer))
         );
@@ -782,10 +782,10 @@ describe('Project', () => {
     it('resolves to null when the directory does not have a repository', () => {
       waitsForPromise(() => {
         const directory = new Directory('/tmp');
-        return atom.project.repositoryForDirectory(directory).then(result => {
+        return core.project.repositoryForDirectory(directory).then(result => {
           expect(result).toBeNull();
-          expect(atom.project.repositoryProviders.length).toBeGreaterThan(0);
-          expect(atom.project.repositoryPromisesByPath.size).toBe(0);
+          expect(core.project.repositoryProviders.length).toBeGreaterThan(0);
+          expect(core.project.repositoryPromisesByPath.size).toBe(0);
         });
       });
     });
@@ -793,14 +793,14 @@ describe('Project', () => {
     it('resolves to a GitRepository and is cached when the given directory is a Git repo', () => {
       waitsForPromise(() => {
         const directory = new Directory(path.join(__dirname, '..'));
-        const promise = atom.project.repositoryForDirectory(directory);
+        const promise = core.project.repositoryForDirectory(directory);
         return promise.then(result => {
           expect(result).toBeInstanceOf(GitRepository);
           const dirPath = directory.getRealPathSync();
           expect(result.getPath()).toBe(path.join(dirPath, '.git'));
 
           // Verify that the result is cached.
-          expect(atom.project.repositoryForDirectory(directory)).toBe(promise);
+          expect(core.project.repositoryForDirectory(directory)).toBe(promise);
         });
       });
     });
@@ -810,7 +810,7 @@ describe('Project', () => {
       const directory = new Directory(path.join(__dirname, '..'));
 
       waitsForPromise(() =>
-        atom.project.repositoryForDirectory(directory).then(repo => {
+        core.project.repositoryForDirectory(directory).then(repo => {
           repository = repo;
         })
       );
@@ -822,7 +822,7 @@ describe('Project', () => {
       });
 
       waitsForPromise(() =>
-        atom.project.repositoryForDirectory(directory).then(repo => {
+        core.project.repositoryForDirectory(directory).then(repo => {
           repository = repo;
         })
       );
@@ -835,9 +835,9 @@ describe('Project', () => {
     describe('when path is a file', () => {
       it("sets its path to the file's parent directory and updates the root directory", () => {
         const filePath = require.resolve('./fixtures/dir/a');
-        atom.project.setPaths([filePath]);
-        expect(atom.project.getPaths()[0]).toEqual(path.dirname(filePath));
-        expect(atom.project.getDirectories()[0].path).toEqual(
+        core.project.setPaths([filePath]);
+        expect(core.project.getPaths()[0]).toEqual(path.dirname(filePath));
+        expect(core.project.getDirectories()[0].path).toEqual(
           path.dirname(filePath)
         );
       });
@@ -855,9 +855,9 @@ describe('Project', () => {
         fs.copySync(gitDirPath, path.join(directory2, '.git'));
         fs.copySync(gitDirPath, path.join(directory3, '.git'));
 
-        atom.project.setPaths([directory1, directory2, directory3]);
+        core.project.setPaths([directory1, directory2, directory3]);
 
-        const [repo1, repo2, repo3] = atom.project.getRepositories();
+        const [repo1, repo2, repo3] = core.project.getRepositories();
         expect(repo1).toBeNull();
         expect(repo2.getShortHead()).toBe('master');
         expect(repo2.getPath()).toBe(
@@ -871,10 +871,10 @@ describe('Project', () => {
 
       it('calls callbacks registered with ::onDidChangePaths', () => {
         const onDidChangePathsSpy = jasmine.createSpy('onDidChangePaths spy');
-        atom.project.onDidChangePaths(onDidChangePathsSpy);
+        core.project.onDidChangePaths(onDidChangePathsSpy);
 
         const paths = [temp.mkdirSync('dir1'), temp.mkdirSync('dir2')];
-        atom.project.setPaths(paths);
+        core.project.setPaths(paths);
 
         expect(onDidChangePathsSpy.callCount).toBe(1);
         expect(onDidChangePathsSpy.mostRecentCall.args[0]).toEqual(paths);
@@ -889,34 +889,34 @@ describe('Project', () => {
         ];
 
         try {
-          atom.project.setPaths(paths, { mustExist: true });
+          core.project.setPaths(paths, { mustExist: true });
           expect('no exception thrown').toBeUndefined();
         } catch (e) {
           expect(e.missingProjectPaths).toEqual([paths[1], paths[3]]);
         }
 
-        expect(atom.project.getPaths()).toEqual([paths[0], paths[2]]);
+        expect(core.project.getPaths()).toEqual([paths[0], paths[2]]);
       });
     });
 
     describe('when no paths are given', () => {
       it('clears its path', () => {
-        atom.project.setPaths([]);
-        expect(atom.project.getPaths()).toEqual([]);
-        expect(atom.project.getDirectories()).toEqual([]);
+        core.project.setPaths([]);
+        expect(core.project.getPaths()).toEqual([]);
+        expect(core.project.getDirectories()).toEqual([]);
       });
     });
 
     it('normalizes the path to remove consecutive slashes, ., and .. segments', () => {
-      atom.project.setPaths([
+      core.project.setPaths([
         `${require.resolve('./fixtures/dir/a')}${path.sep}b${path.sep}${
           path.sep
         }..`
       ]);
-      expect(atom.project.getPaths()[0]).toEqual(
+      expect(core.project.getPaths()[0]).toEqual(
         path.dirname(require.resolve('./fixtures/dir/a'))
       );
-      expect(atom.project.getDirectories()[0].path).toEqual(
+      expect(core.project.getDirectories()[0].path).toEqual(
         path.dirname(require.resolve('./fixtures/dir/a'))
       );
     });
@@ -925,12 +925,12 @@ describe('Project', () => {
   describe('.addPath(path, options)', () => {
     it('calls callbacks registered with ::onDidChangePaths', () => {
       const onDidChangePathsSpy = jasmine.createSpy('onDidChangePaths spy');
-      atom.project.onDidChangePaths(onDidChangePathsSpy);
+      core.project.onDidChangePaths(onDidChangePathsSpy);
 
-      const [oldPath] = atom.project.getPaths();
+      const [oldPath] = core.project.getPaths();
 
       const newPath = temp.mkdirSync('dir');
-      atom.project.addPath(newPath);
+      core.project.addPath(newPath);
 
       expect(onDidChangePathsSpy.callCount).toBe(1);
       expect(onDidChangePathsSpy.mostRecentCall.args[0]).toEqual([
@@ -941,35 +941,35 @@ describe('Project', () => {
 
     it("doesn't add redundant paths", () => {
       const onDidChangePathsSpy = jasmine.createSpy('onDidChangePaths spy');
-      atom.project.onDidChangePaths(onDidChangePathsSpy);
-      const [oldPath] = atom.project.getPaths();
+      core.project.onDidChangePaths(onDidChangePathsSpy);
+      const [oldPath] = core.project.getPaths();
 
       // Doesn't re-add an existing root directory
-      atom.project.addPath(oldPath);
-      expect(atom.project.getPaths()).toEqual([oldPath]);
+      core.project.addPath(oldPath);
+      expect(core.project.getPaths()).toEqual([oldPath]);
       expect(onDidChangePathsSpy).not.toHaveBeenCalled();
 
       // Doesn't add an entry for a file-path within an existing root directory
-      atom.project.addPath(path.join(oldPath, 'some-file.txt'));
-      expect(atom.project.getPaths()).toEqual([oldPath]);
+      core.project.addPath(path.join(oldPath, 'some-file.txt'));
+      expect(core.project.getPaths()).toEqual([oldPath]);
       expect(onDidChangePathsSpy).not.toHaveBeenCalled();
 
       // Does add an entry for a directory within an existing directory
       const newPath = path.join(oldPath, 'a-dir');
-      atom.project.addPath(newPath);
-      expect(atom.project.getPaths()).toEqual([oldPath, newPath]);
+      core.project.addPath(newPath);
+      expect(core.project.getPaths()).toEqual([oldPath, newPath]);
       expect(onDidChangePathsSpy).toHaveBeenCalled();
     });
 
     it("doesn't add non-existent directories", () => {
-      const previousPaths = atom.project.getPaths();
-      atom.project.addPath('/this-definitely/does-not-exist');
-      expect(atom.project.getPaths()).toEqual(previousPaths);
+      const previousPaths = core.project.getPaths();
+      core.project.addPath('/this-definitely/does-not-exist');
+      expect(core.project.getPaths()).toEqual(previousPaths);
     });
 
     it('optionally throws on non-existent directories', () => {
       expect(() =>
-        atom.project.addPath('/this-definitely/does-not-exist', {
+        core.project.addPath('/this-definitely/does-not-exist', {
           mustExist: true
         })
       ).toThrow();
@@ -981,37 +981,37 @@ describe('Project', () => {
 
     beforeEach(() => {
       onDidChangePathsSpy = jasmine.createSpy('onDidChangePaths listener');
-      atom.project.onDidChangePaths(onDidChangePathsSpy);
+      core.project.onDidChangePaths(onDidChangePathsSpy);
     });
 
     it('removes the directory and repository for the path', () => {
-      const result = atom.project.removePath(atom.project.getPaths()[0]);
-      expect(atom.project.getDirectories()).toEqual([]);
-      expect(atom.project.getRepositories()).toEqual([]);
-      expect(atom.project.getPaths()).toEqual([]);
+      const result = core.project.removePath(core.project.getPaths()[0]);
+      expect(core.project.getDirectories()).toEqual([]);
+      expect(core.project.getRepositories()).toEqual([]);
+      expect(core.project.getPaths()).toEqual([]);
       expect(result).toBe(true);
       expect(onDidChangePathsSpy).toHaveBeenCalled();
     });
 
     it("does nothing if the path is not one of the project's root paths", () => {
-      const originalPaths = atom.project.getPaths();
-      const result = atom.project.removePath(originalPaths[0] + 'xyz');
+      const originalPaths = core.project.getPaths();
+      const result = core.project.removePath(originalPaths[0] + 'xyz');
       expect(result).toBe(false);
-      expect(atom.project.getPaths()).toEqual(originalPaths);
+      expect(core.project.getPaths()).toEqual(originalPaths);
       expect(onDidChangePathsSpy).not.toHaveBeenCalled();
     });
 
     it("doesn't destroy the repository if it is shared by another root directory", () => {
-      atom.project.setPaths([__dirname, path.join(__dirname, '..', 'src')]);
-      atom.project.removePath(__dirname);
-      expect(atom.project.getPaths()).toEqual([
+      core.project.setPaths([__dirname, path.join(__dirname, '..', 'src')]);
+      core.project.removePath(__dirname);
+      expect(core.project.getPaths()).toEqual([
         path.join(__dirname, '..', 'src')
       ]);
-      expect(atom.project.getRepositories()[0].isSubmodule('src')).toBe(false);
+      expect(core.project.getRepositories()[0].isSubmodule('src')).toBe(false);
     });
 
     it('removes a path that is represented as a URI', () => {
-      atom.packages.serviceHub.provide('atom.directory-provider', '0.1.0', {
+      core.packages.serviceHub.provide('atom.directory-provider', '0.1.0', {
         directoryForURISync(uri) {
           return {
             getPath() {
@@ -1033,11 +1033,11 @@ describe('Project', () => {
 
       const ftpURI = 'ftp://example.com/some/folder';
 
-      atom.project.setPaths([ftpURI]);
-      expect(atom.project.getPaths()).toEqual([ftpURI]);
+      core.project.setPaths([ftpURI]);
+      expect(core.project.getPaths()).toEqual([ftpURI]);
 
-      atom.project.removePath(ftpURI);
-      expect(atom.project.getPaths()).toEqual([]);
+      core.project.removePath(ftpURI);
+      expect(core.project.getPaths()).toEqual([]);
     });
   });
 
@@ -1048,7 +1048,7 @@ describe('Project', () => {
 
     beforeEach(() => {
       events = [];
-      sub = atom.project.onDidChangeFiles(incoming => {
+      sub = core.project.onDidChangeFiles(incoming => {
         events.push(...incoming);
         checkCallback();
       });
@@ -1094,10 +1094,10 @@ describe('Project', () => {
       // Ensure that all preexisting watchers are stopped
       await stopAllWatchers();
 
-      atom.project.setPaths([dirOne]);
-      await atom.project.getWatcherPromise(dirOne);
+      core.project.setPaths([dirOne]);
+      await core.project.getWatcherPromise(dirOne);
 
-      expect(atom.project.watcherPromisesByPath[dirTwo]).toEqual(undefined);
+      expect(core.project.watcherPromisesByPath[dirTwo]).toEqual(undefined);
       fs.writeFileSync(fileThree, 'three\n');
       fs.writeFileSync(fileTwo, 'two\n');
       fs.writeFileSync(fileOne, 'one\n');
@@ -1112,18 +1112,18 @@ describe('Project', () => {
       const added = [];
 
       waitsForPromise(() =>
-        atom.project
+        core.project
           .buildBuffer(require.resolve('./fixtures/dir/a'))
           .then(o => buffers.push(o))
       );
 
       runs(() => {
         expect(buffers.length).toBe(1);
-        atom.project.onDidAddBuffer(buffer => added.push(buffer));
+        core.project.onDidAddBuffer(buffer => added.push(buffer));
       });
 
       waitsForPromise(() =>
-        atom.project
+        core.project
           .buildBuffer(require.resolve('./fixtures/dir/b'))
           .then(o => buffers.push(o))
       );
@@ -1141,25 +1141,25 @@ describe('Project', () => {
       const observed = [];
 
       waitsForPromise(() =>
-        atom.project
+        core.project
           .buildBuffer(require.resolve('./fixtures/dir/a'))
           .then(o => buffers.push(o))
       );
 
       waitsForPromise(() =>
-        atom.project
+        core.project
           .buildBuffer(require.resolve('./fixtures/dir/b'))
           .then(o => buffers.push(o))
       );
 
       runs(() => {
         expect(buffers.length).toBe(2);
-        atom.project.observeBuffers(buffer => observed.push(buffer));
+        core.project.observeBuffers(buffer => observed.push(buffer));
         expect(observed).toEqual(buffers);
       });
 
       waitsForPromise(() =>
-        atom.project
+        core.project
           .buildBuffer(require.resolve('./fixtures/dir/b'))
           .then(o => buffers.push(o))
       );
@@ -1194,9 +1194,9 @@ describe('Project', () => {
       );
       fs.copySync(gitDirPath2, path.join(directory2, '.git'));
 
-      atom.project.setPaths([directory1]);
+      core.project.setPaths([directory1]);
 
-      const disposable = atom.project.observeRepositories(repo =>
+      const disposable = core.project.observeRepositories(repo =>
         observed.push(repo)
       );
       expect(observed.length).toBe(1);
@@ -1204,7 +1204,7 @@ describe('Project', () => {
         'ef046e9eecaa5255ea5e9817132d4001724d6ae1'
       );
 
-      atom.project.addPath(directory2);
+      core.project.addPath(directory2);
       expect(observed.length).toBe(2);
       expect(observed[1].getReferenceTarget('refs/heads/master')).toBe(
         'd2b0ad9cbc6f6c4372e8956e5cc5af771b2342e5'
@@ -1217,7 +1217,7 @@ describe('Project', () => {
   describe('.onDidAddRepository()', () => {
     it('invokes callback when a path is added and the path is the root of a repository', () => {
       const observed = [];
-      const disposable = atom.project.onDidAddRepository(repo =>
+      const disposable = core.project.onDidAddRepository(repo =>
         observed.push(repo)
       );
 
@@ -1227,7 +1227,7 @@ describe('Project', () => {
       );
       fs.copySync(fixtureRepoPath, path.join(projectRootPath, '.git'));
 
-      atom.project.addPath(projectRootPath);
+      core.project.addPath(projectRootPath);
       expect(observed.length).toBe(1);
       expect(observed[0].getOriginURL()).toEqual(
         'https://github.com/example-user/example-repo.git'
@@ -1238,7 +1238,7 @@ describe('Project', () => {
 
     it('invokes callback when a path is added and the path is subdirectory of a repository', () => {
       const observed = [];
-      const disposable = atom.project.onDidAddRepository(repo =>
+      const disposable = core.project.onDidAddRepository(repo =>
         observed.push(repo)
       );
 
@@ -1251,7 +1251,7 @@ describe('Project', () => {
       const projectSubDirPath = path.join(projectRootPath, 'sub-dir');
       fs.mkdirSync(projectSubDirPath);
 
-      atom.project.addPath(projectSubDirPath);
+      core.project.addPath(projectSubDirPath);
       expect(observed.length).toBe(1);
       expect(observed[0].getOriginURL()).toEqual(
         'https://github.com/example-user/example-repo.git'
@@ -1262,11 +1262,11 @@ describe('Project', () => {
 
     it('does not invoke callback when a path is added and the path is not part of a repository', () => {
       const observed = [];
-      const disposable = atom.project.onDidAddRepository(repo =>
+      const disposable = core.project.onDidAddRepository(repo =>
         observed.push(repo)
       );
 
-      atom.project.addPath(temp.mkdirSync('not-a-repository'));
+      core.project.addPath(temp.mkdirSync('not-a-repository'));
       expect(observed.length).toBe(0);
 
       disposable.dispose();
@@ -1275,41 +1275,41 @@ describe('Project', () => {
 
   describe('.relativize(path)', () => {
     it('returns the path, relative to whichever root directory it is inside of', () => {
-      atom.project.addPath(temp.mkdirSync('another-path'));
+      core.project.addPath(temp.mkdirSync('another-path'));
 
-      let rootPath = atom.project.getPaths()[0];
+      let rootPath = core.project.getPaths()[0];
       let childPath = path.join(rootPath, 'some', 'child', 'directory');
-      expect(atom.project.relativize(childPath)).toBe(
+      expect(core.project.relativize(childPath)).toBe(
         path.join('some', 'child', 'directory')
       );
 
-      rootPath = atom.project.getPaths()[1];
+      rootPath = core.project.getPaths()[1];
       childPath = path.join(rootPath, 'some', 'child', 'directory');
-      expect(atom.project.relativize(childPath)).toBe(
+      expect(core.project.relativize(childPath)).toBe(
         path.join('some', 'child', 'directory')
       );
     });
 
     it('returns the given path if it is not in any of the root directories', () => {
       const randomPath = path.join('some', 'random', 'path');
-      expect(atom.project.relativize(randomPath)).toBe(randomPath);
+      expect(core.project.relativize(randomPath)).toBe(randomPath);
     });
   });
 
   describe('.relativizePath(path)', () => {
     it('returns the root path that contains the given path, and the path relativized to that root path', () => {
-      atom.project.addPath(temp.mkdirSync('another-path'));
+      core.project.addPath(temp.mkdirSync('another-path'));
 
-      let rootPath = atom.project.getPaths()[0];
+      let rootPath = core.project.getPaths()[0];
       let childPath = path.join(rootPath, 'some', 'child', 'directory');
-      expect(atom.project.relativizePath(childPath)).toEqual([
+      expect(core.project.relativizePath(childPath)).toEqual([
         rootPath,
         path.join('some', 'child', 'directory')
       ]);
 
-      rootPath = atom.project.getPaths()[1];
+      rootPath = core.project.getPaths()[1];
       childPath = path.join(rootPath, 'some', 'child', 'directory');
-      expect(atom.project.relativizePath(childPath)).toEqual([
+      expect(core.project.relativizePath(childPath)).toEqual([
         rootPath,
         path.join('some', 'child', 'directory')
       ]);
@@ -1318,7 +1318,7 @@ describe('Project', () => {
     describe("when the given path isn't inside of any of the project's path", () => {
       it('returns null for the root path, and the given path unchanged', () => {
         const randomPath = path.join('some', 'random', 'path');
-        expect(atom.project.relativizePath(randomPath)).toEqual([
+        expect(core.project.relativizePath(randomPath)).toEqual([
           null,
           randomPath
         ]);
@@ -1328,23 +1328,23 @@ describe('Project', () => {
     describe('when the given path is a URL', () => {
       it('returns null for the root path, and the given path unchanged', () => {
         const url = 'http://the-path';
-        expect(atom.project.relativizePath(url)).toEqual([null, url]);
+        expect(core.project.relativizePath(url)).toEqual([null, url]);
       });
     });
 
     describe('when the given path is inside more than one root folder', () => {
       it('uses the root folder that is closest to the given path', () => {
-        atom.project.addPath(path.join(atom.project.getPaths()[0], 'a-dir'));
+        core.project.addPath(path.join(core.project.getPaths()[0], 'a-dir'));
 
         const inputPath = path.join(
-          atom.project.getPaths()[1],
+          core.project.getPaths()[1],
           'somewhere/something.txt'
         );
 
-        expect(atom.project.getDirectories()[0].contains(inputPath)).toBe(true);
-        expect(atom.project.getDirectories()[1].contains(inputPath)).toBe(true);
-        expect(atom.project.relativizePath(inputPath)).toEqual([
-          atom.project.getPaths()[1],
+        expect(core.project.getDirectories()[0].contains(inputPath)).toBe(true);
+        expect(core.project.getDirectories()[1].contains(inputPath)).toBe(true);
+        expect(core.project.relativizePath(inputPath)).toEqual([
+          core.project.getPaths()[1],
           path.join('somewhere', 'something.txt')
         ]);
       });
@@ -1353,18 +1353,18 @@ describe('Project', () => {
 
   describe('.contains(path)', () => {
     it('returns whether or not the given path is in one of the root directories', () => {
-      const rootPath = atom.project.getPaths()[0];
+      const rootPath = core.project.getPaths()[0];
       const childPath = path.join(rootPath, 'some', 'child', 'directory');
-      expect(atom.project.contains(childPath)).toBe(true);
+      expect(core.project.contains(childPath)).toBe(true);
 
       const randomPath = path.join('some', 'random', 'path');
-      expect(atom.project.contains(randomPath)).toBe(false);
+      expect(core.project.contains(randomPath)).toBe(false);
     });
   });
 
   describe('.resolvePath(uri)', () => {
     it('normalizes disk drive letter in passed path on #win32', () => {
-      expect(atom.project.resolvePath('d:\\file.txt')).toEqual('D:\\file.txt');
+      expect(core.project.resolvePath('d:\\file.txt')).toEqual('D:\\file.txt');
     });
   });
 });

--- a/spec/selection-spec.js
+++ b/spec/selection-spec.js
@@ -4,7 +4,7 @@ describe('Selection', () => {
   let buffer, editor, selection;
 
   beforeEach(() => {
-    buffer = atom.project.bufferForPathSync('sample.js');
+    buffer = core.project.bufferForPathSync('sample.js');
     editor = new TextEditor({ buffer, tabLength: 2 });
     selection = editor.getLastSelection();
   });

--- a/spec/spec-helper.js
+++ b/spec/spec-helper.js
@@ -27,11 +27,11 @@ const {clipboard} = require('electron');
 const {mockDebounce} = require("./spec-helper-functions.js");
 
 const jasmineStyle = document.createElement('style');
-jasmineStyle.textContent = atom.themes.loadStylesheet(atom.themes.resolveStylesheet('../static/jasmine'));
+jasmineStyle.textContent = core.themes.loadStylesheet(core.themes.resolveStylesheet('../static/jasmine'));
 document.head.appendChild(jasmineStyle);
 
 const fixturePackagesPath = path.resolve(__dirname, './fixtures/packages');
-atom.packages.packageDirPaths.unshift(fixturePackagesPath);
+core.packages.packageDirPaths.unshift(fixturePackagesPath);
 
 document.querySelector('html').style.overflow = 'auto';
 document.body.style.overflow = 'auto';
@@ -76,7 +76,7 @@ if (process.env.CI) {
   jasmine.getEnv().defaultTimeoutInterval = 5000;
 }
 
-const {testPaths} = atom.getLoadSettings();
+const {testPaths} = core.getLoadSettings();
 
 if (specPackagePath = FindParentDir.sync(testPaths[0], 'package.json')) {
   const packageMetadata = require(path.join(specPackagePath, 'package.json'));
@@ -91,9 +91,9 @@ if ((specDirectory = FindParentDir.sync(testPaths[0], 'fixtures'))) {
 
 beforeEach(function() {
   // Do not clobber recent project history
-  spyOn(Object.getPrototypeOf(atom.history), 'saveState').andReturn(Promise.resolve());
+  spyOn(Object.getPrototypeOf(core.history), 'saveState').andReturn(Promise.resolve());
 
-  atom.project.setPaths([specProjectPath]);
+  core.project.setPaths([specProjectPath]);
 
   window.resetTimeouts();
   spyOn(_._, "now").andCallFake(() => window.now);
@@ -102,24 +102,24 @@ beforeEach(function() {
   spyOn(window, "clearTimeout").andCallFake(window.fakeClearTimeout);
   spyOn(_, "debounce").andCallFake(mockDebounce);
 
-  const spy = spyOn(atom.packages, 'resolvePackagePath').andCallFake(function(packageName) {
+  const spy = spyOn(core.packages, 'resolvePackagePath').andCallFake(function(packageName) {
     if (specPackageName && (packageName === specPackageName)) {
       return resolvePackagePath(specPackagePath);
     } else {
       return resolvePackagePath(packageName);
     }
   });
-  var resolvePackagePath = _.bind(spy.originalValue, atom.packages);
+  var resolvePackagePath = _.bind(spy.originalValue, core.packages);
 
   // prevent specs from modifying Atom's menus
-  spyOn(atom.menu, 'sendToBrowserProcess');
+  spyOn(core.menu, 'sendToBrowserProcess');
 
   // reset config before each spec
-  atom.config.set("core.destroyEmptyPanes", false);
-  atom.config.set("editor.fontFamily", "Courier");
-  atom.config.set("editor.fontSize", 16);
-  atom.config.set("editor.autoIndent", false);
-  atom.config.set("core.disabledPackages", ["package-that-throws-an-exception",
+  core.config.set("core.destroyEmptyPanes", false);
+  core.config.set("editor.fontFamily", "Courier");
+  core.config.set("editor.fontSize", 16);
+  core.config.set("editor.autoIndent", false);
+  core.config.set("core.disabledPackages", ["package-that-throws-an-exception",
     "package-with-broken-package-json", "package-with-broken-keymap"]);
   advanceClock(1000);
   window.setTimeout.reset();
@@ -162,7 +162,7 @@ afterEach(function() {
   ensureNoDeprecatedFunctionCalls();
   ensureNoDeprecatedStylesheets();
 
-  waitsForPromise(() => atom.reset());
+  waitsForPromise(() => core.reset());
 
   return runs(function() {
     if (!window.debugContent) { document.getElementById('jasmine-content').innerHTML = ''; }
@@ -207,8 +207,8 @@ var ensureNoDeprecatedFunctionCalls = function() {
 };
 
 var ensureNoDeprecatedStylesheets = function() {
-  const deprecations = _.clone(atom.styles.getDeprecations());
-  atom.styles.clearDeprecations();
+  const deprecations = _.clone(core.styles.getDeprecations());
+  core.styles.clearDeprecations();
   return (() => {
     const result = [];
     for (let sourcePath in deprecations) {
@@ -249,12 +249,12 @@ let grimDeprecationsSnapshot = null;
 let stylesDeprecationsSnapshot = null;
 jasmine.snapshotDeprecations = function() {
   grimDeprecationsSnapshot = _.clone(Grim.deprecations);
-  return stylesDeprecationsSnapshot = _.clone(atom.styles.deprecationsBySourcePath);
+  return stylesDeprecationsSnapshot = _.clone(core.styles.deprecationsBySourcePath);
 };
 
 jasmine.restoreDeprecationsSnapshot = function() {
   Grim.deprecations = grimDeprecationsSnapshot;
-  return atom.styles.deprecationsBySourcePath = stylesDeprecationsSnapshot;
+  return core.styles.deprecationsBySourcePath = stylesDeprecationsSnapshot;
 };
 
 jasmine.useRealClock = function() {

--- a/spec/styles-element-spec.js
+++ b/spec/styles-element-spec.js
@@ -10,7 +10,7 @@ describe('StylesElement', function() {
 
   beforeEach(function() {
     element = createStylesElement();
-    element.initialize(atom.styles);
+    element.initialize(core.styles);
     document.querySelector('#jasmine-content').appendChild(element);
     addedStyleElements = [];
     removedStyleElements = [];
@@ -27,14 +27,14 @@ describe('StylesElement', function() {
   it('renders a style tag for all currently active stylesheets in the style manager', function() {
     const initialChildCount = element.children.length;
 
-    const disposable1 = atom.styles.addStyleSheet('a {color: red;}');
+    const disposable1 = core.styles.addStyleSheet('a {color: red;}');
     expect(element.children.length).toBe(initialChildCount + 1);
     expect(element.children[initialChildCount].textContent).toBe(
       'a {color: red;}'
     );
     expect(addedStyleElements).toEqual([element.children[initialChildCount]]);
 
-    atom.styles.addStyleSheet('a {color: blue;}');
+    core.styles.addStyleSheet('a {color: blue;}');
     expect(element.children.length).toBe(initialChildCount + 2);
     expect(element.children[initialChildCount + 1].textContent).toBe(
       'a {color: blue;}'
@@ -55,10 +55,10 @@ describe('StylesElement', function() {
   it('orders style elements by priority', function() {
     const initialChildCount = element.children.length;
 
-    atom.styles.addStyleSheet('a {color: red}', { priority: 1 });
-    atom.styles.addStyleSheet('a {color: blue}', { priority: 0 });
-    atom.styles.addStyleSheet('a {color: green}', { priority: 2 });
-    atom.styles.addStyleSheet('a {color: yellow}', { priority: 1 });
+    core.styles.addStyleSheet('a {color: red}', { priority: 1 });
+    core.styles.addStyleSheet('a {color: blue}', { priority: 0 });
+    core.styles.addStyleSheet('a {color: green}', { priority: 2 });
+    core.styles.addStyleSheet('a {color: yellow}', { priority: 1 });
 
     expect(element.children[initialChildCount].textContent).toBe(
       'a {color: blue}'
@@ -77,8 +77,8 @@ describe('StylesElement', function() {
   it('updates existing style nodes when style elements are updated', function() {
     const initialChildCount = element.children.length;
 
-    atom.styles.addStyleSheet('a {color: red;}', { sourcePath: '/foo/bar' });
-    atom.styles.addStyleSheet('a {color: blue;}', { sourcePath: '/foo/bar' });
+    core.styles.addStyleSheet('a {color: red;}', { sourcePath: '/foo/bar' });
+    core.styles.addStyleSheet('a {color: blue;}', { sourcePath: '/foo/bar' });
 
     expect(element.children.length).toBe(initialChildCount + 1);
     expect(element.children[initialChildCount].textContent).toBe(
@@ -90,8 +90,8 @@ describe('StylesElement', function() {
   it("only includes style elements matching the 'context' attribute", function() {
     const initialChildCount = element.children.length;
 
-    atom.styles.addStyleSheet('a {color: red;}', { context: 'test-context' });
-    atom.styles.addStyleSheet('a {color: green;}');
+    core.styles.addStyleSheet('a {color: red;}', { context: 'test-context' });
+    core.styles.addStyleSheet('a {color: green;}');
 
     expect(element.children.length).toBe(initialChildCount + 2);
     expect(element.children[initialChildCount].textContent).toBe(
@@ -106,8 +106,8 @@ describe('StylesElement', function() {
     expect(element.children.length).toBe(1);
     expect(element.children[0].textContent).toBe('a {color: red;}');
 
-    atom.styles.addStyleSheet('a {color: blue;}', { context: 'test-context' });
-    atom.styles.addStyleSheet('a {color: yellow;}');
+    core.styles.addStyleSheet('a {color: blue;}', { context: 'test-context' });
+    core.styles.addStyleSheet('a {color: yellow;}');
 
     expect(element.children.length).toBe(2);
     expect(element.children[0].textContent).toBe('a {color: red;}');

--- a/spec/text-editor-component-spec.js
+++ b/spec/text-editor-component-spec.js
@@ -917,12 +917,12 @@ describe('TextEditorComponent', () => {
     });
 
     it('adds the data-grammar attribute and updates it when the grammar changes', async () => {
-      await atom.packages.activatePackage('language-javascript');
+      await core.packages.activatePackage('language-javascript');
 
       const { editor, element, component } = buildComponent();
       expect(element.dataset.grammar).toBe('text plain null-grammar');
 
-      atom.grammars.assignLanguageMode(editor.getBuffer(), 'source.js');
+      core.grammars.assignLanguageMode(editor.getBuffer(), 'source.js');
       await component.getNextUpdatePromise();
       expect(element.dataset.grammar).toBe('source js');
     });
@@ -4064,7 +4064,7 @@ describe('TextEditorComponent', () => {
     describe('on the lines', () => {
       describe('when there is only one cursor', () => {
         it('positions the cursor on single-click or when middle-clicking', async () => {
-          atom.config.set('editor.selectionClipboard', false);
+          core.config.set('editor.selectionClipboard', false);
           for (const button of [0, 1]) {
             const { component, editor } = buildComponent();
             const { lineHeight } = component.measurements;
@@ -4235,7 +4235,7 @@ describe('TextEditorComponent', () => {
         });
 
         it('adds or removes cursors when holding cmd or ctrl when single-clicking', () => {
-          atom.config.set('editor.multiCursorOnClick', true);
+          core.config.set('editor.multiCursorOnClick', true);
           const { component, editor } = buildComponent({ platform: 'darwin' });
           expect(editor.getCursorScreenPositions()).toEqual([[0, 0]]);
 
@@ -4316,7 +4316,7 @@ describe('TextEditorComponent', () => {
         });
 
         it('adds word selections when holding cmd or ctrl when double-clicking', () => {
-          atom.config.set('editor.multiCursorOnClick', true);
+          core.config.set('editor.multiCursorOnClick', true);
           const { component, editor } = buildComponent();
           editor.addCursorAtScreenPosition([1, 16], { autoscroll: false });
           expect(editor.getCursorScreenPositions()).toEqual([[0, 0], [1, 16]]);
@@ -4343,7 +4343,7 @@ describe('TextEditorComponent', () => {
         });
 
         it('adds line selections when holding cmd or ctrl when triple-clicking', () => {
-          atom.config.set('editor.multiCursorOnClick', true);
+          core.config.set('editor.multiCursorOnClick', true);
           const { component, editor } = buildComponent();
           editor.addCursorAtScreenPosition([1, 16], { autoscroll: false });
           expect(editor.getCursorScreenPositions()).toEqual([[0, 0], [1, 16]]);
@@ -4383,7 +4383,7 @@ describe('TextEditorComponent', () => {
         });
 
         it('does not add cursors when holding cmd or ctrl when single-clicking', () => {
-          atom.config.set('editor.multiCursorOnClick', false);
+          core.config.set('editor.multiCursorOnClick', false);
           const { component, editor } = buildComponent({ platform: 'darwin' });
           expect(editor.getCursorScreenPositions()).toEqual([[0, 0]]);
 
@@ -4425,7 +4425,7 @@ describe('TextEditorComponent', () => {
         });
 
         it('does not add word selections when holding cmd or ctrl when double-clicking', () => {
-          atom.config.set('editor.multiCursorOnClick', false);
+          core.config.set('editor.multiCursorOnClick', false);
           const { component, editor } = buildComponent();
 
           component.didMouseDownOnContent(
@@ -4449,7 +4449,7 @@ describe('TextEditorComponent', () => {
         });
 
         it('does not add line selections when holding cmd or ctrl when triple-clicking', () => {
-          atom.config.set('editor.multiCursorOnClick', false);
+          core.config.set('editor.multiCursorOnClick', false);
           const { component, editor } = buildComponent();
 
           const { clientX, clientY } = clientPositionForCharacter(
@@ -4571,7 +4571,7 @@ describe('TextEditorComponent', () => {
         });
 
         it('expands the last selection on drag', () => {
-          atom.config.set('editor.multiCursorOnClick', true);
+          core.config.set('editor.multiCursorOnClick', true);
           const { component, editor } = buildComponent();
           spyOn(component, 'handleMouseDragUntilMouseUp');
 
@@ -4812,7 +4812,7 @@ describe('TextEditorComponent', () => {
         const { component, editor } = buildComponent({ platform: 'linux' });
 
         // Middle mouse pasting.
-        atom.config.set('editor.selectionClipboard', true);
+        core.config.set('editor.selectionClipboard', true);
         editor.setSelectedBufferRange([[1, 6], [1, 10]]);
         await conditionPromise(() => TextEditor.clipboard.read() === 'sort');
         component.didMouseDownOnContent({
@@ -4825,7 +4825,7 @@ describe('TextEditorComponent', () => {
         editor.undo();
 
         // Doesn't paste when middle mouse button is clicked
-        atom.config.set('editor.selectionClipboard', false);
+        core.config.set('editor.selectionClipboard', false);
         editor.setSelectedBufferRange([[1, 6], [1, 10]]);
         component.didMouseDownOnContent({
           button: 1,
@@ -4836,7 +4836,7 @@ describe('TextEditorComponent', () => {
         expect(editor.lineTextForBufferRow(10)).toBe('');
 
         // Ensure left clicks don't interfere.
-        atom.config.set('editor.selectionClipboard', true);
+        core.config.set('editor.selectionClipboard', true);
         editor.setSelectedBufferRange([[1, 2], [1, 5]]);
         await conditionPromise(() => TextEditor.clipboard.read() === 'var');
         component.didMouseDownOnContent({
@@ -6166,7 +6166,7 @@ function buildEditor(params = {}) {
   ]) {
     if (params[paramName] != null) editorParams[paramName] = params[paramName];
   }
-  atom.grammars.autoAssignLanguageMode(buffer);
+  core.grammars.autoAssignLanguageMode(buffer);
   const editor = new TextEditor(editorParams);
   editor.testAutoscrollRequests = [];
   editor.onDidRequestAutoscroll(request => {

--- a/spec/text-editor-element-spec.js
+++ b/spec/text-editor-element-spec.js
@@ -109,7 +109,7 @@ describe('TextEditorElement', () => {
     it("adds the 'mini' attribute if .isMini() returns true on the model", async () => {
       const element = buildTextEditorElement();
       element.getModel().update({ mini: true });
-      await atom.views.getNextUpdatePromise();
+      await core.views.getNextUpdatePromise();
       expect(element.hasAttribute('mini')).toBe(true);
     }));
 

--- a/spec/text-editor-registry-spec.js
+++ b/spec/text-editor-registry-spec.js
@@ -12,9 +12,9 @@ describe('TextEditorRegistry', function() {
     initialPackageActivation = Promise.resolve();
 
     registry = new TextEditorRegistry({
-      assert: atom.assert,
-      config: atom.config,
-      grammarRegistry: atom.grammars,
+      assert: core.assert,
+      config: core.config,
+      grammarRegistry: core.grammars,
       packageManager: {
         getActivatePromise() {
           return initialPackageActivation;
@@ -24,7 +24,7 @@ describe('TextEditorRegistry', function() {
 
     editor = new TextEditor({ autoHeight: false });
     expect(
-      atom.grammars.assignLanguageMode(editor, 'text.plain.null-grammar')
+      core.grammars.assignLanguageMode(editor, 'text.plain.null-grammar')
     ).toBe(true);
   });
 
@@ -71,7 +71,7 @@ describe('TextEditorRegistry', function() {
 
   describe('.build', function() {
     it('constructs a TextEditor with the right parameters based on its path and text', function() {
-      atom.config.set('editor.tabLength', 8, { scope: '.source.js' });
+      core.config.set('editor.tabLength', 8, { scope: '.source.js' });
 
       const languageMode = {
         grammar: NullGrammar,
@@ -104,11 +104,11 @@ describe('TextEditorRegistry', function() {
 
   describe('.maintainConfig(editor)', function() {
     it('does not update the editor when config settings change for unrelated scope selectors', async function() {
-      await atom.packages.activatePackage('language-javascript');
+      await core.packages.activatePackage('language-javascript');
 
       const editor2 = new TextEditor();
 
-      atom.grammars.assignLanguageMode(editor2, 'source.js');
+      core.grammars.assignLanguageMode(editor2, 'source.js');
 
       registry.maintainConfig(editor);
       registry.maintainConfig(editor2);
@@ -124,10 +124,10 @@ describe('TextEditorRegistry', function() {
       expect(editor.getEncoding()).toBe('utf8');
       expect(editor2.getEncoding()).toBe('utf8');
 
-      atom.config.set('core.fileEncoding', 'utf16le', {
+      core.config.set('core.fileEncoding', 'utf16le', {
         scopeSelector: '.text.plain.null-grammar'
       });
-      atom.config.set('core.fileEncoding', 'utf16be', {
+      core.config.set('core.fileEncoding', 'utf16be', {
         scopeSelector: '.source.js'
       });
 
@@ -141,13 +141,13 @@ describe('TextEditorRegistry', function() {
         resolveActivatePromise = resolve;
       });
 
-      atom.config.set('core.fileEncoding', 'utf16le');
+      core.config.set('core.fileEncoding', 'utf16le');
 
       registry.maintainConfig(editor);
       await Promise.resolve();
       expect(editor.getEncoding()).toBe('utf8');
 
-      atom.config.set('core.fileEncoding', 'utf16be');
+      core.config.set('core.fileEncoding', 'utf16be');
       await Promise.resolve();
       expect(editor.getEncoding()).toBe('utf8');
 
@@ -157,37 +157,37 @@ describe('TextEditorRegistry', function() {
     });
 
     it("updates the editor's settings when its grammar changes", async function() {
-      await atom.packages.activatePackage('language-javascript');
+      await core.packages.activatePackage('language-javascript');
 
       registry.maintainConfig(editor);
       await initialPackageActivation;
 
-      atom.config.set('core.fileEncoding', 'utf16be', {
+      core.config.set('core.fileEncoding', 'utf16be', {
         scopeSelector: '.source.js'
       });
       expect(editor.getEncoding()).toBe('utf8');
 
-      atom.config.set('core.fileEncoding', 'utf16le', {
+      core.config.set('core.fileEncoding', 'utf16le', {
         scopeSelector: '.source.js'
       });
       expect(editor.getEncoding()).toBe('utf8');
 
-      atom.grammars.assignLanguageMode(editor, 'source.js');
+      core.grammars.assignLanguageMode(editor, 'source.js');
       await initialPackageActivation;
       expect(editor.getEncoding()).toBe('utf16le');
 
-      atom.config.set('core.fileEncoding', 'utf16be', {
+      core.config.set('core.fileEncoding', 'utf16be', {
         scopeSelector: '.source.js'
       });
       expect(editor.getEncoding()).toBe('utf16be');
 
-      atom.grammars.assignLanguageMode(editor, 'text.plain.null-grammar');
+      core.grammars.assignLanguageMode(editor, 'text.plain.null-grammar');
       await initialPackageActivation;
       expect(editor.getEncoding()).toBe('utf8');
     });
 
     it("preserves editor settings that haven't changed between previous and current language modes", async function() {
-      await atom.packages.activatePackage('language-javascript');
+      await core.packages.activatePackage('language-javascript');
 
       registry.maintainConfig(editor);
       await initialPackageActivation;
@@ -200,23 +200,23 @@ describe('TextEditorRegistry', function() {
       editor.setSoftWrapped(true);
       expect(editor.isSoftWrapped()).toBe(true);
 
-      atom.grammars.assignLanguageMode(editor, 'source.js');
+      core.grammars.assignLanguageMode(editor, 'source.js');
       await initialPackageActivation;
       expect(editor.getEncoding()).toBe('utf16le');
       expect(editor.isSoftWrapped()).toBe(true);
     });
 
     it('updates editor settings that have changed between previous and current language modes', async function() {
-      await atom.packages.activatePackage('language-javascript');
+      await core.packages.activatePackage('language-javascript');
 
       registry.maintainConfig(editor);
       await initialPackageActivation;
 
       expect(editor.getEncoding()).toBe('utf8');
-      atom.config.set('core.fileEncoding', 'utf16be', {
+      core.config.set('core.fileEncoding', 'utf16be', {
         scopeSelector: '.text.plain.null-grammar'
       });
-      atom.config.set('core.fileEncoding', 'utf16le', {
+      core.config.set('core.fileEncoding', 'utf16le', {
         scopeSelector: '.source.js'
       });
       expect(editor.getEncoding()).toBe('utf16be');
@@ -224,13 +224,13 @@ describe('TextEditorRegistry', function() {
       editor.setEncoding('utf8');
       expect(editor.getEncoding()).toBe('utf8');
 
-      atom.grammars.assignLanguageMode(editor, 'source.js');
+      core.grammars.assignLanguageMode(editor, 'source.js');
       await initialPackageActivation;
       expect(editor.getEncoding()).toBe('utf16le');
     });
 
     it("returns a disposable that can be used to stop the registry from updating the editor's config", async function() {
-      await atom.packages.activatePackage('language-javascript');
+      await core.packages.activatePackage('language-javascript');
 
       const previousSubscriptionCount = getSubscriptionCount(editor);
       const disposable = registry.maintainConfig(editor);
@@ -240,14 +240,14 @@ describe('TextEditorRegistry', function() {
       );
       expect(registry.editorsWithMaintainedConfig.size).toBe(1);
 
-      atom.config.set('core.fileEncoding', 'utf16be');
+      core.config.set('core.fileEncoding', 'utf16be');
       expect(editor.getEncoding()).toBe('utf16be');
-      atom.config.set('core.fileEncoding', 'utf8');
+      core.config.set('core.fileEncoding', 'utf8');
       expect(editor.getEncoding()).toBe('utf8');
 
       disposable.dispose();
 
-      atom.config.set('core.fileEncoding', 'utf16be');
+      core.config.set('core.fileEncoding', 'utf16be');
       expect(editor.getEncoding()).toBe('utf8');
       expect(getSubscriptionCount(editor)).toBe(previousSubscriptionCount);
       expect(retainedEditorCount(registry)).toBe(0);
@@ -257,12 +257,12 @@ describe('TextEditorRegistry', function() {
       editor.update({ encoding: 'utf8' });
       expect(editor.getEncoding()).toBe('utf8');
 
-      atom.config.set('core.fileEncoding', 'utf16le');
+      core.config.set('core.fileEncoding', 'utf16le');
       registry.maintainConfig(editor);
       await initialPackageActivation;
       expect(editor.getEncoding()).toBe('utf16le');
 
-      atom.config.set('core.fileEncoding', 'utf8');
+      core.config.set('core.fileEncoding', 'utf8');
       expect(editor.getEncoding()).toBe('utf8');
     });
 
@@ -270,24 +270,24 @@ describe('TextEditorRegistry', function() {
       editor.update({ tabLength: 4 });
       expect(editor.getTabLength()).toBe(4);
 
-      atom.config.set('editor.tabLength', 8);
+      core.config.set('editor.tabLength', 8);
       registry.maintainConfig(editor);
       await initialPackageActivation;
       expect(editor.getTabLength()).toBe(8);
 
-      atom.config.set('editor.tabLength', 4);
+      core.config.set('editor.tabLength', 4);
       expect(editor.getTabLength()).toBe(4);
     });
 
     it('enables soft tabs when the tabType config setting is "soft"', async function() {
-      atom.config.set('editor.tabType', 'soft');
+      core.config.set('editor.tabType', 'soft');
       registry.maintainConfig(editor);
       await initialPackageActivation;
       expect(editor.getSoftTabs()).toBe(true);
     });
 
     it('disables soft tabs when the tabType config setting is "hard"', async function() {
-      atom.config.set('editor.tabType', 'hard');
+      core.config.set('editor.tabType', 'hard');
       registry.maintainConfig(editor);
       await initialPackageActivation;
       expect(editor.getSoftTabs()).toBe(false);
@@ -296,9 +296,9 @@ describe('TextEditorRegistry', function() {
     describe('when the "tabType" config setting is "auto"', function() {
       it("enables or disables soft tabs based on the editor's content", async function() {
         await initialPackageActivation;
-        await atom.packages.activatePackage('language-javascript');
-        atom.grammars.assignLanguageMode(editor, 'source.js');
-        atom.config.set('editor.tabType', 'auto');
+        await core.packages.activatePackage('language-javascript');
+        core.grammars.assignLanguageMode(editor, 'source.js');
+        core.config.set('editor.tabType', 'auto');
         await initialPackageActivation;
 
         editor.setText(dedent`
@@ -368,11 +368,11 @@ describe('TextEditorRegistry', function() {
         await initialPackageActivation;
 
         editor.setText('abc\ndef');
-        atom.config.set('editor.softTabs', true);
-        atom.config.set('editor.tabType', 'auto');
+        core.config.set('editor.softTabs', true);
+        core.config.set('editor.tabType', 'auto');
         expect(editor.getSoftTabs()).toBe(true);
 
-        atom.config.set('editor.softTabs', false);
+        core.config.set('editor.softTabs', false);
         expect(editor.getSoftTabs()).toBe(false);
       });
     });
@@ -381,16 +381,16 @@ describe('TextEditorRegistry', function() {
       editor.update({ softTabs: true });
       expect(editor.getSoftTabs()).toBe(true);
 
-      atom.config.set('editor.tabType', 'hard');
+      core.config.set('editor.tabType', 'hard');
       registry.maintainConfig(editor);
       await initialPackageActivation;
       expect(editor.getSoftTabs()).toBe(false);
 
-      atom.config.set('editor.tabType', 'soft');
+      core.config.set('editor.tabType', 'soft');
       expect(editor.getSoftTabs()).toBe(true);
 
-      atom.config.set('editor.tabType', 'auto');
-      atom.config.set('editor.softTabs', true);
+      core.config.set('editor.tabType', 'auto');
+      core.config.set('editor.softTabs', true);
       expect(editor.getSoftTabs()).toBe(true);
     });
 
@@ -398,12 +398,12 @@ describe('TextEditorRegistry', function() {
       editor.update({ atomicSoftTabs: true });
       expect(editor.hasAtomicSoftTabs()).toBe(true);
 
-      atom.config.set('editor.atomicSoftTabs', false);
+      core.config.set('editor.atomicSoftTabs', false);
       registry.maintainConfig(editor);
       await initialPackageActivation;
       expect(editor.hasAtomicSoftTabs()).toBe(false);
 
-      atom.config.set('editor.atomicSoftTabs', true);
+      core.config.set('editor.atomicSoftTabs', true);
       expect(editor.hasAtomicSoftTabs()).toBe(true);
     });
 
@@ -411,12 +411,12 @@ describe('TextEditorRegistry', function() {
       editor.update({ showCursorOnSelection: true });
       expect(editor.getShowCursorOnSelection()).toBe(true);
 
-      atom.config.set('editor.showCursorOnSelection', false);
+      core.config.set('editor.showCursorOnSelection', false);
       registry.maintainConfig(editor);
       await initialPackageActivation;
       expect(editor.getShowCursorOnSelection()).toBe(false);
 
-      atom.config.set('editor.showCursorOnSelection', true);
+      core.config.set('editor.showCursorOnSelection', true);
       expect(editor.getShowCursorOnSelection()).toBe(true);
     });
 
@@ -424,12 +424,12 @@ describe('TextEditorRegistry', function() {
       editor.update({ showLineNumbers: true });
       expect(editor.showLineNumbers).toBe(true);
 
-      atom.config.set('editor.showLineNumbers', false);
+      core.config.set('editor.showLineNumbers', false);
       registry.maintainConfig(editor);
       await initialPackageActivation;
       expect(editor.showLineNumbers).toBe(false);
 
-      atom.config.set('editor.showLineNumbers', true);
+      core.config.set('editor.showLineNumbers', true);
       expect(editor.showLineNumbers).toBe(true);
     });
 
@@ -443,16 +443,16 @@ describe('TextEditorRegistry', function() {
       });
       expect(editor.getInvisibles()).toEqual(invisibles1);
 
-      atom.config.set('editor.showInvisibles', true);
-      atom.config.set('editor.invisibles', invisibles2);
+      core.config.set('editor.showInvisibles', true);
+      core.config.set('editor.invisibles', invisibles2);
       registry.maintainConfig(editor);
       await initialPackageActivation;
       expect(editor.getInvisibles()).toEqual(invisibles2);
 
-      atom.config.set('editor.invisibles', invisibles1);
+      core.config.set('editor.invisibles', invisibles1);
       expect(editor.getInvisibles()).toEqual(invisibles1);
 
-      atom.config.set('editor.showInvisibles', false);
+      core.config.set('editor.showInvisibles', false);
       expect(editor.getInvisibles()).toEqual({});
     });
 
@@ -460,12 +460,12 @@ describe('TextEditorRegistry', function() {
       editor.update({ showIndentGuide: true });
       expect(editor.doesShowIndentGuide()).toBe(true);
 
-      atom.config.set('editor.showIndentGuide', false);
+      core.config.set('editor.showIndentGuide', false);
       registry.maintainConfig(editor);
       await initialPackageActivation;
       expect(editor.doesShowIndentGuide()).toBe(false);
 
-      atom.config.set('editor.showIndentGuide', true);
+      core.config.set('editor.showIndentGuide', true);
       expect(editor.doesShowIndentGuide()).toBe(true);
     });
 
@@ -473,12 +473,12 @@ describe('TextEditorRegistry', function() {
       editor.update({ softWrapped: true });
       expect(editor.isSoftWrapped()).toBe(true);
 
-      atom.config.set('editor.softWrap', false);
+      core.config.set('editor.softWrap', false);
       registry.maintainConfig(editor);
       await initialPackageActivation;
       expect(editor.isSoftWrapped()).toBe(false);
 
-      atom.config.set('editor.softWrap', true);
+      core.config.set('editor.softWrap', true);
       expect(editor.isSoftWrapped()).toBe(true);
     });
 
@@ -486,12 +486,12 @@ describe('TextEditorRegistry', function() {
       editor.update({ softWrapHangingIndentLength: 4 });
       expect(editor.getSoftWrapHangingIndentLength()).toBe(4);
 
-      atom.config.set('editor.softWrapHangingIndent', 2);
+      core.config.set('editor.softWrapHangingIndent', 2);
       registry.maintainConfig(editor);
       await initialPackageActivation;
       expect(editor.getSoftWrapHangingIndentLength()).toBe(2);
 
-      atom.config.set('editor.softWrapHangingIndent', 4);
+      core.config.set('editor.softWrapHangingIndent', 4);
       expect(editor.getSoftWrapHangingIndentLength()).toBe(4);
     });
 
@@ -505,13 +505,13 @@ describe('TextEditorRegistry', function() {
 
       expect(editor.getSoftWrapColumn()).toBe(80);
 
-      atom.config.set('editor.softWrap', true);
-      atom.config.set('editor.softWrapAtPreferredLineLength', false);
+      core.config.set('editor.softWrap', true);
+      core.config.set('editor.softWrapAtPreferredLineLength', false);
       registry.maintainConfig(editor);
       await initialPackageActivation;
       expect(editor.getSoftWrapColumn()).toBe(120);
 
-      atom.config.set('editor.softWrapAtPreferredLineLength', true);
+      core.config.set('editor.softWrapAtPreferredLineLength', true);
       expect(editor.getSoftWrapColumn()).toBe(80);
     });
 
@@ -523,8 +523,8 @@ describe('TextEditorRegistry', function() {
 
       expect(editor.getSoftWrapColumn()).toBe(1500);
 
-      atom.config.set('editor.softWrap', false);
-      atom.config.set('editor.maxScreenLineLength', 500);
+      core.config.set('editor.softWrap', false);
+      core.config.set('editor.maxScreenLineLength', 500);
       registry.maintainConfig(editor);
       await initialPackageActivation;
       expect(editor.getSoftWrapColumn()).toBe(500);
@@ -534,12 +534,12 @@ describe('TextEditorRegistry', function() {
       editor.update({ preferredLineLength: 80 });
       expect(editor.getPreferredLineLength()).toBe(80);
 
-      atom.config.set('editor.preferredLineLength', 110);
+      core.config.set('editor.preferredLineLength', 110);
       registry.maintainConfig(editor);
       await initialPackageActivation;
       expect(editor.getPreferredLineLength()).toBe(110);
 
-      atom.config.set('editor.preferredLineLength', 80);
+      core.config.set('editor.preferredLineLength', 80);
       expect(editor.getPreferredLineLength()).toBe(80);
     });
 
@@ -547,12 +547,12 @@ describe('TextEditorRegistry', function() {
       editor.update({ autoIndent: true });
       expect(editor.shouldAutoIndent()).toBe(true);
 
-      atom.config.set('editor.autoIndent', false);
+      core.config.set('editor.autoIndent', false);
       registry.maintainConfig(editor);
       await initialPackageActivation;
       expect(editor.shouldAutoIndent()).toBe(false);
 
-      atom.config.set('editor.autoIndent', true);
+      core.config.set('editor.autoIndent', true);
       expect(editor.shouldAutoIndent()).toBe(true);
     });
 
@@ -560,12 +560,12 @@ describe('TextEditorRegistry', function() {
       editor.update({ autoIndentOnPaste: true });
       expect(editor.shouldAutoIndentOnPaste()).toBe(true);
 
-      atom.config.set('editor.autoIndentOnPaste', false);
+      core.config.set('editor.autoIndentOnPaste', false);
       registry.maintainConfig(editor);
       await initialPackageActivation;
       expect(editor.shouldAutoIndentOnPaste()).toBe(false);
 
-      atom.config.set('editor.autoIndentOnPaste', true);
+      core.config.set('editor.autoIndentOnPaste', true);
       expect(editor.shouldAutoIndentOnPaste()).toBe(true);
     });
 
@@ -573,12 +573,12 @@ describe('TextEditorRegistry', function() {
       editor.update({ scrollPastEnd: true });
       expect(editor.getScrollPastEnd()).toBe(true);
 
-      atom.config.set('editor.scrollPastEnd', false);
+      core.config.set('editor.scrollPastEnd', false);
       registry.maintainConfig(editor);
       await initialPackageActivation;
       expect(editor.getScrollPastEnd()).toBe(false);
 
-      atom.config.set('editor.scrollPastEnd', true);
+      core.config.set('editor.scrollPastEnd', true);
       expect(editor.getScrollPastEnd()).toBe(true);
     });
 
@@ -586,12 +586,12 @@ describe('TextEditorRegistry', function() {
       editor.update({ undoGroupingInterval: 300 });
       expect(editor.getUndoGroupingInterval()).toBe(300);
 
-      atom.config.set('editor.undoGroupingInterval', 600);
+      core.config.set('editor.undoGroupingInterval', 600);
       registry.maintainConfig(editor);
       await initialPackageActivation;
       expect(editor.getUndoGroupingInterval()).toBe(600);
 
-      atom.config.set('editor.undoGroupingInterval', 300);
+      core.config.set('editor.undoGroupingInterval', 300);
       expect(editor.getUndoGroupingInterval()).toBe(300);
     });
 
@@ -599,12 +599,12 @@ describe('TextEditorRegistry', function() {
       editor.update({ scrollSensitivity: 50 });
       expect(editor.getScrollSensitivity()).toBe(50);
 
-      atom.config.set('editor.scrollSensitivity', 60);
+      core.config.set('editor.scrollSensitivity', 60);
       registry.maintainConfig(editor);
       await initialPackageActivation;
       expect(editor.getScrollSensitivity()).toBe(60);
 
-      atom.config.set('editor.scrollSensitivity', 70);
+      core.config.set('editor.scrollSensitivity', 70);
       expect(editor.getScrollSensitivity()).toBe(70);
     });
 
@@ -616,15 +616,15 @@ describe('TextEditorRegistry', function() {
         const disposable2 = registry.maintainConfig(editor);
         await initialPackageActivation;
 
-        atom.config.set('editor.scrollSensitivity', 60);
+        core.config.set('editor.scrollSensitivity', 60);
         expect(editor.getScrollSensitivity()).toBe(60);
 
         disposable2.dispose();
-        atom.config.set('editor.scrollSensitivity', 70);
+        core.config.set('editor.scrollSensitivity', 70);
         expect(editor.getScrollSensitivity()).toBe(70);
 
         disposable1.dispose();
-        atom.config.set('editor.scrollSensitivity', 80);
+        core.config.set('editor.scrollSensitivity', 80);
         expect(editor.getScrollSensitivity()).toBe(70);
       });
     });

--- a/spec/text-editor-spec.js
+++ b/spec/text-editor-spec.js
@@ -13,11 +13,11 @@ describe('TextEditor', () => {
   let buffer, editor, lineLengths;
 
   beforeEach(async () => {
-    editor = await atom.workspace.open('sample.js');
+    editor = await core.workspace.open('sample.js');
     buffer = editor.buffer;
     editor.update({ autoIndent: false });
     lineLengths = buffer.getLines().map(line => line.length);
-    await atom.packages.activatePackage('language-javascript');
+    await core.packages.activatePackage('language-javascript');
   });
 
   it('generates unique ids for each editor', async () => {
@@ -40,8 +40,8 @@ describe('TextEditor', () => {
 
       const buffer2 = await TextBuffer.deserialize(editor.buffer.serialize());
       const editor2 = TextEditor.deserialize(editor.serialize(), {
-        assert: atom.assert,
-        textEditors: atom.textEditors,
+        assert: core.assert,
+        textEditors: core.textEditors,
         project: {
           bufferForIdSync() {
             return buffer2;
@@ -77,8 +77,8 @@ describe('TextEditor', () => {
       // reusing the same buffer instance
       const buffer2 = await TextBuffer.deserialize(editor.buffer.serialize());
       const editor2 = TextEditor.deserialize(editor.serialize(), {
-        assert: atom.assert,
-        textEditors: atom.textEditors,
+        assert: core.assert,
+        textEditors: core.textEditors,
         project: {
           bufferForIdSync() {
             return buffer2;
@@ -105,8 +105,8 @@ describe('TextEditor', () => {
 
     it('ignores buffers with retired IDs', () => {
       const editor2 = TextEditor.deserialize(editor.serialize(), {
-        assert: atom.assert,
-        textEditors: atom.textEditors,
+        assert: core.assert,
+        textEditors: core.textEditors,
         project: {
           bufferForIdSync() {
             return null;
@@ -220,10 +220,10 @@ describe('TextEditor', () => {
       });
 
       it("returns '<filename> — <parent-directory>' when opened files have identical file names", async () => {
-        const editor1 = await atom.workspace.open(
+        const editor1 = await core.workspace.open(
           path.join('sample-theme-1', 'readme')
         );
-        const editor2 = await atom.workspace.open(
+        const editor2 = await core.workspace.open(
           path.join('sample-theme-2', 'readme')
         );
         expect(editor1.getLongTitle()).toBe('readme \u2014 sample-theme-1');
@@ -233,17 +233,17 @@ describe('TextEditor', () => {
       it("returns '<filename> — <parent-directories>' when opened files have identical file names in subdirectories", async () => {
         const path1 = path.join('sample-theme-1', 'src', 'js');
         const path2 = path.join('sample-theme-2', 'src', 'js');
-        const editor1 = await atom.workspace.open(path.join(path1, 'main.js'));
-        const editor2 = await atom.workspace.open(path.join(path2, 'main.js'));
+        const editor1 = await core.workspace.open(path.join(path1, 'main.js'));
+        const editor2 = await core.workspace.open(path.join(path2, 'main.js'));
         expect(editor1.getLongTitle()).toBe(`main.js \u2014 ${path1}`);
         expect(editor2.getLongTitle()).toBe(`main.js \u2014 ${path2}`);
       });
 
       it("returns '<filename> — <parent-directories>' when opened files have identical file and same parent dir name", async () => {
-        const editor1 = await atom.workspace.open(
+        const editor1 = await core.workspace.open(
           path.join('sample-theme-2', 'src', 'js', 'main.js')
         );
-        const editor2 = await atom.workspace.open(
+        const editor2 = await core.workspace.open(
           path.join('sample-theme-2', 'src', 'js', 'plugin', 'main.js')
         );
         expect(editor1.getLongTitle()).toBe('main.js \u2014 js');
@@ -257,7 +257,7 @@ describe('TextEditor', () => {
           expect(editor.getLongTitle()).toBe('sample.js');
         });
 
-        await atom.workspace.getActivePane().close();
+        await core.workspace.getActivePane().close();
         expect(editor.isDestroyed()).toBe(true);
       });
     });
@@ -1431,7 +1431,7 @@ describe('TextEditor', () => {
       });
 
       it('will limit paragraph range to comments', () => {
-        atom.grammars.assignLanguageMode(editor.getBuffer(), 'source.js');
+        core.grammars.assignLanguageMode(editor.getBuffer(), 'source.js');
         editor.setText(dedent`
           var quicksort = function () {
             /* Single line comment block */
@@ -2474,7 +2474,7 @@ describe('TextEditor', () => {
         });
 
         it('takes atomic tokens into account', async () => {
-          editor = await atom.workspace.open(
+          editor = await core.workspace.open(
             'sample-with-tabs-and-leading-comment.coffee',
             { autoIndent: false }
           );
@@ -2614,7 +2614,7 @@ describe('TextEditor', () => {
         });
 
         it('takes atomic tokens into account', async () => {
-          editor = await atom.workspace.open(
+          editor = await core.workspace.open(
             'sample-with-tabs-and-leading-comment.coffee',
             { autoIndent: false }
           );
@@ -2793,8 +2793,8 @@ describe('TextEditor', () => {
     });
 
     it('does not share selections between different edit sessions for the same buffer', async () => {
-      atom.workspace.getActivePane().splitRight();
-      const editor2 = await atom.workspace.open(editor.getPath());
+      core.workspace.getActivePane().splitRight();
+      const editor2 = await core.workspace.open(editor.getPath());
 
       expect(editor2.getText()).toBe(editor.getText());
       editor.setSelectedBufferRanges([[[1, 2], [3, 4]], [[5, 6], [7, 8]]]);
@@ -3208,7 +3208,7 @@ describe('TextEditor', () => {
 
         describe('when there are many folds', () => {
           beforeEach(async () => {
-            editor = await atom.workspace.open('sample-with-many-folds.js', {
+            editor = await core.workspace.open('sample-with-many-folds.js', {
               autoIndent: false
             });
           });
@@ -3644,7 +3644,7 @@ describe('TextEditor', () => {
 
           describe('when there are many folds', () => {
             beforeEach(async () => {
-              editor = await atom.workspace.open('sample-with-many-folds.js', {
+              editor = await core.workspace.open('sample-with-many-folds.js', {
                 autoIndent: false
               });
             });
@@ -4243,7 +4243,7 @@ describe('TextEditor', () => {
       describe('when a newline is appended with a trailing closing tag behind the cursor (e.g. by pressing enter in the middel of a line)', () => {
         it('indents the new line to the correct level when editor.autoIndent is true and using a curly-bracket language', () => {
           editor.update({ autoIndent: true });
-          atom.grammars.assignLanguageMode(editor, 'source.js');
+          core.grammars.assignLanguageMode(editor, 'source.js');
           editor.setText('var test = () => {\n  return true;};');
           editor.setCursorBufferPosition([1, 14]);
           editor.insertNewline();
@@ -4252,20 +4252,20 @@ describe('TextEditor', () => {
         });
 
         it('indents the new line to the current level when editor.autoIndent is true and no increaseIndentPattern is specified', () => {
-          atom.grammars.assignLanguageMode(editor, null);
+          core.grammars.assignLanguageMode(editor, null);
           editor.update({ autoIndent: true });
           editor.setText('  if true');
           editor.setCursorBufferPosition([0, 8]);
           editor.insertNewline();
-          expect(editor.getGrammar()).toBe(atom.grammars.nullGrammar);
+          expect(editor.getGrammar()).toBe(core.grammars.nullGrammar);
           expect(editor.indentationForBufferRow(0)).toBe(1);
           expect(editor.indentationForBufferRow(1)).toBe(1);
         });
 
         it('indents the new line to the correct level when editor.autoIndent is true and using an off-side rule language', async () => {
-          await atom.packages.activatePackage('language-coffee-script');
+          await core.packages.activatePackage('language-coffee-script');
           editor.update({ autoIndent: true });
-          atom.grammars.assignLanguageMode(editor, 'source.coffee');
+          core.grammars.assignLanguageMode(editor, 'source.coffee');
           editor.setText('if true\n  return trueelse\n  return false');
           editor.setCursorBufferPosition([1, 13]);
           editor.insertNewline();
@@ -4277,9 +4277,9 @@ describe('TextEditor', () => {
 
       describe('when a newline is appended on a line that matches the decreaseNextIndentPattern', () => {
         it('indents the new line to the correct level when editor.autoIndent is true', async () => {
-          await atom.packages.activatePackage('language-go');
+          await core.packages.activatePackage('language-go');
           editor.update({ autoIndent: true });
-          atom.grammars.assignLanguageMode(editor, 'source.go');
+          core.grammars.assignLanguageMode(editor, 'source.go');
           editor.setText('fmt.Printf("some%s",\n	"thing")'); // eslint-disable-line no-tabs
           editor.setCursorBufferPosition([1, 10]);
           editor.insertNewline();
@@ -5070,7 +5070,7 @@ describe('TextEditor', () => {
               '      current < pivot ? left.push(current) : right.push(current);'
             );
 
-            expect(atom.clipboard.read()).toEqual(
+            expect(core.clipboard.read()).toEqual(
               [
                 'var quicksort = function () {',
                 '',
@@ -5089,7 +5089,7 @@ describe('TextEditor', () => {
               [[1, 6], [1, 10]]
             ]);
             editor.cutSelectedText();
-            expect(atom.clipboard.read()).toEqual(
+            expect(core.clipboard.read()).toEqual(
               ['quicksort', 'sort', 'items'].join(os.EOL)
             );
           });
@@ -5118,7 +5118,7 @@ describe('TextEditor', () => {
               editor.cutToEndOfLine();
               expect(buffer.lineForRow(2)).toBe('    if (items.length');
               expect(buffer.lineForRow(3)).toBe('    var pivot = item');
-              expect(atom.clipboard.read()).toBe(
+              expect(core.clipboard.read()).toBe(
                 ` <= 1) return items;${
                   os.EOL
                 }s.shift(), current, left = [], right = [];`
@@ -5136,7 +5136,7 @@ describe('TextEditor', () => {
                 '    if (items.lengthurn items;'
               );
               expect(buffer.lineForRow(3)).toBe('    var pivot = item');
-              expect(atom.clipboard.read()).toBe(
+              expect(core.clipboard.read()).toBe(
                 ` <= 1) ret${os.EOL}s.shift(), current, left = [], right = [];`
               );
             }));
@@ -5156,7 +5156,7 @@ describe('TextEditor', () => {
             editor.cutToEndOfBufferLine();
             expect(buffer.lineForRow(2)).toBe('    if (items.length');
             expect(buffer.lineForRow(3)).toBe('    var pivot = item');
-            expect(atom.clipboard.read()).toBe(
+            expect(core.clipboard.read()).toBe(
               ` <= 1) return items;${
                 os.EOL
               }s.shift(), current, left = [], right = [];`
@@ -5173,7 +5173,7 @@ describe('TextEditor', () => {
             editor.cutToEndOfBufferLine();
             expect(buffer.lineForRow(2)).toBe('    if (items.lengthurn items;');
             expect(buffer.lineForRow(3)).toBe('    var pivot = item');
-            expect(atom.clipboard.read()).toBe(
+            expect(core.clipboard.read()).toBe(
               ` <= 1) ret${os.EOL}s.shift(), current, left = [], right = [];`
             );
           });
@@ -5197,7 +5197,7 @@ describe('TextEditor', () => {
           expect(clipboard.readText()).toBe(
             ['quicksort', 'sort', 'items'].join(os.EOL)
           );
-          expect(atom.clipboard.read()).toEqual(
+          expect(core.clipboard.read()).toEqual(
             ['quicksort', 'sort', 'items'].join(os.EOL)
           );
         });
@@ -5212,7 +5212,7 @@ describe('TextEditor', () => {
 
           it('copies the lines on which there are cursors', () => {
             editor.copySelectedText();
-            expect(atom.clipboard.read()).toEqual(
+            expect(core.clipboard.read()).toEqual(
               [
                 `  var sort = function(items) {${os.EOL}`,
                 `      current = items.shift();${os.EOL}`
@@ -5233,7 +5233,7 @@ describe('TextEditor', () => {
               [[1, 6], [1, 10]]
             ]);
             editor.copySelectedText();
-            expect(atom.clipboard.read()).toEqual(
+            expect(core.clipboard.read()).toEqual(
               ['quicksort', 'sort', 'items'].join(os.EOL)
             );
           });
@@ -5258,7 +5258,7 @@ describe('TextEditor', () => {
             expect(clipboard.readText()).toBe(
               ['quicksort', 'sort', 'items'].join(os.EOL)
             );
-            expect(atom.clipboard.read()).toEqual(
+            expect(core.clipboard.read()).toEqual(
               ['quicksort', 'sort', 'items'].join(os.EOL)
             );
           });
@@ -5268,7 +5268,7 @@ describe('TextEditor', () => {
           it('does not copy anything', () => {
             editor.setCursorBufferPosition([1, 5]);
             editor.copyOnlySelectedText();
-            expect(atom.clipboard.read()).toEqual('initial clipboard content');
+            expect(core.clipboard.read()).toEqual('initial clipboard content');
           });
         });
       });
@@ -5279,7 +5279,7 @@ describe('TextEditor', () => {
             [[0, 4], [0, 13]],
             [[1, 6], [1, 10]]
           ]);
-          atom.clipboard.write('first');
+          core.clipboard.write('first');
           editor.pasteText();
           expect(editor.lineTextForBufferRow(0)).toBe(
             'var first = function () {'
@@ -5296,7 +5296,7 @@ describe('TextEditor', () => {
             cancel();
           });
 
-          atom.clipboard.write('hello');
+          core.clipboard.write('hello');
           editor.pasteText();
 
           expect(insertedStrings).toEqual(['hello']);
@@ -5308,7 +5308,7 @@ describe('TextEditor', () => {
             insertedStrings.push(text)
           );
 
-          atom.clipboard.write('hello');
+          core.clipboard.write('hello');
           editor.pasteText();
 
           expect(insertedStrings).toEqual(['hello']);
@@ -5319,7 +5319,7 @@ describe('TextEditor', () => {
 
           describe('when pasting multiple lines before any non-whitespace characters', () => {
             it('auto-indents the lines spanned by the pasted text, based on the first pasted line', () => {
-              atom.clipboard.write('a(x);\n  b(x);\n    c(x);\n', {
+              core.clipboard.write('a(x);\n  b(x);\n    c(x);\n', {
                 indentBasis: 0
               });
               editor.setCursorBufferPosition([5, 0]);
@@ -5340,7 +5340,7 @@ describe('TextEditor', () => {
               editor.setSoftTabs(false);
               expect(editor.indentationForBufferRow(5)).toBe(3);
 
-              atom.clipboard.write('/**\n\t * testing\n\t * indent\n\t **/\n', {
+              core.clipboard.write('/**\n\t * testing\n\t * indent\n\t **/\n', {
                 indentBasis: 1
               });
               editor.setCursorBufferPosition([5, 0]);
@@ -5356,7 +5356,7 @@ describe('TextEditor', () => {
 
           describe('when pasting line(s) above a line that matches the decreaseIndentPattern', () =>
             it('auto-indents based on the pasted line(s) only', () => {
-              atom.clipboard.write('a(x);\n  b(x);\n    c(x);\n', {
+              core.clipboard.write('a(x);\n  b(x);\n    c(x);\n', {
                 indentBasis: 0
               });
               editor.setCursorBufferPosition([7, 0]);
@@ -5370,7 +5370,7 @@ describe('TextEditor', () => {
 
           describe('when pasting a line of text without line ending', () =>
             it('does not auto-indent the text', () => {
-              atom.clipboard.write('a(x);', { indentBasis: 0 });
+              core.clipboard.write('a(x);', { indentBasis: 0 });
               editor.setCursorBufferPosition([5, 0]);
               editor.pasteText();
 
@@ -5391,7 +5391,7 @@ describe('TextEditor', () => {
                 }\
               `);
 
-              atom.clipboard.write(' z();\n h();');
+              core.clipboard.write(' z();\n h();');
               editor.setCursorBufferPosition([1, Infinity]);
 
               // The indentation of the non-standard line is unchanged.
@@ -5547,7 +5547,7 @@ describe('TextEditor', () => {
 
         it('respects options that preserve the formatting of the pasted text', () => {
           editor.update({ autoIndentOnPaste: true });
-          atom.clipboard.write('a(x);\n  b(x);\r\nc(x);\n', { indentBasis: 0 });
+          core.clipboard.write('a(x);\n  b(x);\r\nc(x);\n', { indentBasis: 0 });
           editor.setCursorBufferPosition([5, 0]);
           editor.insertText('  ');
           editor.pasteText({
@@ -6473,7 +6473,7 @@ describe('TextEditor', () => {
               [[0, 4], [0, 13]],
               [[1, 6], [1, 10]]
             ]);
-            atom.clipboard.write('first');
+            core.clipboard.write('first');
             editor.pasteText(opts);
           }
         },
@@ -6822,7 +6822,7 @@ describe('TextEditor', () => {
 
   describe("when the buffer's language mode changes", () => {
     beforeEach(() => {
-      atom.config.set('core.useTreeSitterParsers', false);
+      core.config.set('core.useTreeSitterParsers', false);
     });
 
     it('notifies onDidTokenize observers when retokenization is finished', async () => {
@@ -6834,9 +6834,9 @@ describe('TextEditor', () => {
       const events = [];
       editor.onDidTokenize(event => events.push(event));
 
-      await atom.packages.activatePackage('language-c');
+      await core.packages.activatePackage('language-c');
       expect(
-        atom.grammars.assignLanguageMode(editor.getBuffer(), 'source.c')
+        core.grammars.assignLanguageMode(editor.getBuffer(), 'source.c')
       ).toBe(true);
       advanceClock(1);
       expect(events.length).toBe(1);
@@ -6846,9 +6846,9 @@ describe('TextEditor', () => {
       const events = [];
       editor.onDidChangeGrammar(grammar => events.push(grammar));
 
-      await atom.packages.activatePackage('language-c');
+      await core.packages.activatePackage('language-c');
       expect(
-        atom.grammars.assignLanguageMode(editor.getBuffer(), 'source.c')
+        core.grammars.assignLanguageMode(editor.getBuffer(), 'source.c')
       ).toBe(true);
       expect(events.length).toBe(1);
       expect(events[0].name).toBe('C');
@@ -7379,20 +7379,20 @@ describe('TextEditor', () => {
 
   describe("when the editor's grammar has an injection selector", () => {
     beforeEach(async () => {
-      atom.config.set('core.useTreeSitterParsers', false);
-      await atom.packages.activatePackage('language-text');
-      await atom.packages.activatePackage('language-javascript');
+      core.config.set('core.useTreeSitterParsers', false);
+      await core.packages.activatePackage('language-text');
+      await core.packages.activatePackage('language-javascript');
     });
 
     it("includes the grammar's patterns when the selector matches the current scope in other grammars", async () => {
-      await atom.packages.activatePackage('language-hyperlink');
+      await core.packages.activatePackage('language-hyperlink');
 
-      const grammar = atom.grammars.selectGrammar('text.js');
+      const grammar = core.grammars.selectGrammar('text.js');
       const { line, tags } = grammar.tokenizeLine(
         'var i; // http://github.com'
       );
 
-      const tokens = atom.grammars.decodeTokens(line, tags);
+      const tokens = core.grammars.decodeTokens(line, tags);
       expect(tokens[0].value).toBe('var');
       expect(tokens[0].scopes).toEqual(['source.js', 'storage.type.var.js']);
       expect(tokens[6].value).toBe('http://github.com');
@@ -7405,7 +7405,7 @@ describe('TextEditor', () => {
 
     describe('when the grammar is added', () => {
       it('retokenizes existing buffers that contain tokens that match the injection selector', async () => {
-        editor = await atom.workspace.open('sample.js');
+        editor = await core.workspace.open('sample.js');
         editor.setText('// http://github.com');
         let tokens = editor.tokensForScreenRow(0);
         expect(tokens).toEqual([
@@ -7426,7 +7426,7 @@ describe('TextEditor', () => {
           }
         ]);
 
-        await atom.packages.activatePackage('language-hyperlink');
+        await core.packages.activatePackage('language-hyperlink');
         tokens = editor.tokensForScreenRow(0);
         expect(tokens).toEqual([
           {
@@ -7457,7 +7457,7 @@ describe('TextEditor', () => {
 
       describe('when the grammar is updated', () => {
         it('retokenizes existing buffers that contain tokens that match the injection selector', async () => {
-          editor = await atom.workspace.open('sample.js');
+          editor = await core.workspace.open('sample.js');
           editor.setText('// SELECT * FROM OCTOCATS');
           let tokens = editor.tokensForScreenRow(0);
           expect(tokens).toEqual([
@@ -7478,7 +7478,7 @@ describe('TextEditor', () => {
             }
           ]);
 
-          await atom.packages.activatePackage(
+          await core.packages.activatePackage(
             'package-with-injection-selector'
           );
           tokens = editor.tokensForScreenRow(0);
@@ -7500,7 +7500,7 @@ describe('TextEditor', () => {
             }
           ]);
 
-          await atom.packages.activatePackage('language-sql');
+          await core.packages.activatePackage('language-sql');
           tokens = editor.tokensForScreenRow(0);
           expect(tokens).toEqual([
             {
@@ -8181,15 +8181,15 @@ describe('TextEditor', () => {
 
   describe('.syntaxTreeScopeDescriptorForBufferPosition(position)', () => {
     it('returns the result of scopeDescriptorForBufferPosition() when textmate language mode is used', async () => {
-      atom.config.set('core.useTreeSitterParsers', false);
-      editor = await atom.workspace.open('sample.js', { autoIndent: false });
-      await atom.packages.activatePackage('language-javascript');
+      core.config.set('core.useTreeSitterParsers', false);
+      editor = await core.workspace.open('sample.js', { autoIndent: false });
+      await core.packages.activatePackage('language-javascript');
 
       let buffer = editor.getBuffer();
 
       let languageMode = new TextMateLanguageMode({
         buffer,
-        grammar: atom.grammars.grammarForScopeName('source.js')
+        grammar: core.grammars.grammarForScopeName('source.js')
       });
 
       buffer.setLanguageMode(languageMode);
@@ -8209,15 +8209,15 @@ describe('TextEditor', () => {
     });
 
     it('returns the result of syntaxTreeScopeDescriptorForBufferPosition() when tree-sitter language mode is used', async () => {
-      editor = await atom.workspace.open('sample.js', { autoIndent: false });
-      await atom.packages.activatePackage('language-javascript');
+      editor = await core.workspace.open('sample.js', { autoIndent: false });
+      await core.packages.activatePackage('language-javascript');
 
       let buffer = editor.getBuffer();
 
       buffer.setLanguageMode(
         new TreeSitterLanguageMode({
           buffer,
-          grammar: atom.grammars.grammarForScopeName('source.js')
+          grammar: core.grammars.grammarForScopeName('source.js')
         })
       );
 
@@ -8246,9 +8246,9 @@ describe('TextEditor', () => {
 
   describe('.shouldPromptToSave()', () => {
     beforeEach(async () => {
-      editor = await atom.workspace.open('sample.js');
+      editor = await core.workspace.open('sample.js');
       jasmine.unspy(editor, 'shouldPromptToSave');
-      spyOn(atom.stateStore, 'isConnected').andReturn(true);
+      spyOn(core.stateStore, 'isConnected').andReturn(true);
     });
 
     it('returns true when buffer has unsaved changes', () => {
@@ -8260,8 +8260,8 @@ describe('TextEditor', () => {
     it("returns false when an editor's buffer is in use by more than one buffer", async () => {
       editor.setText('changed');
 
-      atom.workspace.getActivePane().splitRight();
-      const editor2 = await atom.workspace.open('sample.js', {
+      core.workspace.getActivePane().splitRight();
+      const editor2 = await core.workspace.open('sample.js', {
         autoIndent: false
       });
       expect(editor.shouldPromptToSave()).toBeFalsy();
@@ -8317,8 +8317,8 @@ describe('TextEditor', () => {
 
   describe('.toggleLineCommentsInSelection()', () => {
     beforeEach(async () => {
-      await atom.packages.activatePackage('language-javascript');
-      editor = await atom.workspace.open('sample.js');
+      await core.packages.activatePackage('language-javascript');
+      editor = await core.workspace.open('sample.js');
     });
 
     it('toggles comments on the selected lines', () => {
@@ -8442,7 +8442,7 @@ describe('TextEditor', () => {
     });
 
     it('does nothing for empty lines and null grammar', () => {
-      atom.grammars.assignLanguageMode(editor, null);
+      core.grammars.assignLanguageMode(editor, null);
       editor.setCursorBufferPosition([10, 0]);
       editor.toggleLineCommentsInSelection();
       expect(editor.lineTextForBufferRow(10)).toBe('');
@@ -8478,8 +8478,8 @@ describe('TextEditor', () => {
   describe('.toggleLineCommentsForBufferRows', () => {
     describe('xml', () => {
       beforeEach(async () => {
-        await atom.packages.activatePackage('language-xml');
-        editor = await atom.workspace.open('test.xml');
+        await core.packages.activatePackage('language-xml');
+        editor = await core.workspace.open('test.xml');
         editor.setText('<!-- test -->');
       });
 
@@ -8557,9 +8557,9 @@ describe('TextEditor', () => {
 
     describe('less', () => {
       beforeEach(async () => {
-        await atom.packages.activatePackage('language-less');
-        await atom.packages.activatePackage('language-css');
-        editor = await atom.workspace.open('sample.less');
+        await core.packages.activatePackage('language-less');
+        await core.packages.activatePackage('language-css');
+        editor = await core.workspace.open('sample.less');
       });
 
       it('only uses the `commentEnd` pattern if it comes from the same grammar as the `commentStart` when commenting lines', () => {
@@ -8570,8 +8570,8 @@ describe('TextEditor', () => {
 
     describe('css', () => {
       beforeEach(async () => {
-        await atom.packages.activatePackage('language-css');
-        editor = await atom.workspace.open('css.css');
+        await core.packages.activatePackage('language-css');
+        editor = await core.workspace.open('css.css');
       });
 
       it('comments/uncomments lines in the given range', () => {
@@ -8630,8 +8630,8 @@ describe('TextEditor', () => {
 
     describe('coffeescript', () => {
       beforeEach(async () => {
-        await atom.packages.activatePackage('language-coffee-script');
-        editor = await atom.workspace.open('coffee.coffee');
+        await core.packages.activatePackage('language-coffee-script');
+        editor = await core.workspace.open('coffee.coffee');
       });
 
       it('comments/uncomments lines in the given range', () => {
@@ -8671,8 +8671,8 @@ describe('TextEditor', () => {
 
     describe('javascript', () => {
       beforeEach(async () => {
-        await atom.packages.activatePackage('language-javascript');
-        editor = await atom.workspace.open('sample.js');
+        await core.packages.activatePackage('language-javascript');
+        editor = await core.workspace.open('sample.js');
       });
 
       it('comments/uncomments lines in the given range', () => {
@@ -8732,11 +8732,11 @@ describe('TextEditor', () => {
 
   describe('folding', () => {
     beforeEach(async () => {
-      await atom.packages.activatePackage('language-javascript');
+      await core.packages.activatePackage('language-javascript');
     });
 
     it('maintains cursor buffer position when a folding/unfolding', async () => {
-      editor = await atom.workspace.open('sample.js', { autoIndent: false });
+      editor = await core.workspace.open('sample.js', { autoIndent: false });
       editor.setCursorBufferPosition([5, 5]);
       editor.foldAll();
       expect(editor.getCursorBufferPosition()).toEqual([5, 5]);
@@ -8744,7 +8744,7 @@ describe('TextEditor', () => {
 
     describe('.unfoldAll()', () => {
       it('unfolds every folded line', async () => {
-        editor = await atom.workspace.open('sample.js', { autoIndent: false });
+        editor = await core.workspace.open('sample.js', { autoIndent: false });
 
         const initialScreenLineCount = editor.getScreenLineCount();
         editor.foldBufferRow(0);
@@ -8757,7 +8757,7 @@ describe('TextEditor', () => {
       });
 
       it('unfolds every folded line with comments', async () => {
-        editor = await atom.workspace.open('sample-with-comments.js', {
+        editor = await core.workspace.open('sample-with-comments.js', {
           autoIndent: false
         });
 
@@ -8774,7 +8774,7 @@ describe('TextEditor', () => {
 
     describe('.foldAll()', () => {
       it('folds every foldable line', async () => {
-        editor = await atom.workspace.open('sample.js', { autoIndent: false });
+        editor = await core.workspace.open('sample.js', { autoIndent: false });
 
         editor.foldAll();
         const [fold1, fold2, fold3] = editor.unfoldAll();
@@ -8786,7 +8786,7 @@ describe('TextEditor', () => {
 
     describe('.foldBufferRow(bufferRow)', () => {
       beforeEach(async () => {
-        editor = await atom.workspace.open('sample.js');
+        editor = await core.workspace.open('sample.js');
       });
 
       describe('when bufferRow can be folded', () => {
@@ -8828,7 +8828,7 @@ describe('TextEditor', () => {
 
     describe('.foldCurrentRow()', () => {
       it('creates a fold at the location of the last cursor', async () => {
-        editor = await atom.workspace.open();
+        editor = await core.workspace.open();
         editor.setText('\nif (x) {\n  y()\n}');
         editor.setCursorBufferPosition([1, 0]);
         expect(editor.getScreenLineCount()).toBe(4);
@@ -8837,7 +8837,7 @@ describe('TextEditor', () => {
       });
 
       it('does nothing when the current row cannot be folded', async () => {
-        editor = await atom.workspace.open();
+        editor = await core.workspace.open();
         editor.setText('var x;\nx++\nx++');
         editor.setCursorBufferPosition([0, 0]);
         expect(editor.getScreenLineCount()).toBe(3);
@@ -8848,7 +8848,7 @@ describe('TextEditor', () => {
 
     describe('.foldAllAtIndentLevel(indentLevel)', () => {
       it('folds blocks of text at the given indentation level', async () => {
-        editor = await atom.workspace.open('sample.js', { autoIndent: false });
+        editor = await core.workspace.open('sample.js', { autoIndent: false });
 
         editor.foldAllAtIndentLevel(0);
         expect(editor.lineTextForScreenRow(0)).toBe(
@@ -8879,7 +8879,7 @@ describe('TextEditor', () => {
       });
 
       it('does not fold anything but the indentLevel', async () => {
-        editor = await atom.workspace.open('sample-with-comments.js', {
+        editor = await core.workspace.open('sample-with-comments.js', {
           autoIndent: false
         });
 

--- a/spec/text-mate-language-mode-spec.js
+++ b/spec/text-mate-language-mode-spec.js
@@ -9,12 +9,12 @@ describe('TextMateLanguageMode', () => {
   let languageMode, buffer, config;
 
   beforeEach(async () => {
-    config = atom.config;
+    config = core.config;
     config.set('core.useTreeSitterParsers', false);
     // enable async tokenization
     TextMateLanguageMode.prototype.chunkSize = 5;
     jasmine.unspy(TextMateLanguageMode.prototype, 'tokenizeInBackground');
-    await atom.packages.activatePackage('language-javascript');
+    await core.packages.activatePackage('language-javascript');
   });
 
   afterEach(() => {
@@ -30,7 +30,7 @@ describe('TextMateLanguageMode', () => {
       expect(buffer.getText().length).toBe(2 * 1024 * 1024);
       languageMode = new TextMateLanguageMode({
         buffer,
-        grammar: atom.grammars.grammarForScopeName('source.js'),
+        grammar: core.grammars.grammarForScopeName('source.js'),
         tabLength: 2
       });
       buffer.setLanguageMode(languageMode);
@@ -54,11 +54,11 @@ describe('TextMateLanguageMode', () => {
   describe('tokenizing', () => {
     describe('when the buffer is destroyed', () => {
       beforeEach(() => {
-        buffer = atom.project.bufferForPathSync('sample.js');
+        buffer = core.project.bufferForPathSync('sample.js');
         languageMode = new TextMateLanguageMode({
           buffer,
           config,
-          grammar: atom.grammars.grammarForScopeName('source.js')
+          grammar: core.grammars.grammarForScopeName('source.js')
         });
         languageMode.startTokenizing();
       });
@@ -73,11 +73,11 @@ describe('TextMateLanguageMode', () => {
 
     describe('when the buffer contains soft-tabs', () => {
       beforeEach(() => {
-        buffer = atom.project.bufferForPathSync('sample.js');
+        buffer = core.project.bufferForPathSync('sample.js');
         languageMode = new TextMateLanguageMode({
           buffer,
           config,
-          grammar: atom.grammars.grammarForScopeName('source.js')
+          grammar: core.grammars.grammarForScopeName('source.js')
         });
         buffer.setLanguageMode(languageMode);
         languageMode.startTokenizing();
@@ -428,13 +428,13 @@ describe('TextMateLanguageMode', () => {
 
     describe('when the buffer contains hard-tabs', () => {
       beforeEach(async () => {
-        atom.packages.activatePackage('language-coffee-script');
+        core.packages.activatePackage('language-coffee-script');
 
-        buffer = atom.project.bufferForPathSync('sample-with-tabs.coffee');
+        buffer = core.project.bufferForPathSync('sample-with-tabs.coffee');
         languageMode = new TextMateLanguageMode({
           buffer,
           config,
-          grammar: atom.grammars.grammarForScopeName('source.coffee')
+          grammar: core.grammars.grammarForScopeName('source.coffee')
         });
         languageMode.startTokenizing();
       });
@@ -451,7 +451,7 @@ describe('TextMateLanguageMode', () => {
 
     describe('when tokenization completes', () => {
       it('emits the `tokenized` event', async () => {
-        const editor = await atom.workspace.open('sample.js');
+        const editor = await core.workspace.open('sample.js');
 
         const tokenizedHandler = jasmine.createSpy('tokenized handler');
         editor.languageMode.onDidTokenize(tokenizedHandler);
@@ -460,7 +460,7 @@ describe('TextMateLanguageMode', () => {
       });
 
       it("doesn't re-emit the `tokenized` event when it is re-tokenized", async () => {
-        const editor = await atom.workspace.open('sample.js');
+        const editor = await core.workspace.open('sample.js');
         fullyTokenize(editor.languageMode);
 
         const tokenizedHandler = jasmine.createSpy('tokenized handler');
@@ -475,29 +475,29 @@ describe('TextMateLanguageMode', () => {
       it('re-emits the `tokenized` event', async () => {
         let tokenizationCount = 0;
 
-        const editor = await atom.workspace.open('coffee.coffee');
+        const editor = await core.workspace.open('coffee.coffee');
         editor.onDidTokenize(() => {
           tokenizationCount++;
         });
         fullyTokenize(editor.getBuffer().getLanguageMode());
         tokenizationCount = 0;
 
-        await atom.packages.activatePackage('language-coffee-script');
+        await core.packages.activatePackage('language-coffee-script');
         fullyTokenize(editor.getBuffer().getLanguageMode());
         expect(tokenizationCount).toBe(1);
       });
 
       it('retokenizes the buffer', async () => {
-        await atom.packages.activatePackage('language-ruby-on-rails');
-        await atom.packages.activatePackage('language-ruby');
+        await core.packages.activatePackage('language-ruby-on-rails');
+        await core.packages.activatePackage('language-ruby');
 
-        buffer = atom.project.bufferForPathSync();
+        buffer = core.project.bufferForPathSync();
         buffer.setText("<div class='name'><%= User.find(2).full_name %></div>");
 
         languageMode = new TextMateLanguageMode({
           buffer,
           config,
-          grammar: atom.grammars.selectGrammar('test.erb')
+          grammar: core.grammars.selectGrammar('test.erb')
         });
         fullyTokenize(languageMode);
         expect(languageMode.tokenizedLines[0].tokens[0]).toEqual({
@@ -505,7 +505,7 @@ describe('TextMateLanguageMode', () => {
           scopes: ['text.html.ruby']
         });
 
-        await atom.packages.activatePackage('language-html');
+        await core.packages.activatePackage('language-html');
         fullyTokenize(languageMode);
         expect(languageMode.tokenizedLines[0].tokens[0]).toEqual({
           value: '<',
@@ -521,7 +521,7 @@ describe('TextMateLanguageMode', () => {
     describe('when the buffer is configured with the null grammar', () => {
       it('does not actually tokenize using the grammar', () => {
         spyOn(NullGrammar, 'tokenizeLine').andCallThrough();
-        buffer = atom.project.bufferForPathSync(
+        buffer = core.project.bufferForPathSync(
           'sample.will-use-the-null-grammar'
         );
         buffer.setText('a\nb\nc');
@@ -552,11 +552,11 @@ describe('TextMateLanguageMode', () => {
     });
 
     it('returns the correct token (regression)', () => {
-      buffer = atom.project.bufferForPathSync('sample.js');
+      buffer = core.project.bufferForPathSync('sample.js');
       languageMode = new TextMateLanguageMode({
         buffer,
         config,
-        grammar: atom.grammars.grammarForScopeName('source.js')
+        grammar: core.grammars.grammarForScopeName('source.js')
       });
       fullyTokenize(languageMode);
       expect(languageMode.tokenForPosition([1, 0]).scopes).toEqual([
@@ -574,11 +574,11 @@ describe('TextMateLanguageMode', () => {
 
   describe('.bufferRangeForScopeAtPosition(selector, position)', () => {
     beforeEach(() => {
-      buffer = atom.project.bufferForPathSync('sample.js');
+      buffer = core.project.bufferForPathSync('sample.js');
       languageMode = new TextMateLanguageMode({
         buffer,
         config,
-        grammar: atom.grammars.grammarForScopeName('source.js')
+        grammar: core.grammars.grammarForScopeName('source.js')
       });
       fullyTokenize(languageMode);
     });
@@ -617,8 +617,8 @@ describe('TextMateLanguageMode', () => {
 
   describe('.tokenizedLineForRow(row)', () => {
     it("returns the tokenized line for a row, or a placeholder line if it hasn't been tokenized yet", () => {
-      buffer = atom.project.bufferForPathSync('sample.js');
-      const grammar = atom.grammars.grammarForScopeName('source.js');
+      buffer = core.project.bufferForPathSync('sample.js');
+      const grammar = core.grammars.grammarForScopeName('source.js');
       languageMode = new TextMateLanguageMode({ buffer, config, grammar });
       const line0 = buffer.lineForRow(0);
 
@@ -643,8 +643,8 @@ describe('TextMateLanguageMode', () => {
     });
 
     it('returns undefined if the requested row is outside the buffer range', () => {
-      buffer = atom.project.bufferForPathSync('sample.js');
-      const grammar = atom.grammars.grammarForScopeName('source.js');
+      buffer = core.project.bufferForPathSync('sample.js');
+      const grammar = core.grammars.grammarForScopeName('source.js');
       languageMode = new TextMateLanguageMode({ buffer, config, grammar });
       fullyTokenize(languageMode);
       expect(languageMode.tokenizedLineForRow(999)).toBeUndefined();
@@ -659,7 +659,7 @@ describe('TextMateLanguageMode', () => {
       languageMode = new TextMateLanguageMode({
         buffer,
         config,
-        grammar: atom.grammars.grammarForScopeName('source.js')
+        grammar: core.grammars.grammarForScopeName('source.js')
       });
       fullyTokenize(languageMode);
 
@@ -833,13 +833,13 @@ describe('TextMateLanguageMode', () => {
     }); // ensure we don't infinitely loop (regression test)
 
     it('does not report columns beyond the length of the line', async () => {
-      await atom.packages.activatePackage('language-coffee-script');
+      await core.packages.activatePackage('language-coffee-script');
 
       buffer = new TextBuffer({ text: '# hello\n# world' });
       languageMode = new TextMateLanguageMode({
         buffer,
         config,
-        grammar: atom.grammars.grammarForScopeName('source.coffee')
+        grammar: core.grammars.grammarForScopeName('source.coffee')
       });
       fullyTokenize(languageMode);
 
@@ -860,7 +860,7 @@ describe('TextMateLanguageMode', () => {
     });
 
     it('correctly terminates scopes at the beginning of the line (regression)', () => {
-      const grammar = atom.grammars.createGrammar('test', {
+      const grammar = core.grammars.createGrammar('test', {
         scopeName: 'text.broken',
         name: 'Broken grammar',
         patterns: [
@@ -999,8 +999,8 @@ describe('TextMateLanguageMode', () => {
 
     describe('javascript', () => {
       beforeEach(async () => {
-        editor = await atom.workspace.open('sample.js', { autoIndent: false });
-        await atom.packages.activatePackage('language-javascript');
+        editor = await core.workspace.open('sample.js', { autoIndent: false });
+        await core.packages.activatePackage('language-javascript');
       });
 
       it('bases indentation off of the previous non-blank line', () => {
@@ -1027,9 +1027,9 @@ describe('TextMateLanguageMode', () => {
 
     describe('css', () => {
       beforeEach(async () => {
-        editor = await atom.workspace.open('css.css', { autoIndent: true });
-        await atom.packages.activatePackage('language-source');
-        await atom.packages.activatePackage('language-css');
+        editor = await core.workspace.open('css.css', { autoIndent: true });
+        await core.packages.activatePackage('language-source');
+        await core.packages.activatePackage('language-css');
       });
 
       it('does not return negative values (regression)', () => {
@@ -1043,13 +1043,13 @@ describe('TextMateLanguageMode', () => {
     let editor;
 
     beforeEach(() => {
-      buffer = atom.project.bufferForPathSync('sample.js');
+      buffer = core.project.bufferForPathSync('sample.js');
       buffer.insert([10, 0], '  // multi-line\n  // comment\n  // block\n');
       buffer.insert([0, 0], '// multi-line\n// comment\n// block\n');
       languageMode = new TextMateLanguageMode({
         buffer,
         config,
-        grammar: atom.grammars.grammarForScopeName('source.js')
+        grammar: core.grammars.grammarForScopeName('source.js')
       });
       buffer.setLanguageMode(languageMode);
       fullyTokenize(languageMode);
@@ -1118,7 +1118,7 @@ describe('TextMateLanguageMode', () => {
     });
 
     it('returns true if the line starts a multi-line comment', async () => {
-      editor = await atom.workspace.open('sample-with-comments.js');
+      editor = await core.workspace.open('sample-with-comments.js');
       fullyTokenize(editor.getBuffer().getLanguageMode());
 
       expect(editor.isFoldableAtBufferRow(1)).toBe(true);
@@ -1133,13 +1133,13 @@ describe('TextMateLanguageMode', () => {
     });
 
     it('returns true for lines that end with a comment and are followed by an indented line', async () => {
-      editor = await atom.workspace.open('sample-with-comments.js');
+      editor = await core.workspace.open('sample-with-comments.js');
 
       expect(editor.isFoldableAtBufferRow(5)).toBe(true);
     });
 
     it("does not return true for a line in the middle of a comment that's followed by an indented line", async () => {
-      editor = await atom.workspace.open('sample-with-comments.js');
+      editor = await core.workspace.open('sample-with-comments.js');
       fullyTokenize(editor.getBuffer().getLanguageMode());
 
       expect(editor.isFoldableAtBufferRow(7)).toBe(false);
@@ -1215,7 +1215,7 @@ describe('TextMateLanguageMode', () => {
     });
 
     it('folds every foldable range at a given indentLevel', async () => {
-      editor = await atom.workspace.open('sample-with-comments.js');
+      editor = await core.workspace.open('sample-with-comments.js');
       fullyTokenize(editor.getBuffer().getLanguageMode());
 
       editor.foldAllAtIndentLevel(2);
@@ -1263,8 +1263,8 @@ describe('TextMateLanguageMode', () => {
     });
 
     it('works with multi-line comments', async () => {
-      await atom.packages.activatePackage('language-javascript');
-      const editor = await atom.workspace.open('sample-with-comments.js', {
+      await core.packages.activatePackage('language-javascript');
+      const editor = await core.workspace.open('sample-with-comments.js', {
         autoIndent: false
       });
       fullyTokenize(editor.getBuffer().getLanguageMode());
@@ -1362,8 +1362,8 @@ describe('TextMateLanguageMode', () => {
     });
 
     it('works for coffee-script', async () => {
-      const editor = await atom.workspace.open('coffee.coffee');
-      await atom.packages.activatePackage('language-coffee-script');
+      const editor = await core.workspace.open('coffee.coffee');
+      await core.packages.activatePackage('language-coffee-script');
       buffer = editor.buffer;
       languageMode = editor.languageMode;
 
@@ -1382,8 +1382,8 @@ describe('TextMateLanguageMode', () => {
     });
 
     it('works for javascript', async () => {
-      const editor = await atom.workspace.open('sample.js');
-      await atom.packages.activatePackage('language-javascript');
+      const editor = await core.workspace.open('sample.js');
+      await core.packages.activatePackage('language-javascript');
       buffer = editor.buffer;
       languageMode = editor.languageMode;
 
@@ -1414,8 +1414,8 @@ describe('TextMateLanguageMode', () => {
     });
 
     it('searches upward and downward for surrounding comment lines and folds them as a single fold', async () => {
-      await atom.packages.activatePackage('language-javascript');
-      const editor = await atom.workspace.open('sample-with-comments.js');
+      await core.packages.activatePackage('language-javascript');
+      const editor = await core.workspace.open('sample-with-comments.js');
       editor.buffer.insert(
         [1, 0],
         '  //this is a comment\n  // and\n  //more docs\n\n//second comment'
@@ -1429,7 +1429,7 @@ describe('TextMateLanguageMode', () => {
 
   describe('TokenIterator', () =>
     it('correctly terminates scopes at the beginning of the line (regression)', () => {
-      const grammar = atom.grammars.createGrammar('test', {
+      const grammar = core.grammars.createGrammar('test', {
         scopeName: 'text.broken',
         name: 'Broken grammar',
         patterns: [
@@ -1456,10 +1456,10 @@ describe('TextMateLanguageMode', () => {
       const languageMode = new TextMateLanguageMode({
         buffer,
         grammar,
-        config: atom.config,
-        grammarRegistry: atom.grammars,
-        packageManager: atom.packages,
-        assert: atom.assert
+        config: core.config,
+        grammarRegistry: core.grammars,
+        packageManager: core.packages,
+        assert: core.assert
       });
 
       fullyTokenize(languageMode);

--- a/spec/theme-manager-spec.js
+++ b/spec/theme-manager-spec.js
@@ -2,14 +2,14 @@ const path = require('path');
 const fs = require('fs-plus');
 const temp = require('temp').track();
 
-describe('atom.themes', function() {
+describe('core.themes', function() {
   beforeEach(function() {
-    spyOn(atom, 'inSpecMode').andReturn(false);
+    spyOn(core, 'inSpecMode').andReturn(false);
     spyOn(console, 'warn');
   });
 
   afterEach(function() {
-    waitsForPromise(() => atom.themes.deactivateThemes());
+    waitsForPromise(() => core.themes.deactivateThemes());
     runs(function() {
       try {
         temp.cleanupSync();
@@ -20,25 +20,25 @@ describe('atom.themes', function() {
   describe('theme getters and setters', function() {
     beforeEach(function() {
       jasmine.snapshotDeprecations();
-      atom.packages.loadPackages();
+      core.packages.loadPackages();
     });
 
     afterEach(() => jasmine.restoreDeprecationsSnapshot());
 
     describe('getLoadedThemes', () =>
       it('gets all the loaded themes', function() {
-        const themes = atom.themes.getLoadedThemes();
+        const themes = core.themes.getLoadedThemes();
         expect(themes.length).toBeGreaterThan(2);
       }));
 
     describe('getActiveThemes', () =>
       it('gets all the active themes', function() {
-        waitsForPromise(() => atom.themes.activateThemes());
+        waitsForPromise(() => core.themes.activateThemes());
 
         runs(function() {
-          const names = atom.config.get('core.themes');
+          const names = core.config.get('core.themes');
           expect(names.length).toBeGreaterThan(0);
-          const themes = atom.themes.getActiveThemes();
+          const themes = core.themes.getActiveThemes();
           expect(themes).toHaveLength(names.length);
         });
       }));
@@ -46,7 +46,7 @@ describe('atom.themes', function() {
 
   describe('when the core.themes config value contains invalid entry', () =>
     it('ignores theme', function() {
-      atom.config.set('core.themes', [
+      core.config.set('core.themes', [
         'atom-light-ui',
         null,
         undefined,
@@ -58,7 +58,7 @@ describe('atom.themes', function() {
         'atom-dark-ui'
       ]);
 
-      expect(atom.themes.getEnabledThemeNames()).toEqual([
+      expect(core.themes.getEnabledThemeNames()).toEqual([
         'atom-dark-ui',
         'atom-light-ui'
       ]);
@@ -66,13 +66,13 @@ describe('atom.themes', function() {
 
   describe('::getImportPaths()', function() {
     it('returns the theme directories before the themes are loaded', function() {
-      atom.config.set('core.themes', [
+      core.config.set('core.themes', [
         'theme-with-index-less',
         'atom-dark-ui',
         'atom-light-ui'
       ]);
 
-      const paths = atom.themes.getImportPaths();
+      const paths = core.themes.getImportPaths();
 
       // syntax theme is not a dir at this time, so only two.
       expect(paths.length).toBe(2);
@@ -81,24 +81,24 @@ describe('atom.themes', function() {
     });
 
     it('ignores themes that cannot be resolved to a directory', function() {
-      atom.config.set('core.themes', ['definitely-not-a-theme']);
-      expect(() => atom.themes.getImportPaths()).not.toThrow();
+      core.config.set('core.themes', ['definitely-not-a-theme']);
+      expect(() => core.themes.getImportPaths()).not.toThrow();
     });
   });
 
   describe('when the core.themes config value changes', function() {
     it('add/removes stylesheets to reflect the new config value', function() {
       let didChangeActiveThemesHandler;
-      atom.themes.onDidChangeActiveThemes(
+      core.themes.onDidChangeActiveThemes(
         (didChangeActiveThemesHandler = jasmine.createSpy())
       );
-      spyOn(atom.styles, 'getUserStyleSheetPath').andCallFake(() => null);
+      spyOn(core.styles, 'getUserStyleSheetPath').andCallFake(() => null);
 
-      waitsForPromise(() => atom.themes.activateThemes());
+      waitsForPromise(() => core.themes.activateThemes());
 
       runs(function() {
         didChangeActiveThemesHandler.reset();
-        atom.config.set('core.themes', []);
+        core.config.set('core.themes', []);
       });
 
       waitsFor('a', () => didChangeActiveThemesHandler.callCount === 1);
@@ -106,7 +106,7 @@ describe('atom.themes', function() {
       runs(function() {
         didChangeActiveThemesHandler.reset();
         expect(document.querySelectorAll('style.theme')).toHaveLength(0);
-        atom.config.set('core.themes', ['atom-dark-ui']);
+        core.config.set('core.themes', ['atom-dark-ui']);
       });
 
       waitsFor('b', () => didChangeActiveThemesHandler.callCount === 1);
@@ -121,7 +121,7 @@ describe('atom.themes', function() {
             .querySelector('style[priority="1"]')
             .getAttribute('source-path')
         ).toMatch(/atom-dark-ui/);
-        atom.config.set('core.themes', ['atom-light-ui', 'atom-dark-ui']);
+        core.config.set('core.themes', ['atom-light-ui', 'atom-dark-ui']);
       });
 
       waitsFor('c', () => didChangeActiveThemesHandler.callCount === 1);
@@ -141,7 +141,7 @@ describe('atom.themes', function() {
             .querySelectorAll('style[priority="1"]')[1]
             .getAttribute('source-path')
         ).toMatch(/atom-light-ui/);
-        atom.config.set('core.themes', []);
+        core.config.set('core.themes', []);
       });
 
       waitsFor(() => didChangeActiveThemesHandler.callCount === 1);
@@ -152,7 +152,7 @@ describe('atom.themes', function() {
           2
         );
         // atom-dark-ui has a directory path, the syntax one doesn't
-        atom.config.set('core.themes', [
+        core.config.set('core.themes', [
           'theme-with-index-less',
           'atom-dark-ui'
         ]);
@@ -164,29 +164,29 @@ describe('atom.themes', function() {
         expect(document.querySelectorAll('style[priority="1"]')).toHaveLength(
           2
         );
-        const importPaths = atom.themes.getImportPaths();
+        const importPaths = core.themes.getImportPaths();
         expect(importPaths.length).toBe(1);
         expect(importPaths[0]).toContain('atom-dark-ui');
       });
     });
 
     it('adds theme-* classes to the workspace for each active theme', function() {
-      atom.config.set('core.themes', ['atom-dark-ui', 'atom-dark-syntax']);
+      core.config.set('core.themes', ['atom-dark-ui', 'atom-dark-syntax']);
 
       let didChangeActiveThemesHandler;
-      atom.themes.onDidChangeActiveThemes(
+      core.themes.onDidChangeActiveThemes(
         (didChangeActiveThemesHandler = jasmine.createSpy())
       );
-      waitsForPromise(() => atom.themes.activateThemes());
+      waitsForPromise(() => core.themes.activateThemes());
 
-      const workspaceElement = atom.workspace.getElement();
+      const workspaceElement = core.workspace.getElement();
       runs(function() {
         expect(workspaceElement).toHaveClass('theme-atom-dark-ui');
 
-        atom.themes.onDidChangeActiveThemes(
+        core.themes.onDidChangeActiveThemes(
           (didChangeActiveThemesHandler = jasmine.createSpy())
         );
-        atom.config.set('core.themes', [
+        core.config.set('core.themes', [
           'theme-with-ui-variables',
           'theme-with-syntax-variables'
         ]);
@@ -209,7 +209,7 @@ describe('atom.themes', function() {
   describe('when a theme fails to load', () =>
     it('logs a warning', function() {
       console.warn.reset();
-      atom.packages
+      core.packages
         .activatePackage('a-theme-that-will-not-be-found')
         .then(function() {}, function() {});
       expect(console.warn.callCount).toBe(1);
@@ -225,19 +225,19 @@ describe('atom.themes', function() {
 
     it('synchronously loads css at the given path and installs a style tag for it in the head', function() {
       let styleElementAddedHandler;
-      atom.styles.onDidAddStyleElement(
+      core.styles.onDidAddStyleElement(
         (styleElementAddedHandler = jasmine.createSpy(
           'styleElementAddedHandler'
         ))
       );
 
       const cssPath = getAbsolutePath(
-        atom.project.getDirectories()[0],
+        core.project.getDirectories()[0],
         'css.css'
       );
       const lengthBefore = document.querySelectorAll('head style').length;
 
-      atom.themes.requireStylesheet(cssPath);
+      core.themes.requireStylesheet(cssPath);
       expect(document.querySelectorAll('head style').length).toBe(
         lengthBefore + 1
       );
@@ -252,7 +252,7 @@ describe('atom.themes', function() {
 
       // doesn't append twice
       styleElementAddedHandler.reset();
-      atom.themes.requireStylesheet(cssPath);
+      core.themes.requireStylesheet(cssPath);
       expect(document.querySelectorAll('head style').length).toBe(
         lengthBefore + 1
       );
@@ -267,11 +267,11 @@ describe('atom.themes', function() {
 
     it('synchronously loads and parses less files at the given path and installs a style tag for it in the head', function() {
       const lessPath = getAbsolutePath(
-        atom.project.getDirectories()[0],
+        core.project.getDirectories()[0],
         'sample.less'
       );
       const lengthBefore = document.querySelectorAll('head style').length;
-      atom.themes.requireStylesheet(lessPath);
+      core.themes.requireStylesheet(lessPath);
       expect(document.querySelectorAll('head style').length).toBe(
         lengthBefore + 1
       );
@@ -291,7 +291,7 @@ h2 {
 `);
 
       // doesn't append twice
-      atom.themes.requireStylesheet(lessPath);
+      core.themes.requireStylesheet(lessPath);
       expect(document.querySelectorAll('head style').length).toBe(
         lengthBefore + 1
       );
@@ -303,21 +303,21 @@ h2 {
     });
 
     it('supports requiring css and less stylesheets without an explicit extension', function() {
-      atom.themes.requireStylesheet(path.join(__dirname, 'fixtures', 'css'));
+      core.themes.requireStylesheet(path.join(__dirname, 'fixtures', 'css'));
       expect(
         document
           .querySelector('head style[source-path*="css.css"]')
           .getAttribute('source-path')
       ).toEqualPath(
-        getAbsolutePath(atom.project.getDirectories()[0], 'css.css')
+        getAbsolutePath(core.project.getDirectories()[0], 'css.css')
       );
-      atom.themes.requireStylesheet(path.join(__dirname, 'fixtures', 'sample'));
+      core.themes.requireStylesheet(path.join(__dirname, 'fixtures', 'sample'));
       expect(
         document
           .querySelector('head style[source-path*="sample.less"]')
           .getAttribute('source-path')
       ).toEqualPath(
-        getAbsolutePath(atom.project.getDirectories()[0], 'sample.less')
+        getAbsolutePath(core.project.getDirectories()[0], 'sample.less')
       );
 
       document.querySelector('head style[source-path*="css.css"]').remove();
@@ -328,11 +328,11 @@ h2 {
       const cssPath = require.resolve('./fixtures/css.css');
 
       expect(getComputedStyle(document.body).fontWeight).not.toBe('700');
-      const disposable = atom.themes.requireStylesheet(cssPath);
+      const disposable = core.themes.requireStylesheet(cssPath);
       expect(getComputedStyle(document.body).fontWeight).toBe('700');
 
       let styleElementRemovedHandler;
-      atom.styles.onDidRemoveStyleElement(
+      core.styles.onDidRemoveStyleElement(
         (styleElementRemovedHandler = jasmine.createSpy(
           'styleElementRemovedHandler'
         ))
@@ -348,19 +348,19 @@ h2 {
 
   describe('base style sheet loading', function() {
     beforeEach(function() {
-      const workspaceElement = atom.workspace.getElement();
-      jasmine.attachToDOM(atom.workspace.getElement());
+      const workspaceElement = core.workspace.getElement();
+      jasmine.attachToDOM(core.workspace.getElement());
       workspaceElement.appendChild(document.createElement('atom-text-editor'));
 
-      waitsForPromise(() => atom.themes.activateThemes());
+      waitsForPromise(() => core.themes.activateThemes());
     });
 
     it("loads the correct values from the theme's ui-variables file", function() {
       let didChangeActiveThemesHandler;
-      atom.themes.onDidChangeActiveThemes(
+      core.themes.onDidChangeActiveThemes(
         (didChangeActiveThemesHandler = jasmine.createSpy())
       );
-      atom.config.set('core.themes', [
+      core.config.set('core.themes', [
         'theme-with-ui-variables',
         'theme-with-syntax-variables'
       ]);
@@ -370,7 +370,7 @@ h2 {
       runs(function() {
         // an override loaded in the base css
         expect(
-          getComputedStyle(atom.workspace.getElement())['background-color']
+          getComputedStyle(core.workspace.getElement())['background-color']
         ).toBe('rgb(0, 0, 255)');
 
         // from within the theme itself
@@ -392,10 +392,10 @@ h2 {
     describe('when there is a theme with incomplete variables', () =>
       it('loads the correct values from the fallback ui-variables', function() {
         let didChangeActiveThemesHandler;
-        atom.themes.onDidChangeActiveThemes(
+        core.themes.onDidChangeActiveThemes(
           (didChangeActiveThemesHandler = jasmine.createSpy())
         );
-        atom.config.set('core.themes', [
+        core.config.set('core.themes', [
           'theme-with-incomplete-ui-variables',
           'theme-with-syntax-variables'
         ]);
@@ -405,7 +405,7 @@ h2 {
         runs(function() {
           // an override loaded in the base css
           expect(
-            getComputedStyle(atom.workspace.getElement())['background-color']
+            getComputedStyle(core.workspace.getElement())['background-color']
           ).toBe('rgb(0, 0, 255)');
 
           // from within the theme itself
@@ -425,7 +425,7 @@ h2 {
         userStylesheetPath,
         'body {border-style: dotted !important;}'
       );
-      spyOn(atom.styles, 'getUserStyleSheetPath').andReturn(userStylesheetPath);
+      spyOn(core.styles, 'getUserStyleSheetPath').andReturn(userStylesheetPath);
     });
 
     describe('when the user stylesheet changes', function() {
@@ -436,27 +436,27 @@ h2 {
       it('reloads it', function() {
         let styleElementAddedHandler, styleElementRemovedHandler;
 
-        waitsForPromise(() => atom.themes.activateThemes());
+        waitsForPromise(() => core.themes.activateThemes());
 
         runs(function() {
-          atom.styles.onDidRemoveStyleElement(
+          core.styles.onDidRemoveStyleElement(
             (styleElementRemovedHandler = jasmine.createSpy(
               'styleElementRemovedHandler'
             ))
           );
-          atom.styles.onDidAddStyleElement(
+          core.styles.onDidAddStyleElement(
             (styleElementAddedHandler = jasmine.createSpy(
               'styleElementAddedHandler'
             ))
           );
 
-          spyOn(atom.themes, 'loadUserStylesheet').andCallThrough();
+          spyOn(core.themes, 'loadUserStylesheet').andCallThrough();
 
           expect(getComputedStyle(document.body).borderStyle).toBe('dotted');
           fs.writeFileSync(userStylesheetPath, 'body {border-style: dashed}');
         });
 
-        waitsFor(() => atom.themes.loadUserStylesheet.callCount === 1);
+        waitsFor(() => core.themes.loadUserStylesheet.callCount === 1);
 
         runs(function() {
           expect(getComputedStyle(document.body).borderStyle).toBe('dashed');
@@ -475,7 +475,7 @@ h2 {
           fs.removeSync(userStylesheetPath);
         });
 
-        waitsFor(() => atom.themes.loadUserStylesheet.callCount === 2);
+        waitsFor(() => core.themes.loadUserStylesheet.callCount === 2);
 
         runs(function() {
           expect(styleElementRemovedHandler).toHaveBeenCalled();
@@ -490,24 +490,24 @@ h2 {
     describe('when there is an error reading the stylesheet', function() {
       let addErrorHandler = null;
       beforeEach(function() {
-        atom.themes.loadUserStylesheet();
-        spyOn(atom.themes.lessCache, 'cssForFile').andCallFake(function() {
+        core.themes.loadUserStylesheet();
+        spyOn(core.themes.lessCache, 'cssForFile').andCallFake(function() {
           throw new Error('EACCES permission denied "styles.less"');
         });
-        atom.notifications.onDidAddNotification(
+        core.notifications.onDidAddNotification(
           (addErrorHandler = jasmine.createSpy())
         );
       });
 
       it('creates an error notification and does not add the stylesheet', function() {
-        atom.themes.loadUserStylesheet();
+        core.themes.loadUserStylesheet();
         expect(addErrorHandler).toHaveBeenCalled();
         const note = addErrorHandler.mostRecentCall.args[0];
         expect(note.getType()).toBe('error');
         expect(note.getMessage()).toContain('Error loading');
         expect(
-          atom.styles.styleElementsBySourcePath[
-            atom.styles.getUserStyleSheetPath()
+          core.styles.styleElementsBySourcePath[
+            core.styles.getUserStyleSheetPath()
           ]
         ).toBeUndefined();
       });
@@ -522,14 +522,14 @@ h2 {
             throw new Error('Unable to watch path');
           }
         });
-        spyOn(atom.themes, 'loadStylesheet').andReturn('');
-        atom.notifications.onDidAddNotification(
+        spyOn(core.themes, 'loadStylesheet').andReturn('');
+        core.notifications.onDidAddNotification(
           (addErrorHandler = jasmine.createSpy())
         );
       });
 
       it('creates an error notification', function() {
-        atom.themes.loadUserStylesheet();
+        core.themes.loadUserStylesheet();
         expect(addErrorHandler).toHaveBeenCalled();
         const note = addErrorHandler.mostRecentCall.args[0];
         expect(note.getType()).toBe('error');
@@ -539,9 +539,9 @@ h2 {
 
     it("adds a notification when a theme's stylesheet is invalid", function() {
       const addErrorHandler = jasmine.createSpy();
-      atom.notifications.onDidAddNotification(addErrorHandler);
+      core.notifications.onDidAddNotification(addErrorHandler);
       expect(() =>
-        atom.packages
+        core.packages
           .activatePackage('theme-with-invalid-styles')
           .then(function() {}, function() {})
       ).not.toThrow();
@@ -555,16 +555,16 @@ h2 {
   describe('when a non-existent theme is present in the config', function() {
     beforeEach(function() {
       console.warn.reset();
-      atom.config.set('core.themes', [
+      core.config.set('core.themes', [
         'non-existent-dark-ui',
         'non-existent-dark-syntax'
       ]);
 
-      waitsForPromise(() => atom.themes.activateThemes());
+      waitsForPromise(() => core.themes.activateThemes());
     });
 
     it('uses the default one-dark UI and syntax themes and logs a warning', function() {
-      const activeThemeNames = atom.themes.getActiveThemeNames();
+      const activeThemeNames = core.themes.getActiveThemeNames();
       expect(console.warn.callCount).toBe(2);
       expect(activeThemeNames.length).toBe(2);
       expect(activeThemeNames).toContain('one-dark-ui');
@@ -575,13 +575,13 @@ h2 {
   describe('when in safe mode', function() {
     describe('when the enabled UI and syntax themes are bundled with Atom', function() {
       beforeEach(function() {
-        atom.config.set('core.themes', ['atom-light-ui', 'atom-dark-syntax']);
+        core.config.set('core.themes', ['atom-light-ui', 'atom-dark-syntax']);
 
-        waitsForPromise(() => atom.themes.activateThemes());
+        waitsForPromise(() => core.themes.activateThemes());
       });
 
       it('uses the enabled themes', function() {
-        const activeThemeNames = atom.themes.getActiveThemeNames();
+        const activeThemeNames = core.themes.getActiveThemeNames();
         expect(activeThemeNames.length).toBe(2);
         expect(activeThemeNames).toContain('atom-light-ui');
         expect(activeThemeNames).toContain('atom-dark-syntax');
@@ -590,16 +590,16 @@ h2 {
 
     describe('when the enabled UI and syntax themes are not bundled with Atom', function() {
       beforeEach(function() {
-        atom.config.set('core.themes', [
+        core.config.set('core.themes', [
           'installed-dark-ui',
           'installed-dark-syntax'
         ]);
 
-        waitsForPromise(() => atom.themes.activateThemes());
+        waitsForPromise(() => core.themes.activateThemes());
       });
 
       it('uses the default dark UI and syntax themes', function() {
-        const activeThemeNames = atom.themes.getActiveThemeNames();
+        const activeThemeNames = core.themes.getActiveThemeNames();
         expect(activeThemeNames.length).toBe(2);
         expect(activeThemeNames).toContain('one-dark-ui');
         expect(activeThemeNames).toContain('one-dark-syntax');
@@ -608,16 +608,16 @@ h2 {
 
     describe('when the enabled UI theme is not bundled with Atom', function() {
       beforeEach(function() {
-        atom.config.set('core.themes', [
+        core.config.set('core.themes', [
           'installed-dark-ui',
           'atom-light-syntax'
         ]);
 
-        waitsForPromise(() => atom.themes.activateThemes());
+        waitsForPromise(() => core.themes.activateThemes());
       });
 
       it('uses the default one-dark UI theme', function() {
-        const activeThemeNames = atom.themes.getActiveThemeNames();
+        const activeThemeNames = core.themes.getActiveThemeNames();
         expect(activeThemeNames.length).toBe(2);
         expect(activeThemeNames).toContain('one-dark-ui');
         expect(activeThemeNames).toContain('atom-light-syntax');
@@ -626,16 +626,16 @@ h2 {
 
     describe('when the enabled syntax theme is not bundled with Atom', function() {
       beforeEach(function() {
-        atom.config.set('core.themes', [
+        core.config.set('core.themes', [
           'atom-light-ui',
           'installed-dark-syntax'
         ]);
 
-        waitsForPromise(() => atom.themes.activateThemes());
+        waitsForPromise(() => core.themes.activateThemes());
       });
 
       it('uses the default one-dark syntax theme', function() {
-        const activeThemeNames = atom.themes.getActiveThemeNames();
+        const activeThemeNames = core.themes.getActiveThemeNames();
         expect(activeThemeNames.length).toBe(2);
         expect(activeThemeNames).toContain('atom-light-ui');
         expect(activeThemeNames).toContain('one-dark-syntax');

--- a/spec/title-bar-spec.js
+++ b/spec/title-bar-spec.js
@@ -4,16 +4,16 @@ const temp = require('temp').track();
 describe('TitleBar', () => {
   it('updates its title when document.title changes', () => {
     const titleBar = new TitleBar({
-      workspace: atom.workspace,
-      themes: atom.themes,
-      applicationDelegate: atom.applicationDelegate
+      workspace: core.workspace,
+      themes: core.themes,
+      applicationDelegate: core.applicationDelegate
     });
     expect(titleBar.element.querySelector('.title').textContent).toBe(
       document.title
     );
 
     const paneItem = new FakePaneItem('Title 1');
-    atom.workspace.getActivePane().activateItem(paneItem);
+    core.workspace.getActivePane().activateItem(paneItem);
     expect(document.title).toMatch('Title 1');
     expect(titleBar.element.querySelector('.title').textContent).toBe(
       document.title
@@ -25,7 +25,7 @@ describe('TitleBar', () => {
       document.title
     );
 
-    atom.project.setPaths([temp.mkdirSync('project-1')]);
+    core.project.setPaths([temp.mkdirSync('project-1')]);
     expect(document.title).toMatch('project-1');
     expect(titleBar.element.querySelector('.title').textContent).toBe(
       document.title
@@ -34,9 +34,9 @@ describe('TitleBar', () => {
 
   it('can update the sheet offset for the current window based on its height', () => {
     const titleBar = new TitleBar({
-      workspace: atom.workspace,
-      themes: atom.themes,
-      applicationDelegate: atom.applicationDelegate
+      workspace: core.workspace,
+      themes: core.themes,
+      applicationDelegate: core.applicationDelegate
     });
     expect(() => titleBar.updateWindowSheetOffset()).not.toThrow();
   });

--- a/spec/tooltip-manager-spec.js
+++ b/spec/tooltip-manager-spec.js
@@ -19,8 +19,8 @@ describe('TooltipManager', () => {
 
   beforeEach(function() {
     manager = new TooltipManager({
-      keymapManager: atom.keymaps,
-      viewRegistry: atom.views
+      keymapManager: core.keymaps,
+      viewRegistry: core.views
     });
     element = createElement('foo');
   });
@@ -184,7 +184,7 @@ describe('TooltipManager', () => {
     describe('when a keyBindingCommand is specified', () => {
       describe('when a title is specified', () =>
         it('appends the key binding corresponding to the command to the title', () => {
-          atom.keymaps.add('test', {
+          core.keymaps.add('test', {
             '.foo': { 'ctrl-x ctrl-y': 'test-command' },
             '.bar': { 'ctrl-x ctrl-z': 'test-command' }
           });
@@ -202,7 +202,7 @@ describe('TooltipManager', () => {
 
       describe('when no title is specified', () =>
         it('shows the key binding corresponding to the command alone', () => {
-          atom.keymaps.add('test', {
+          core.keymaps.add('test', {
             '.foo': { 'ctrl-x ctrl-y': 'test-command' }
           });
 
@@ -216,7 +216,7 @@ describe('TooltipManager', () => {
 
       describe('when a keyBindingTarget is specified', () => {
         it('looks up the key binding relative to the target', () => {
-          atom.keymaps.add('test', {
+          core.keymaps.add('test', {
             '.bar': { 'ctrl-x ctrl-z': 'test-command' },
             '.foo': { 'ctrl-x ctrl-y': 'test-command' }
           });

--- a/spec/tree-indenter-spec.js
+++ b/spec/tree-indenter-spec.js
@@ -50,11 +50,11 @@ describe('TreeIndenter', () => {
   let languageMode, treeIndenter;
 
   beforeEach(async () => {
-    editor = await atom.workspace.open('');
+    editor = await core.workspace.open('');
     buffer = editor.getBuffer();
     editor.displayLayer.reset({ foldCharacter: '…' });
 
-    grammar = new TreeSitterGrammar(atom.grammars, jsGrammarPath, {
+    grammar = new TreeSitterGrammar(core.grammars, jsGrammarPath, {
       parser: 'tree-sitter-javascript'
     });
   });

--- a/spec/tree-sitter-language-mode-spec.js
+++ b/spec/tree-sitter-language-mode-spec.js
@@ -38,14 +38,14 @@ describe('TreeSitterLanguageMode', () => {
   let editor, buffer;
 
   beforeEach(async () => {
-    editor = await atom.workspace.open('');
+    editor = await core.workspace.open('');
     buffer = editor.getBuffer();
     editor.displayLayer.reset({ foldCharacter: '…' });
   });
 
   describe('highlighting', () => {
     it('applies the most specific scope mapping to each node in the syntax tree', async () => {
-      const grammar = new TreeSitterGrammar(atom.grammars, jsGrammarPath, {
+      const grammar = new TreeSitterGrammar(core.grammars, jsGrammarPath, {
         parser: 'tree-sitter-javascript',
         scopes: {
           program: 'source',
@@ -74,7 +74,7 @@ describe('TreeSitterLanguageMode', () => {
     });
 
     it('provides the grammar with the text of leaf nodes only', async () => {
-      const grammar = new TreeSitterGrammar(atom.grammars, jsGrammarPath, {
+      const grammar = new TreeSitterGrammar(core.grammars, jsGrammarPath, {
         parser: 'tree-sitter-javascript',
         scopes: {
           program: 'source',
@@ -126,7 +126,7 @@ describe('TreeSitterLanguageMode', () => {
     });
 
     it('can start or end multiple scopes at the same position', async () => {
-      const grammar = new TreeSitterGrammar(atom.grammars, jsGrammarPath, {
+      const grammar = new TreeSitterGrammar(core.grammars, jsGrammarPath, {
         parser: 'tree-sitter-javascript',
         scopes: {
           program: 'source',
@@ -157,7 +157,7 @@ describe('TreeSitterLanguageMode', () => {
     });
 
     it('can resume highlighting on a line that starts with whitespace', async () => {
-      const grammar = new TreeSitterGrammar(atom.grammars, jsGrammarPath, {
+      const grammar = new TreeSitterGrammar(core.grammars, jsGrammarPath, {
         parser: 'tree-sitter-javascript',
         scopes: {
           'call_expression > member_expression > property_identifier':
@@ -184,7 +184,7 @@ describe('TreeSitterLanguageMode', () => {
     });
 
     it('correctly skips over tokens with zero size', async () => {
-      const grammar = new TreeSitterGrammar(atom.grammars, cGrammarPath, {
+      const grammar = new TreeSitterGrammar(core.grammars, cGrammarPath, {
         parser: 'tree-sitter-c',
         scopes: {
           primitive_type: 'type',
@@ -231,7 +231,7 @@ describe('TreeSitterLanguageMode', () => {
     });
 
     it("updates lines' highlighting when they are affected by distant changes", async () => {
-      const grammar = new TreeSitterGrammar(atom.grammars, jsGrammarPath, {
+      const grammar = new TreeSitterGrammar(core.grammars, jsGrammarPath, {
         parser: 'tree-sitter-javascript',
         scopes: {
           'call_expression > identifier': 'function',
@@ -262,7 +262,7 @@ describe('TreeSitterLanguageMode', () => {
     });
 
     it('allows comma-separated selectors as scope mapping keys', async () => {
-      const grammar = new TreeSitterGrammar(atom.grammars, jsGrammarPath, {
+      const grammar = new TreeSitterGrammar(core.grammars, jsGrammarPath, {
         parser: 'tree-sitter-javascript',
         scopes: {
           'identifier, call_expression > identifier': [
@@ -291,7 +291,7 @@ describe('TreeSitterLanguageMode', () => {
     });
 
     it('handles edits after tokens that end between CR and LF characters (regression)', async () => {
-      const grammar = new TreeSitterGrammar(atom.grammars, jsGrammarPath, {
+      const grammar = new TreeSitterGrammar(core.grammars, jsGrammarPath, {
         parser: 'tree-sitter-javascript',
         scopes: {
           comment: 'comment',
@@ -331,7 +331,7 @@ describe('TreeSitterLanguageMode', () => {
     });
 
     it('handles multi-line nodes with children on different lines (regression)', async () => {
-      const grammar = new TreeSitterGrammar(atom.grammars, jsGrammarPath, {
+      const grammar = new TreeSitterGrammar(core.grammars, jsGrammarPath, {
         parser: 'tree-sitter-javascript',
         scopes: {
           template_string: 'string',
@@ -364,7 +364,7 @@ describe('TreeSitterLanguageMode', () => {
     });
 
     it('handles folds inside of highlighted tokens', async () => {
-      const grammar = new TreeSitterGrammar(atom.grammars, jsGrammarPath, {
+      const grammar = new TreeSitterGrammar(core.grammars, jsGrammarPath, {
         parser: 'tree-sitter-javascript',
         scopes: {
           comment: 'comment',
@@ -397,7 +397,7 @@ describe('TreeSitterLanguageMode', () => {
     });
 
     it('applies regex match rules when specified', async () => {
-      const grammar = new TreeSitterGrammar(atom.grammars, jsGrammarPath, {
+      const grammar = new TreeSitterGrammar(core.grammars, jsGrammarPath, {
         parser: 'tree-sitter-javascript',
         scopes: {
           identifier: [
@@ -429,7 +429,7 @@ describe('TreeSitterLanguageMode', () => {
     });
 
     it('handles nodes that start before their first child and end after their last child', async () => {
-      const grammar = new TreeSitterGrammar(atom.grammars, rubyGrammarPath, {
+      const grammar = new TreeSitterGrammar(core.grammars, rubyGrammarPath, {
         parser: 'tree-sitter-ruby',
         scopes: {
           bare_string: 'string',
@@ -461,7 +461,7 @@ describe('TreeSitterLanguageMode', () => {
 
     describe('when the buffer changes during a parse', () => {
       it('immediately parses again when the current parse completes', async () => {
-        const grammar = new TreeSitterGrammar(atom.grammars, jsGrammarPath, {
+        const grammar = new TreeSitterGrammar(core.grammars, jsGrammarPath, {
           parser: 'tree-sitter-javascript',
           scopes: {
             identifier: 'variable',
@@ -521,7 +521,7 @@ describe('TreeSitterLanguageMode', () => {
 
     describe('when changes are small enough to be re-parsed synchronously', () => {
       it('can incorporate multiple consecutive synchronous updates', () => {
-        const grammar = new TreeSitterGrammar(atom.grammars, jsGrammarPath, {
+        const grammar = new TreeSitterGrammar(core.grammars, jsGrammarPath, {
           parser: 'tree-sitter-javascript',
           scopes: {
             property_identifier: 'property',
@@ -564,7 +564,7 @@ describe('TreeSitterLanguageMode', () => {
       let jsGrammar, htmlGrammar;
 
       beforeEach(() => {
-        jsGrammar = new TreeSitterGrammar(atom.grammars, jsGrammarPath, {
+        jsGrammar = new TreeSitterGrammar(core.grammars, jsGrammarPath, {
           scopeName: 'javascript',
           parser: 'tree-sitter-javascript',
           scopes: {
@@ -582,7 +582,7 @@ describe('TreeSitterLanguageMode', () => {
           ]
         });
 
-        htmlGrammar = new TreeSitterGrammar(atom.grammars, htmlGrammarPath, {
+        htmlGrammar = new TreeSitterGrammar(core.grammars, htmlGrammarPath, {
           scopeName: 'html',
           parser: 'tree-sitter-html',
           scopes: {
@@ -596,14 +596,14 @@ describe('TreeSitterLanguageMode', () => {
       });
 
       it('highlights code inside of injection points', async () => {
-        atom.grammars.addGrammar(jsGrammar);
-        atom.grammars.addGrammar(htmlGrammar);
+        core.grammars.addGrammar(jsGrammar);
+        core.grammars.addGrammar(htmlGrammar);
         buffer.setText('node.innerHTML = html `\na ${b}<img src="d">\n`;');
 
         const languageMode = new TreeSitterLanguageMode({
           buffer,
           grammar: jsGrammar,
-          grammars: atom.grammars
+          grammars: core.grammars
         });
         buffer.setLanguageMode(languageMode);
 
@@ -656,14 +656,14 @@ describe('TreeSitterLanguageMode', () => {
       });
 
       it('highlights the content after injections', async () => {
-        atom.grammars.addGrammar(jsGrammar);
-        atom.grammars.addGrammar(htmlGrammar);
+        core.grammars.addGrammar(jsGrammar);
+        core.grammars.addGrammar(htmlGrammar);
         buffer.setText('<script>\nhello();\n</script>\n<div>\n</div>');
 
         const languageMode = new TreeSitterLanguageMode({
           buffer,
           grammar: htmlGrammar,
-          grammars: atom.grammars
+          grammars: core.grammars
         });
         buffer.setLanguageMode(languageMode);
 
@@ -696,13 +696,13 @@ describe('TreeSitterLanguageMode', () => {
       });
 
       it('updates buffers highlighting when a grammar with injectionRegExp is added', async () => {
-        atom.grammars.addGrammar(jsGrammar);
+        core.grammars.addGrammar(jsGrammar);
 
         buffer.setText('node.innerHTML = html `\na ${b}<img src="d">\n`;');
         const languageMode = new TreeSitterLanguageMode({
           buffer,
           grammar: jsGrammar,
-          grammars: atom.grammars
+          grammars: core.grammars
         });
         buffer.setLanguageMode(languageMode);
 
@@ -725,7 +725,7 @@ describe('TreeSitterLanguageMode', () => {
           [{ text: '`', scopes: ['string'] }, { text: ';', scopes: [] }]
         ]);
 
-        atom.grammars.addGrammar(htmlGrammar);
+        core.grammars.addGrammar(htmlGrammar);
         await nextHighlightingUpdate(languageMode);
         expectTokensToEqual(editor, [
           [
@@ -754,7 +754,7 @@ describe('TreeSitterLanguageMode', () => {
 
       it('handles injections that intersect', async () => {
         const ejsGrammar = new TreeSitterGrammar(
-          atom.grammars,
+          core.grammars,
           ejsGrammarPath,
           {
             id: 'ejs',
@@ -786,14 +786,14 @@ describe('TreeSitterLanguageMode', () => {
           }
         );
 
-        atom.grammars.addGrammar(jsGrammar);
-        atom.grammars.addGrammar(htmlGrammar);
+        core.grammars.addGrammar(jsGrammar);
+        core.grammars.addGrammar(htmlGrammar);
 
         buffer.setText('<body>\n<script>\nb(<%= c.d %>)\n</script>\n</body>');
         const languageMode = new TreeSitterLanguageMode({
           buffer,
           grammar: ejsGrammar,
-          grammars: atom.grammars
+          grammars: core.grammars
         });
         buffer.setLanguageMode(languageMode);
 
@@ -832,14 +832,14 @@ describe('TreeSitterLanguageMode', () => {
       });
 
       it('handles injections that are empty', async () => {
-        atom.grammars.addGrammar(jsGrammar);
-        atom.grammars.addGrammar(htmlGrammar);
+        core.grammars.addGrammar(jsGrammar);
+        core.grammars.addGrammar(htmlGrammar);
         buffer.setText('text = html');
 
         const languageMode = new TreeSitterLanguageMode({
           buffer,
           grammar: jsGrammar,
-          grammars: atom.grammars
+          grammars: core.grammars
         });
         buffer.setLanguageMode(languageMode);
 
@@ -890,7 +890,7 @@ describe('TreeSitterLanguageMode', () => {
 
       it('terminates comment token at the end of an injection, so that the next injection is NOT a continuation of the comment', async () => {
         const ejsGrammar = new TreeSitterGrammar(
-          atom.grammars,
+          core.grammars,
           ejsGrammarPath,
           {
             id: 'ejs',
@@ -923,14 +923,14 @@ describe('TreeSitterLanguageMode', () => {
           }
         );
 
-        atom.grammars.addGrammar(jsGrammar);
-        atom.grammars.addGrammar(htmlGrammar);
+        core.grammars.addGrammar(jsGrammar);
+        core.grammars.addGrammar(htmlGrammar);
 
         buffer.setText('<% // js comment %> b\n<% b() %>');
         const languageMode = new TreeSitterLanguageMode({
           buffer,
           grammar: ejsGrammar,
-          grammars: atom.grammars
+          grammars: core.grammars
         });
         buffer.setLanguageMode(languageMode);
 
@@ -954,7 +954,7 @@ describe('TreeSitterLanguageMode', () => {
 
       it('only covers scope boundaries in parent layers if a nested layer has a boundary at the same position', async () => {
         const jsdocGrammar = new TreeSitterGrammar(
-          atom.grammars,
+          core.grammars,
           jsdocGrammarPath,
           {
             scopeName: 'jsdoc',
@@ -964,8 +964,8 @@ describe('TreeSitterLanguageMode', () => {
             injectionPoints: []
           }
         );
-        atom.grammars.addGrammar(jsGrammar);
-        atom.grammars.addGrammar(jsdocGrammar);
+        core.grammars.addGrammar(jsGrammar);
+        core.grammars.addGrammar(jsdocGrammar);
 
         editor.setGrammar(jsGrammar);
         editor.setText('/**\n*/\n{\n}');
@@ -979,9 +979,9 @@ describe('TreeSitterLanguageMode', () => {
       });
 
       it('reports scopes from shallower layers when they are at the start or end of an injection', async () => {
-        await atom.packages.activatePackage('language-javascript');
+        await core.packages.activatePackage('language-javascript');
 
-        editor.setGrammar(atom.grammars.grammarForScopeName('source.js'));
+        editor.setGrammar(core.grammars.grammarForScopeName('source.js'));
         editor.setText('/** @babel */\n{\n}');
         expectTokensToEqual(editor, [
           [
@@ -1019,7 +1019,7 @@ describe('TreeSitterLanguageMode', () => {
 
       it('respects the `includeChildren` property of injection points', async () => {
         const rustGrammar = new TreeSitterGrammar(
-          atom.grammars,
+          core.grammars,
           rustGrammarPath,
           {
             scopeName: 'rust',
@@ -1054,7 +1054,7 @@ describe('TreeSitterLanguageMode', () => {
           }
         );
 
-        atom.grammars.addGrammar(rustGrammar);
+        core.grammars.addGrammar(rustGrammar);
 
         // Macro call within another macro call.
         buffer.setText('assert_eq!(a.b.c(), vec![d.e()]); f.g();');
@@ -1062,7 +1062,7 @@ describe('TreeSitterLanguageMode', () => {
         const languageMode = new TreeSitterLanguageMode({
           buffer,
           grammar: rustGrammar,
-          grammars: atom.grammars
+          grammars: core.grammars
         });
         buffer.setLanguageMode(languageMode);
 
@@ -1115,14 +1115,14 @@ describe('TreeSitterLanguageMode', () => {
           });
         });
 
-        atom.grammars.addGrammar(jsGrammar);
-        atom.grammars.addGrammar(htmlGrammar);
+        core.grammars.addGrammar(jsGrammar);
+        core.grammars.addGrammar(htmlGrammar);
         buffer.setText('<script>\nhello();\n</script>');
 
         const languageMode = new TreeSitterLanguageMode({
           buffer,
           grammar: htmlGrammar,
-          grammars: atom.grammars,
+          grammars: core.grammars,
           syncTimeoutMicros: 0
         });
         buffer.setLanguageMode(languageMode);
@@ -1151,8 +1151,8 @@ describe('TreeSitterLanguageMode', () => {
         path.join(__dirname, 'fixtures', 'sample.js'),
         'utf8'
       );
-      atom.grammars.loadGrammarSync(jsGrammarPath);
-      atom.grammars.assignLanguageMode(buffer, 'source.js');
+      core.grammars.loadGrammarSync(jsGrammarPath);
+      core.grammars.assignLanguageMode(buffer, 'source.js');
       buffer.getLanguageMode().syncTimeoutMicros = 0;
 
       const initialSeed = Date.now();
@@ -1203,7 +1203,7 @@ describe('TreeSitterLanguageMode', () => {
         // Create a fresh buffer and editor with the same text.
         const buffer2 = new TextBuffer(buffer.getText());
         const editor2 = new TextEditor({ buffer: buffer2 });
-        atom.grammars.assignLanguageMode(buffer2, 'source.js');
+        core.grammars.assignLanguageMode(buffer2, 'source.js');
 
         // Verify that the the two buffers have the same syntax highlighting.
         await buffer.getLanguageMode().parseCompletePromise();
@@ -1232,7 +1232,7 @@ describe('TreeSitterLanguageMode', () => {
 
   describe('folding', () => {
     it('can fold nodes that start and end with specified tokens', async () => {
-      const grammar = new TreeSitterGrammar(atom.grammars, jsGrammarPath, {
+      const grammar = new TreeSitterGrammar(core.grammars, jsGrammarPath, {
         parser: 'tree-sitter-javascript',
         folds: [
           {
@@ -1287,7 +1287,7 @@ describe('TreeSitterLanguageMode', () => {
     });
 
     it('folds entire buffer rows when necessary to keep words on separate lines', async () => {
-      const grammar = new TreeSitterGrammar(atom.grammars, jsGrammarPath, {
+      const grammar = new TreeSitterGrammar(core.grammars, jsGrammarPath, {
         parser: 'tree-sitter-javascript',
         folds: [
           {
@@ -1335,7 +1335,7 @@ describe('TreeSitterLanguageMode', () => {
     });
 
     it('can fold nodes of specified types', async () => {
-      const grammar = new TreeSitterGrammar(atom.grammars, jsGrammarPath, {
+      const grammar = new TreeSitterGrammar(core.grammars, jsGrammarPath, {
         parser: 'tree-sitter-javascript',
         folds: [
           // Start the fold after the first child (the opening tag) and end it at the last child
@@ -1396,7 +1396,7 @@ describe('TreeSitterLanguageMode', () => {
     });
 
     it('can fold entire nodes when no start or end parameters are specified', async () => {
-      const grammar = new TreeSitterGrammar(atom.grammars, jsGrammarPath, {
+      const grammar = new TreeSitterGrammar(core.grammars, jsGrammarPath, {
         parser: 'tree-sitter-javascript',
         folds: [
           // By default, for a node with no children, folds are started at the *end* of the first
@@ -1439,7 +1439,7 @@ describe('TreeSitterLanguageMode', () => {
     });
 
     it('tries each folding strategy for a given node in the order specified', async () => {
-      const grammar = new TreeSitterGrammar(atom.grammars, cGrammarPath, {
+      const grammar = new TreeSitterGrammar(core.grammars, cGrammarPath, {
         parser: 'tree-sitter-c',
         folds: [
           // If the #ifdef has an `#else` clause, then end the fold there.
@@ -1551,7 +1551,7 @@ describe('TreeSitterLanguageMode', () => {
     });
 
     it('does not fold when the start and end parameters match the same child', async () => {
-      const grammar = new TreeSitterGrammar(atom.grammars, htmlGrammarPath, {
+      const grammar = new TreeSitterGrammar(core.grammars, htmlGrammarPath, {
         parser: 'tree-sitter-html',
         folds: [
           {
@@ -1584,7 +1584,7 @@ describe('TreeSitterLanguageMode', () => {
     });
 
     it('can target named vs anonymous nodes as fold boundaries', async () => {
-      const grammar = new TreeSitterGrammar(atom.grammars, rubyGrammarPath, {
+      const grammar = new TreeSitterGrammar(core.grammars, rubyGrammarPath, {
         parser: 'tree-sitter-ruby',
         folds: [
           // Note that this isn't how folds actually work in language-ruby. It's
@@ -1654,7 +1654,7 @@ describe('TreeSitterLanguageMode', () => {
     });
 
     it('updates fold locations when the buffer changes', () => {
-      const grammar = new TreeSitterGrammar(atom.grammars, jsGrammarPath, {
+      const grammar = new TreeSitterGrammar(core.grammars, jsGrammarPath, {
         parser: 'tree-sitter-javascript',
         folds: [
           {
@@ -1692,7 +1692,7 @@ describe('TreeSitterLanguageMode', () => {
     describe('when folding a node that ends with a line break', () => {
       it('ends the fold at the end of the previous line', async () => {
         const grammar = new TreeSitterGrammar(
-          atom.grammars,
+          core.grammars,
           pythonGrammarPath,
           {
             parser: 'tree-sitter-python',
@@ -1730,7 +1730,7 @@ describe('TreeSitterLanguageMode', () => {
 
     it('folds code in injected languages', async () => {
       const htmlGrammar = new TreeSitterGrammar(
-        atom.grammars,
+        core.grammars,
         htmlGrammarPath,
         {
           scopeName: 'html',
@@ -1747,7 +1747,7 @@ describe('TreeSitterLanguageMode', () => {
         }
       );
 
-      const jsGrammar = new TreeSitterGrammar(atom.grammars, jsGrammarPath, {
+      const jsGrammar = new TreeSitterGrammar(core.grammars, jsGrammarPath, {
         scopeName: 'javascript',
         parser: 'tree-sitter-javascript',
         scopes: {},
@@ -1766,7 +1766,7 @@ describe('TreeSitterLanguageMode', () => {
         injectionPoints: [HTML_TEMPLATE_LITERAL_INJECTION_POINT]
       });
 
-      atom.grammars.addGrammar(htmlGrammar);
+      core.grammars.addGrammar(htmlGrammar);
 
       buffer.setText(
         `a = html \`
@@ -1783,7 +1783,7 @@ describe('TreeSitterLanguageMode', () => {
       const languageMode = new TreeSitterLanguageMode({
         buffer,
         grammar: jsGrammar,
-        grammars: atom.grammars
+        grammars: core.grammars
       });
       buffer.setLanguageMode(languageMode);
 
@@ -1817,7 +1817,7 @@ describe('TreeSitterLanguageMode', () => {
 
   describe('.scopeDescriptorForPosition', () => {
     it('returns a scope descriptor representing the given position in the syntax tree', async () => {
-      const grammar = new TreeSitterGrammar(atom.grammars, jsGrammarPath, {
+      const grammar = new TreeSitterGrammar(core.grammars, jsGrammarPath, {
         scopeName: 'source.js',
         parser: 'tree-sitter-javascript',
         scopes: {
@@ -1858,7 +1858,7 @@ describe('TreeSitterLanguageMode', () => {
     });
 
     it('includes nodes in injected syntax trees', async () => {
-      const jsGrammar = new TreeSitterGrammar(atom.grammars, jsGrammarPath, {
+      const jsGrammar = new TreeSitterGrammar(core.grammars, jsGrammarPath, {
         scopeName: 'source.js',
         parser: 'tree-sitter-javascript',
         scopes: {
@@ -1872,7 +1872,7 @@ describe('TreeSitterLanguageMode', () => {
       });
 
       const htmlGrammar = new TreeSitterGrammar(
-        atom.grammars,
+        core.grammars,
         htmlGrammarPath,
         {
           scopeName: 'text.html',
@@ -1886,8 +1886,8 @@ describe('TreeSitterLanguageMode', () => {
         }
       );
 
-      atom.grammars.addGrammar(jsGrammar);
-      atom.grammars.addGrammar(htmlGrammar);
+      core.grammars.addGrammar(jsGrammar);
+      core.grammars.addGrammar(htmlGrammar);
 
       buffer.setText(`
         <div>
@@ -1902,7 +1902,7 @@ describe('TreeSitterLanguageMode', () => {
       const languageMode = new TreeSitterLanguageMode({
         buffer,
         grammar: htmlGrammar,
-        grammars: atom.grammars
+        grammars: core.grammars
       });
       buffer.setLanguageMode(languageMode);
 
@@ -1920,7 +1920,7 @@ describe('TreeSitterLanguageMode', () => {
     });
 
     it('includes the root scope name even when the given position is in trailing whitespace at EOF', () => {
-      const grammar = new TreeSitterGrammar(atom.grammars, jsGrammarPath, {
+      const grammar = new TreeSitterGrammar(core.grammars, jsGrammarPath, {
         scopeName: 'source.js',
         parser: 'tree-sitter-javascript',
         scopes: {
@@ -1937,7 +1937,7 @@ describe('TreeSitterLanguageMode', () => {
     });
 
     it('works when the given position is between tokens', () => {
-      const grammar = new TreeSitterGrammar(atom.grammars, jsGrammarPath, {
+      const grammar = new TreeSitterGrammar(core.grammars, jsGrammarPath, {
         scopeName: 'source.js',
         parser: 'tree-sitter-javascript',
         scopes: {
@@ -1959,7 +1959,7 @@ describe('TreeSitterLanguageMode', () => {
 
   describe('.syntaxTreeScopeDescriptorForPosition', () => {
     it('returns a scope descriptor representing the given position in the syntax tree', async () => {
-      const grammar = new TreeSitterGrammar(atom.grammars, jsGrammarPath, {
+      const grammar = new TreeSitterGrammar(core.grammars, jsGrammarPath, {
         scopeName: 'source.js',
         parser: 'tree-sitter-javascript'
       });
@@ -1993,7 +1993,7 @@ describe('TreeSitterLanguageMode', () => {
     });
 
     it('includes nodes in injected syntax trees', async () => {
-      const jsGrammar = new TreeSitterGrammar(atom.grammars, jsGrammarPath, {
+      const jsGrammar = new TreeSitterGrammar(core.grammars, jsGrammarPath, {
         scopeName: 'source.js',
         parser: 'tree-sitter-javascript',
         scopes: {},
@@ -2002,7 +2002,7 @@ describe('TreeSitterLanguageMode', () => {
       });
 
       const htmlGrammar = new TreeSitterGrammar(
-        atom.grammars,
+        core.grammars,
         htmlGrammarPath,
         {
           scopeName: 'text.html',
@@ -2013,8 +2013,8 @@ describe('TreeSitterLanguageMode', () => {
         }
       );
 
-      atom.grammars.addGrammar(jsGrammar);
-      atom.grammars.addGrammar(htmlGrammar);
+      core.grammars.addGrammar(jsGrammar);
+      core.grammars.addGrammar(htmlGrammar);
 
       buffer.setText(`
         <div>
@@ -2029,7 +2029,7 @@ describe('TreeSitterLanguageMode', () => {
       const languageMode = new TreeSitterLanguageMode({
         buffer,
         grammar: htmlGrammar,
-        grammars: atom.grammars
+        grammars: core.grammars
       });
       buffer.setLanguageMode(languageMode);
 
@@ -2060,7 +2060,7 @@ describe('TreeSitterLanguageMode', () => {
   describe('.bufferRangeForScopeAtPosition(selector?, position)', () => {
     describe('when selector = null', () => {
       it('returns the range of the smallest node at position', async () => {
-        const grammar = new TreeSitterGrammar(atom.grammars, jsGrammarPath, {
+        const grammar = new TreeSitterGrammar(core.grammars, jsGrammarPath, {
           scopeName: 'javascript',
           parser: 'tree-sitter-javascript'
         });
@@ -2079,7 +2079,7 @@ describe('TreeSitterLanguageMode', () => {
       });
 
       it('includes nodes in injected syntax trees', async () => {
-        const jsGrammar = new TreeSitterGrammar(atom.grammars, jsGrammarPath, {
+        const jsGrammar = new TreeSitterGrammar(core.grammars, jsGrammarPath, {
           scopeName: 'javascript',
           parser: 'tree-sitter-javascript',
           scopes: {},
@@ -2088,7 +2088,7 @@ describe('TreeSitterLanguageMode', () => {
         });
 
         const htmlGrammar = new TreeSitterGrammar(
-          atom.grammars,
+          core.grammars,
           htmlGrammarPath,
           {
             scopeName: 'html',
@@ -2099,8 +2099,8 @@ describe('TreeSitterLanguageMode', () => {
           }
         );
 
-        atom.grammars.addGrammar(jsGrammar);
-        atom.grammars.addGrammar(htmlGrammar);
+        core.grammars.addGrammar(jsGrammar);
+        core.grammars.addGrammar(htmlGrammar);
 
         buffer.setText(`
           <div>
@@ -2115,7 +2115,7 @@ describe('TreeSitterLanguageMode', () => {
         const languageMode = new TreeSitterLanguageMode({
           buffer,
           grammar: htmlGrammar,
-          grammars: atom.grammars
+          grammars: core.grammars
         });
         buffer.setLanguageMode(languageMode);
 
@@ -2130,7 +2130,7 @@ describe('TreeSitterLanguageMode', () => {
 
     describe('with a selector', () => {
       it('returns the range of the smallest matching node at position', async () => {
-        const grammar = new TreeSitterGrammar(atom.grammars, jsGrammarPath, {
+        const grammar = new TreeSitterGrammar(core.grammars, jsGrammarPath, {
           scopeName: 'javascript',
           parser: 'tree-sitter-javascript',
           scopes: {
@@ -2151,7 +2151,7 @@ describe('TreeSitterLanguageMode', () => {
       });
 
       it('includes nodes in injected syntax trees', async () => {
-        const jsGrammar = new TreeSitterGrammar(atom.grammars, jsGrammarPath, {
+        const jsGrammar = new TreeSitterGrammar(core.grammars, jsGrammarPath, {
           scopeName: 'javascript',
           parser: 'tree-sitter-javascript',
           scopes: {
@@ -2162,7 +2162,7 @@ describe('TreeSitterLanguageMode', () => {
         });
 
         const htmlGrammar = new TreeSitterGrammar(
-          atom.grammars,
+          core.grammars,
           htmlGrammarPath,
           {
             scopeName: 'html',
@@ -2175,8 +2175,8 @@ describe('TreeSitterLanguageMode', () => {
           }
         );
 
-        atom.grammars.addGrammar(jsGrammar);
-        atom.grammars.addGrammar(htmlGrammar);
+        core.grammars.addGrammar(jsGrammar);
+        core.grammars.addGrammar(htmlGrammar);
 
         buffer.setText(`
           <div>
@@ -2191,7 +2191,7 @@ describe('TreeSitterLanguageMode', () => {
         const languageMode = new TreeSitterLanguageMode({
           buffer,
           grammar: htmlGrammar,
-          grammars: atom.grammars
+          grammars: core.grammars
         });
         buffer.setLanguageMode(languageMode);
 
@@ -2213,7 +2213,7 @@ describe('TreeSitterLanguageMode', () => {
       });
 
       it('accepts node-matching functions as selectors', async () => {
-        const jsGrammar = new TreeSitterGrammar(atom.grammars, jsGrammarPath, {
+        const jsGrammar = new TreeSitterGrammar(core.grammars, jsGrammarPath, {
           scopeName: 'javascript',
           parser: 'tree-sitter-javascript',
           scopes: {},
@@ -2222,7 +2222,7 @@ describe('TreeSitterLanguageMode', () => {
         });
 
         const htmlGrammar = new TreeSitterGrammar(
-          atom.grammars,
+          core.grammars,
           htmlGrammarPath,
           {
             scopeName: 'html',
@@ -2233,8 +2233,8 @@ describe('TreeSitterLanguageMode', () => {
           }
         );
 
-        atom.grammars.addGrammar(jsGrammar);
-        atom.grammars.addGrammar(htmlGrammar);
+        core.grammars.addGrammar(jsGrammar);
+        core.grammars.addGrammar(htmlGrammar);
 
         buffer.setText(`
           <div>
@@ -2249,7 +2249,7 @@ describe('TreeSitterLanguageMode', () => {
         const languageMode = new TreeSitterLanguageMode({
           buffer,
           grammar: htmlGrammar,
-          grammars: atom.grammars
+          grammars: core.grammars
         });
         buffer.setLanguageMode(languageMode);
 
@@ -2271,7 +2271,7 @@ describe('TreeSitterLanguageMode', () => {
 
   describe('.getSyntaxNodeAtPosition(position, where?)', () => {
     it('returns the range of the smallest matching node at position', async () => {
-      const grammar = new TreeSitterGrammar(atom.grammars, jsGrammarPath, {
+      const grammar = new TreeSitterGrammar(core.grammars, jsGrammarPath, {
         scopeName: 'javascript',
         parser: 'tree-sitter-javascript'
       });
@@ -2292,7 +2292,7 @@ describe('TreeSitterLanguageMode', () => {
 
   describe('.commentStringsForPosition(position)', () => {
     it('returns the correct comment strings for nested languages', () => {
-      const jsGrammar = new TreeSitterGrammar(atom.grammars, jsGrammarPath, {
+      const jsGrammar = new TreeSitterGrammar(core.grammars, jsGrammarPath, {
         scopeName: 'javascript',
         parser: 'tree-sitter-javascript',
         comments: { start: '//' },
@@ -2301,7 +2301,7 @@ describe('TreeSitterLanguageMode', () => {
       });
 
       const htmlGrammar = new TreeSitterGrammar(
-        atom.grammars,
+        core.grammars,
         htmlGrammarPath,
         {
           scopeName: 'html',
@@ -2313,13 +2313,13 @@ describe('TreeSitterLanguageMode', () => {
         }
       );
 
-      atom.grammars.addGrammar(jsGrammar);
-      atom.grammars.addGrammar(htmlGrammar);
+      core.grammars.addGrammar(jsGrammar);
+      core.grammars.addGrammar(htmlGrammar);
 
       const languageMode = new TreeSitterLanguageMode({
         buffer,
         grammar: htmlGrammar,
-        grammars: atom.grammars
+        grammars: core.grammars
       });
       buffer.setLanguageMode(languageMode);
       buffer.setText(
@@ -2369,7 +2369,7 @@ describe('TreeSitterLanguageMode', () => {
 
   describe('TextEditor.selectLargerSyntaxNode and .selectSmallerSyntaxNode', () => {
     it('expands and contracts the selection based on the syntax tree', async () => {
-      const grammar = new TreeSitterGrammar(atom.grammars, jsGrammarPath, {
+      const grammar = new TreeSitterGrammar(core.grammars, jsGrammarPath, {
         parser: 'tree-sitter-javascript',
         scopes: { program: 'source' }
       });
@@ -2410,7 +2410,7 @@ describe('TreeSitterLanguageMode', () => {
     });
 
     it('handles injected languages', async () => {
-      const jsGrammar = new TreeSitterGrammar(atom.grammars, jsGrammarPath, {
+      const jsGrammar = new TreeSitterGrammar(core.grammars, jsGrammarPath, {
         scopeName: 'javascript',
         parser: 'tree-sitter-javascript',
         scopes: {
@@ -2425,7 +2425,7 @@ describe('TreeSitterLanguageMode', () => {
       });
 
       const htmlGrammar = new TreeSitterGrammar(
-        atom.grammars,
+        core.grammars,
         htmlGrammarPath,
         {
           scopeName: 'html',
@@ -2439,13 +2439,13 @@ describe('TreeSitterLanguageMode', () => {
         }
       );
 
-      atom.grammars.addGrammar(htmlGrammar);
+      core.grammars.addGrammar(htmlGrammar);
 
       buffer.setText('a = html ` <b>c${def()}e${f}g</b> `');
       const languageMode = new TreeSitterLanguageMode({
         buffer,
         grammar: jsGrammar,
-        grammars: atom.grammars
+        grammars: core.grammars
       });
       buffer.setLanguageMode(languageMode);
 
@@ -2474,7 +2474,7 @@ describe('TreeSitterLanguageMode', () => {
 
   describe('.tokenizedLineForRow(row)', () => {
     it('returns a shimmed TokenizedLine with tokens', () => {
-      const grammar = new TreeSitterGrammar(atom.grammars, jsGrammarPath, {
+      const grammar = new TreeSitterGrammar(core.grammars, jsGrammarPath, {
         parser: 'tree-sitter-javascript',
         scopes: {
           program: 'source',

--- a/spec/window-event-handler-spec.js
+++ b/spec/window-event-handler-spec.js
@@ -16,7 +16,7 @@ describe('WindowEventHandler', () => {
     });
     core.project.destroy();
     windowEventHandler = new WindowEventHandler({
-      coreEnvironment: core,
+      atomEnvironment: core,
       applicationDelegate: core.applicationDelegate
     });
     windowEventHandler.initialize(window, document);

--- a/spec/window-event-handler-spec.js
+++ b/spec/window-event-handler-spec.js
@@ -6,25 +6,25 @@ describe('WindowEventHandler', () => {
   let windowEventHandler;
 
   beforeEach(() => {
-    atom.uninstallWindowEventHandler();
-    spyOn(atom, 'hide');
-    const initialPath = atom.project.getPaths()[0];
-    spyOn(atom, 'getLoadSettings').andCallFake(() => {
-      const loadSettings = atom.getLoadSettings.originalValue.call(atom);
+    core.uninstallWindowEventHandler();
+    spyOn(core, 'hide');
+    const initialPath = core.project.getPaths()[0];
+    spyOn(core, 'getLoadSettings').andCallFake(() => {
+      const loadSettings = core.getLoadSettings.originalValue.call(core);
       loadSettings.initialPath = initialPath;
       return loadSettings;
     });
-    atom.project.destroy();
+    core.project.destroy();
     windowEventHandler = new WindowEventHandler({
-      atomEnvironment: atom,
-      applicationDelegate: atom.applicationDelegate
+      coreEnvironment: core,
+      applicationDelegate: core.applicationDelegate
     });
     windowEventHandler.initialize(window, document);
   });
 
   afterEach(() => {
     windowEventHandler.unsubscribe();
-    atom.installWindowEventHandler();
+    core.installWindowEventHandler();
   });
 
   describe('when the window is loaded', () =>
@@ -54,17 +54,17 @@ describe('WindowEventHandler', () => {
     it('calls storeWindowDimensions', async () => {
       jasmine.useRealClock();
 
-      spyOn(atom, 'storeWindowDimensions');
+      spyOn(core, 'storeWindowDimensions');
       window.dispatchEvent(new CustomEvent('resize'));
 
-      await conditionPromise(() => atom.storeWindowDimensions.callCount > 0);
+      await conditionPromise(() => core.storeWindowDimensions.callCount > 0);
     }));
 
   describe('window:close event', () =>
     it('closes the window', () => {
-      spyOn(atom, 'close');
+      spyOn(core, 'close');
       window.dispatchEvent(new CustomEvent('window:close'));
-      expect(atom.close).toHaveBeenCalled();
+      expect(core.close).toHaveBeenCalled();
     }));
 
   describe('when a link is clicked', () => {
@@ -244,9 +244,9 @@ describe('WindowEventHandler', () => {
   describe('when keydown events occur on the document', () =>
     it('dispatches the event via the KeymapManager and CommandRegistry', () => {
       const dispatchedCommands = [];
-      atom.commands.onWillDispatch(command => dispatchedCommands.push(command));
-      atom.commands.add('*', { 'foo-command': () => {} });
-      atom.keymaps.add('source-name', { '*': { x: 'foo-command' } });
+      core.commands.onWillDispatch(command => dispatchedCommands.push(command));
+      core.commands.add('*', { 'foo-command': () => {} });
+      core.keymaps.add('source-name', { '*': { x: 'foo-command' } });
 
       const event = KeymapManager.buildKeydownEvent('x', {
         target: document.createElement('div')
@@ -263,7 +263,7 @@ describe('WindowEventHandler', () => {
         'copy',
         'paste'
       ]);
-      spyOn(atom.applicationDelegate, 'getCurrentWindow').andReturn({
+      spyOn(core.applicationDelegate, 'getCurrentWindow').andReturn({
         webContents: webContentsSpy,
         on: () => {}
       });
@@ -273,8 +273,8 @@ describe('WindowEventHandler', () => {
       jasmine.attachToDOM(nativeKeyBindingsInput);
       nativeKeyBindingsInput.focus();
 
-      atom.dispatchApplicationMenuCommand('core:copy');
-      atom.dispatchApplicationMenuCommand('core:paste');
+      core.dispatchApplicationMenuCommand('core:copy');
+      core.dispatchApplicationMenuCommand('core:paste');
 
       expect(webContentsSpy.copy).toHaveBeenCalled();
       expect(webContentsSpy.paste).toHaveBeenCalled();
@@ -286,8 +286,8 @@ describe('WindowEventHandler', () => {
       jasmine.attachToDOM(normalInput);
       normalInput.focus();
 
-      atom.dispatchApplicationMenuCommand('core:copy');
-      atom.dispatchApplicationMenuCommand('core:paste');
+      core.dispatchApplicationMenuCommand('core:copy');
+      core.dispatchApplicationMenuCommand('core:paste');
 
       expect(webContentsSpy.copy).not.toHaveBeenCalled();
       expect(webContentsSpy.paste).not.toHaveBeenCalled();

--- a/spec/workspace-center-spec.js
+++ b/spec/workspace-center-spec.js
@@ -5,7 +5,7 @@ const TextEditor = require('../src/text-editor');
 describe('WorkspaceCenter', () => {
   describe('.observeTextEditors()', () => {
     it('invokes the observer with current and future text editors', () => {
-      const workspaceCenter = atom.workspace.getCenter();
+      const workspaceCenter = core.workspace.getCenter();
       const pane = workspaceCenter.getActivePane();
       const observed = [];
 

--- a/spec/workspace-element-spec.js
+++ b/spec/workspace-element-spec.js
@@ -19,9 +19,9 @@ describe('WorkspaceElement', () => {
 
   describe('when the workspace element is focused', () => {
     it('transfers focus to the active pane', () => {
-      const workspaceElement = atom.workspace.getElement();
+      const workspaceElement = core.workspace.getElement();
       jasmine.attachToDOM(workspaceElement);
-      const activePaneElement = atom.workspace.getActivePane().getElement();
+      const activePaneElement = core.workspace.getActivePane().getElement();
       document.body.focus();
       expect(document.activeElement).not.toBe(activePaneElement);
       workspaceElement.focus();
@@ -31,17 +31,17 @@ describe('WorkspaceElement', () => {
 
   describe('when the active pane of an inactive pane container is focused', () => {
     it('changes the active pane container', () => {
-      const dock = atom.workspace.getLeftDock();
+      const dock = core.workspace.getLeftDock();
       dock.show();
-      jasmine.attachToDOM(atom.workspace.getElement());
-      expect(atom.workspace.getActivePaneContainer()).toBe(
-        atom.workspace.getCenter()
+      jasmine.attachToDOM(core.workspace.getElement());
+      expect(core.workspace.getActivePaneContainer()).toBe(
+        core.workspace.getCenter()
       );
       dock
         .getActivePane()
         .getElement()
         .focus();
-      expect(atom.workspace.getActivePaneContainer()).toBe(dock);
+      expect(core.workspace.getActivePaneContainer()).toBe(dock);
     });
   });
 
@@ -62,13 +62,13 @@ describe('WorkspaceElement', () => {
       workspaceElement;
 
     beforeEach(function() {
-      atom.config.set('core.destroyEmptyPanes', false);
+      core.config.set('core.destroyEmptyPanes', false);
       expect(document.hasFocus()).toBe(
         true,
         'Document needs to be focused to run this test'
       );
 
-      workspace = atom.workspace;
+      workspace = core.workspace;
 
       // Set up a workspace center with a grid of 9 panes, in the following
       // arrangement, where the numbers correspond to the variable names below.
@@ -114,7 +114,7 @@ describe('WorkspaceElement', () => {
       rightDockPane = rightDock.getPanes()[0];
       bottomDockPane = bottomDock.getPanes()[0];
 
-      workspaceElement = atom.workspace.getElement();
+      workspaceElement = core.workspace.getElement();
       workspaceElement.style.height = '400px';
       workspaceElement.style.width = '400px';
       jasmine.attachToDOM(workspaceElement);
@@ -309,13 +309,13 @@ describe('WorkspaceElement', () => {
     let workspace, workspaceElement, startingPane;
 
     beforeEach(function() {
-      atom.config.set('core.destroyEmptyPanes', false);
+      core.config.set('core.destroyEmptyPanes', false);
       expect(document.hasFocus()).toBe(
         true,
         'Document needs to be focused to run this test'
       );
 
-      workspace = atom.workspace;
+      workspace = core.workspace;
       expect(workspace.getLeftDock().isVisible()).toBe(false);
       expect(workspace.getRightDock().isVisible()).toBe(false);
       expect(workspace.getBottomDock().isVisible()).toBe(false);
@@ -324,7 +324,7 @@ describe('WorkspaceElement', () => {
       expect(panes.length).toEqual(1);
       startingPane = panes[0];
 
-      workspaceElement = atom.workspace.getElement();
+      workspaceElement = core.workspace.getElement();
       workspaceElement.style.height = '400px';
       workspaceElement.style.width = '400px';
       jasmine.attachToDOM(workspaceElement);
@@ -633,7 +633,7 @@ describe('WorkspaceElement', () => {
     let originalTimeout = jasmine.getEnv().defaultTimeoutInterval;
 
     beforeEach(() => {
-      workspaceElement = atom.workspace.getElement();
+      workspaceElement = core.workspace.getElement();
       workspaceElement.style.width = '600px';
       workspaceElement.style.height = '300px';
       jasmine.attachToDOM(workspaceElement);
@@ -667,7 +667,7 @@ describe('WorkspaceElement', () => {
 
     it('shows the toggle button when the dock is open', async () => {
       await Promise.all([
-        atom.workspace.open({
+        core.workspace.open({
           element: document.createElement('div'),
           getDefaultLocation() {
             return 'left';
@@ -676,7 +676,7 @@ describe('WorkspaceElement', () => {
             return 150;
           }
         }),
-        atom.workspace.open({
+        core.workspace.open({
           element: document.createElement('div'),
           getDefaultLocation() {
             return 'right';
@@ -685,7 +685,7 @@ describe('WorkspaceElement', () => {
             return 150;
           }
         }),
-        atom.workspace.open({
+        core.workspace.open({
           element: document.createElement('div'),
           getDefaultLocation() {
             return 'bottom';
@@ -696,9 +696,9 @@ describe('WorkspaceElement', () => {
         })
       ]);
 
-      const leftDock = atom.workspace.getLeftDock();
-      const rightDock = atom.workspace.getRightDock();
-      const bottomDock = atom.workspace.getBottomDock();
+      const leftDock = core.workspace.getLeftDock();
+      const rightDock = core.workspace.getRightDock();
+      const bottomDock = core.workspace.getBottomDock();
 
       expect(leftDock.isVisible()).toBe(true);
       expect(rightDock.isVisible()).toBe(true);
@@ -871,7 +871,7 @@ describe('WorkspaceElement', () => {
         }
       );
 
-      const workspaceElement = atom.workspace.getElement();
+      const workspaceElement = core.workspace.getElement();
       observeCallback('legacy');
       expect(workspaceElement.className).toMatch('scrollbars-visible-always');
 
@@ -884,38 +884,38 @@ describe('WorkspaceElement', () => {
     let editor, editorElement, workspaceElement;
 
     beforeEach(async () => {
-      await atom.workspace.open('sample.js');
+      await core.workspace.open('sample.js');
 
-      workspaceElement = atom.workspace.getElement();
+      workspaceElement = core.workspace.getElement();
       jasmine.attachToDOM(workspaceElement);
-      editor = atom.workspace.getActiveTextEditor();
+      editor = core.workspace.getActiveTextEditor();
       editorElement = editor.getElement();
     });
 
     it("updates the font-size based on the 'editor.fontSize' config value", async () => {
       const initialCharWidth = editor.getDefaultCharWidth();
       expect(getComputedStyle(editorElement).fontSize).toBe(
-        atom.config.get('editor.fontSize') + 'px'
+        core.config.get('editor.fontSize') + 'px'
       );
 
-      atom.config.set(
+      core.config.set(
         'editor.fontSize',
-        atom.config.get('editor.fontSize') + 5
+        core.config.get('editor.fontSize') + 5
       );
       await editorElement.component.getNextUpdatePromise();
       expect(getComputedStyle(editorElement).fontSize).toBe(
-        atom.config.get('editor.fontSize') + 'px'
+        core.config.get('editor.fontSize') + 'px'
       );
       expect(editor.getDefaultCharWidth()).toBeGreaterThan(initialCharWidth);
     });
 
     it("updates the font-family based on the 'editor.fontFamily' config value", async () => {
       const initialCharWidth = editor.getDefaultCharWidth();
-      let fontFamily = atom.config.get('editor.fontFamily');
+      let fontFamily = core.config.get('editor.fontFamily');
       expect(getComputedStyle(editorElement).fontFamily).toBe(fontFamily);
 
-      atom.config.set('editor.fontFamily', 'sans-serif');
-      fontFamily = atom.config.get('editor.fontFamily');
+      core.config.set('editor.fontFamily', 'sans-serif');
+      fontFamily = core.config.get('editor.fontFamily');
       await editorElement.component.getNextUpdatePromise();
       expect(getComputedStyle(editorElement).fontFamily).toBe(fontFamily);
       expect(editor.getDefaultCharWidth()).not.toBe(initialCharWidth);
@@ -923,17 +923,17 @@ describe('WorkspaceElement', () => {
 
     it("updates the line-height based on the 'editor.lineHeight' config value", async () => {
       const initialLineHeight = editor.getLineHeightInPixels();
-      atom.config.set('editor.lineHeight', '30px');
+      core.config.set('editor.lineHeight', '30px');
       await editorElement.component.getNextUpdatePromise();
       expect(getComputedStyle(editorElement).lineHeight).toBe(
-        atom.config.get('editor.lineHeight')
+        core.config.get('editor.lineHeight')
       );
       expect(editor.getLineHeightInPixels()).not.toBe(initialLineHeight);
     });
 
     it('increases or decreases the font size when a ctrl-mousewheel event occurs', () => {
-      atom.config.set('editor.zoomFontWhenCtrlScrolling', true);
-      atom.config.set('editor.fontSize', 12);
+      core.config.set('editor.zoomFontWhenCtrlScrolling', true);
+      core.config.set('editor.fontSize', 12);
 
       // Zoom out
       editorElement.querySelector('span').dispatchEvent(
@@ -942,7 +942,7 @@ describe('WorkspaceElement', () => {
           ctrlKey: true
         })
       );
-      expect(atom.config.get('editor.fontSize')).toBe(11);
+      expect(core.config.get('editor.fontSize')).toBe(11);
 
       // Zoom in
       editorElement.querySelector('span').dispatchEvent(
@@ -951,7 +951,7 @@ describe('WorkspaceElement', () => {
           ctrlKey: true
         })
       );
-      expect(atom.config.get('editor.fontSize')).toBe(12);
+      expect(core.config.get('editor.fontSize')).toBe(12);
 
       // Not on an atom-text-editor
       workspaceElement.dispatchEvent(
@@ -960,7 +960,7 @@ describe('WorkspaceElement', () => {
           ctrlKey: true
         })
       );
-      expect(atom.config.get('editor.fontSize')).toBe(12);
+      expect(core.config.get('editor.fontSize')).toBe(12);
 
       // No ctrl key
       editorElement.querySelector('span').dispatchEvent(
@@ -968,22 +968,22 @@ describe('WorkspaceElement', () => {
           wheelDeltaY: 10
         })
       );
-      expect(atom.config.get('editor.fontSize')).toBe(12);
+      expect(core.config.get('editor.fontSize')).toBe(12);
 
-      atom.config.set('editor.zoomFontWhenCtrlScrolling', false);
+      core.config.set('editor.zoomFontWhenCtrlScrolling', false);
       editorElement.querySelector('span').dispatchEvent(
         new WheelEvent('mousewheel', {
           wheelDeltaY: 10,
           ctrlKey: true
         })
       );
-      expect(atom.config.get('editor.fontSize')).toBe(12);
+      expect(core.config.get('editor.fontSize')).toBe(12);
     });
   });
 
   describe('panel containers', () => {
     it('inserts panel container elements in the correct places in the DOM', () => {
-      const workspaceElement = atom.workspace.getElement();
+      const workspaceElement = core.workspace.getElement();
 
       const leftContainer = workspaceElement.querySelector(
         'atom-panel-container.left'
@@ -1025,21 +1025,21 @@ describe('WorkspaceElement', () => {
     });
 
     it('stretches header/footer panels to the workspace width', () => {
-      const workspaceElement = atom.workspace.getElement();
+      const workspaceElement = core.workspace.getElement();
       jasmine.attachToDOM(workspaceElement);
       expect(workspaceElement.offsetWidth).toBeGreaterThan(0);
 
       const headerItem = document.createElement('div');
-      atom.workspace.addHeaderPanel({ item: headerItem });
+      core.workspace.addHeaderPanel({ item: headerItem });
       expect(headerItem.offsetWidth).toEqual(workspaceElement.offsetWidth);
 
       const footerItem = document.createElement('div');
-      atom.workspace.addFooterPanel({ item: footerItem });
+      core.workspace.addFooterPanel({ item: footerItem });
       expect(footerItem.offsetWidth).toEqual(workspaceElement.offsetWidth);
     });
 
     it('shrinks horizontal axis according to header/footer panels height', () => {
-      const workspaceElement = atom.workspace.getElement();
+      const workspaceElement = core.workspace.getElement();
       workspaceElement.style.height = '100px';
       const horizontalAxisElement = workspaceElement.querySelector(
         'atom-workspace-axis.horizontal'
@@ -1052,12 +1052,12 @@ describe('WorkspaceElement', () => {
 
       const headerItem = document.createElement('div');
       headerItem.style.height = '10px';
-      atom.workspace.addHeaderPanel({ item: headerItem });
+      core.workspace.addHeaderPanel({ item: headerItem });
       expect(headerItem.offsetHeight).toBeGreaterThan(0);
 
       const footerItem = document.createElement('div');
       footerItem.style.height = '15px';
-      atom.workspace.addFooterPanel({ item: footerItem });
+      core.workspace.addFooterPanel({ item: footerItem });
       expect(footerItem.offsetHeight).toBeGreaterThan(0);
 
       expect(horizontalAxisElement.offsetHeight).toEqual(
@@ -1070,29 +1070,29 @@ describe('WorkspaceElement', () => {
 
   describe("the 'window:toggle-invisibles' command", () => {
     it('shows/hides invisibles in all open and future editors', () => {
-      const workspaceElement = atom.workspace.getElement();
-      expect(atom.config.get('editor.showInvisibles')).toBe(false);
-      atom.commands.dispatch(workspaceElement, 'window:toggle-invisibles');
-      expect(atom.config.get('editor.showInvisibles')).toBe(true);
-      atom.commands.dispatch(workspaceElement, 'window:toggle-invisibles');
-      expect(atom.config.get('editor.showInvisibles')).toBe(false);
+      const workspaceElement = core.workspace.getElement();
+      expect(core.config.get('editor.showInvisibles')).toBe(false);
+      core.commands.dispatch(workspaceElement, 'window:toggle-invisibles');
+      expect(core.config.get('editor.showInvisibles')).toBe(true);
+      core.commands.dispatch(workspaceElement, 'window:toggle-invisibles');
+      expect(core.config.get('editor.showInvisibles')).toBe(false);
     });
   });
 
   describe("the 'window:run-package-specs' command", () => {
     it("runs the package specs for the active item's project path, or the first project path", () => {
-      const workspaceElement = atom.workspace.getElement();
+      const workspaceElement = core.workspace.getElement();
       spyOn(ipcRenderer, 'send');
 
       // No project paths. Don't try to run specs.
-      atom.commands.dispatch(workspaceElement, 'window:run-package-specs');
+      core.commands.dispatch(workspaceElement, 'window:run-package-specs');
       expect(ipcRenderer.send).not.toHaveBeenCalledWith('run-package-specs');
 
       const projectPaths = [temp.mkdirSync('dir1-'), temp.mkdirSync('dir2-')];
-      atom.project.setPaths(projectPaths);
+      core.project.setPaths(projectPaths);
 
       // No active item. Use first project directory.
-      atom.commands.dispatch(workspaceElement, 'window:run-package-specs');
+      core.commands.dispatch(workspaceElement, 'window:run-package-specs');
       expect(ipcRenderer.send).toHaveBeenCalledWith(
         'run-package-specs',
         path.join(projectPaths[0], 'spec'),
@@ -1102,8 +1102,8 @@ describe('WorkspaceElement', () => {
 
       // Active item doesn't implement ::getPath(). Use first project directory.
       const item = document.createElement('div');
-      atom.workspace.getActivePane().activateItem(item);
-      atom.commands.dispatch(workspaceElement, 'window:run-package-specs');
+      core.workspace.getActivePane().activateItem(item);
+      core.commands.dispatch(workspaceElement, 'window:run-package-specs');
       expect(ipcRenderer.send).toHaveBeenCalledWith(
         'run-package-specs',
         path.join(projectPaths[0], 'spec'),
@@ -1113,7 +1113,7 @@ describe('WorkspaceElement', () => {
 
       // Active item has no path. Use first project directory.
       item.getPath = () => null;
-      atom.commands.dispatch(workspaceElement, 'window:run-package-specs');
+      core.commands.dispatch(workspaceElement, 'window:run-package-specs');
       expect(ipcRenderer.send).toHaveBeenCalledWith(
         'run-package-specs',
         path.join(projectPaths[0], 'spec'),
@@ -1123,7 +1123,7 @@ describe('WorkspaceElement', () => {
 
       // Active item has path. Use project path for item path.
       item.getPath = () => path.join(projectPaths[1], 'a-file.txt');
-      atom.commands.dispatch(workspaceElement, 'window:run-package-specs');
+      core.commands.dispatch(workspaceElement, 'window:run-package-specs');
       expect(ipcRenderer.send).toHaveBeenCalledWith(
         'run-package-specs',
         path.join(projectPaths[1], 'spec'),
@@ -1133,11 +1133,11 @@ describe('WorkspaceElement', () => {
     });
 
     it('passes additional options to the spec window', () => {
-      const workspaceElement = atom.workspace.getElement();
+      const workspaceElement = core.workspace.getElement();
       spyOn(ipcRenderer, 'send');
 
       const projectPath = temp.mkdirSync('dir1-');
-      atom.project.setPaths([projectPath]);
+      core.project.setPaths([projectPath]);
       workspaceElement.runPackageSpecs({
         env: { ATOM_GITHUB_BABEL_ENV: 'coverage' }
       });

--- a/src/atom-environment.js
+++ b/src/atom-environment.js
@@ -54,7 +54,7 @@ let nextId = 0;
 
 // Essential: Pulsar global for dealing with packages, themes, menus, and the window.
 //
-// An instance of this class is always available as the `atom` global.
+// An instance of this class is always available as the `core` global and the legacy variant `atom`.
 class AtomEnvironment {
   /*
   Section: Properties
@@ -1211,7 +1211,7 @@ class AtomEnvironment {
   //
   // ```js
   // // Async version (recommended)
-  // atom.confirm({
+  // core.confirm({
   //   message: 'How you feeling?',
   //   detail: 'Be honest.',
   //   buttons: ['Good', 'Bad']
@@ -1226,7 +1226,7 @@ class AtomEnvironment {
   //
   // ```js
   // // Legacy sync version
-  // const chosen = atom.confirm({
+  // const chosen = core.confirm({
   //   message: 'How you feeling?',
   //   detailedMessage: 'Be honest.',
   //   buttons: {
@@ -1417,7 +1417,7 @@ class AtomEnvironment {
   }
 
   showSaveDialogSync(options = {}) {
-    deprecate(`atom.showSaveDialogSync is deprecated and will be removed soon.
+    deprecate(`core.showSaveDialogSync is deprecated and will be removed soon.
 Please, implement ::saveAs and ::getSaveDialogOptions instead for pane items
 or use Pane::saveItemAs for programmatic saving.`);
     return this.applicationDelegate.showSaveDialog(options);
@@ -1560,7 +1560,7 @@ or use Pane::saveItemAs for programmatic saving.`);
     }
   }
 
-  // TODO: We should deprecate the update events here, and use `atom.autoUpdater` instead
+  // TODO: We should deprecate the update events here, and use `core.autoUpdater` instead
   onUpdateAvailable(callback) {
     return this.emitter.on('update-available', callback);
   }

--- a/src/auto-update-manager.js
+++ b/src/auto-update-manager.js
@@ -50,7 +50,7 @@ module.exports = class AutoUpdateManager {
 
   platformSupportsUpdates() {
     return (
-      atom.getReleaseChannel() !== 'dev' && this.getState() !== 'unsupported'
+      core.getReleaseChannel() !== 'dev' && this.getState() !== 'unsupported'
     );
   }
 

--- a/src/clipboard.js
+++ b/src/clipboard.js
@@ -3,14 +3,14 @@ const { clipboard } = require('electron');
 
 // Extended: Represents the clipboard used for copying and pasting in Pulsar.
 //
-// An instance of this class is always available as the `atom.clipboard` global.
+// An instance of this class is always available as the `core.clipboard` global.
 //
 // ## Examples
 //
 // ```js
-// atom.clipboard.write('hello')
+// core.clipboard.write('hello')
 //
-// console.log(atom.clipboard.read()) // 'hello'
+// console.log(core.clipboard.read()) // 'hello'
 // ```
 module.exports = class Clipboard {
   constructor() {

--- a/src/command-registry.js
+++ b/src/command-registry.js
@@ -8,7 +8,7 @@ let SequenceCount = 0;
 
 // Public: Associates listener functions with commands in a
 // context-sensitive way using CSS selectors. You can access a global instance of
-// this class via `atom.commands`, and commands registered there will be
+// this class via `core.commands`, and commands registered there will be
 // presented in the command palette.
 //
 // The global command registry facilitates a style of event handling known as
@@ -16,7 +16,7 @@ let SequenceCount = 0;
 // as custom DOM events that can be invoked on the currently focused element via
 // a key binding or manually via the command palette. Rather than binding
 // listeners for command events directly to DOM nodes, you instead register
-// command event listeners globally on `atom.commands` and constrain them to
+// command event listeners globally on `core.commands` and constrain them to
 // specific kinds of elements with CSS selectors.
 //
 // Command names must follow the `namespace:action` pattern, where `namespace`
@@ -39,7 +39,7 @@ let SequenceCount = 0;
 // Here is a command that inserts the current date in an editor:
 //
 // ```coffee
-// atom.commands.add 'atom-text-editor',
+// core.commands.add 'atom-text-editor',
 //   'user:insert-date': (event) ->
 //     editor = @getModel()
 //     editor.insertText(new Date().toLocaleString())
@@ -101,7 +101,7 @@ module.exports = class CommandRegistry {
   //       `stopImmediatePropagation` to terminate bubbling early.
   //
   //   Additionally, `listener` may have additional properties which are returned
-  //   to those who query using `atom.commands.findCommands`, as well as several
+  //   to those who query using `core.commands.findCommands`, as well as several
   //   meaningful metadata properties:
   //     * `displayName`: Overrides any generated `displayName` that would
   //       otherwise be generated from the event name.

--- a/src/config.js
+++ b/src/config.js
@@ -15,23 +15,23 @@ const schemaEnforcers = {};
 
 // Essential: Used to access all of Pulsar's configuration details.
 //
-// An instance of this class is always available as the `atom.config` global.
+// An instance of this class is always available as the `core.config` global.
 //
 // ## Getting and setting config settings.
 //
 // ```coffee
 // # Note that with no value set, ::get returns the setting's default value.
-// atom.config.get('my-package.myKey') # -> 'defaultValue'
+// core.config.get('my-package.myKey') # -> 'defaultValue'
 //
-// atom.config.set('my-package.myKey', 'value')
-// atom.config.get('my-package.myKey') # -> 'value'
+// core.config.set('my-package.myKey', 'value')
+// core.config.get('my-package.myKey') # -> 'value'
 // ```
 //
 // You may want to watch for changes. Use {::observe} to catch changes to the setting.
 //
 // ```coffee
-// atom.config.set('my-package.myKey', 'value')
-// atom.config.observe 'my-package.myKey', (newValue) ->
+// core.config.set('my-package.myKey', 'value')
+// core.config.observe 'my-package.myKey', (newValue) ->
 //   # `observe` calls immediately and every time the value is changed
 //   console.log 'My configuration changed:', newValue
 // ```
@@ -39,7 +39,7 @@ const schemaEnforcers = {};
 // If you want a notification only when the value changes, use {::onDidChange}.
 //
 // ```coffee
-// atom.config.onDidChange 'my-package.myKey', ({newValue, oldValue}) ->
+// core.config.onDidChange 'my-package.myKey', ({newValue, oldValue}) ->
 //   console.log 'My configuration changed:', newValue, oldValue
 // ```
 //
@@ -51,15 +51,15 @@ const schemaEnforcers = {};
 //
 // ```coffee
 // # When no value has been set, `::get` returns the setting's default value
-// atom.config.get('my-package.anInt') # -> 12
+// core.config.get('my-package.anInt') # -> 12
 //
 // # The string will be coerced to the integer 123
-// atom.config.set('my-package.anInt', '123')
-// atom.config.get('my-package.anInt') # -> 123
+// core.config.set('my-package.anInt', '123')
+// core.config.get('my-package.anInt') # -> 123
 //
 // # The string will be coerced to an integer, but it must be greater than 0, so is set to 1
-// atom.config.set('my-package.anInt', '-20')
-// atom.config.get('my-package.anInt') # -> 1
+// core.config.set('my-package.anInt', '-20')
+// core.config.get('my-package.anInt') # -> 1
 // ```
 //
 // ## Defining settings for your package
@@ -104,16 +104,16 @@ const schemaEnforcers = {};
 // set to a string `'10'`, it will be coerced into an integer.
 //
 // ```coffee
-// atom.config.set('my-package.thingVolume', '10')
-// atom.config.get('my-package.thingVolume') # -> 10
+// core.config.set('my-package.thingVolume', '10')
+// core.config.get('my-package.thingVolume') # -> 10
 //
 // # It respects the min / max
-// atom.config.set('my-package.thingVolume', '400')
-// atom.config.get('my-package.thingVolume') # -> 11
+// core.config.set('my-package.thingVolume', '400')
+// core.config.get('my-package.thingVolume') # -> 11
 //
 // # If it cannot be coerced, the value will not be set
-// atom.config.set('my-package.thingVolume', 'cats')
-// atom.config.get('my-package.thingVolume') # -> 11
+// core.config.set('my-package.thingVolume', 'cats')
+// core.config.get('my-package.thingVolume') # -> 11
 // ```
 //
 // ### Supported Types
@@ -128,11 +128,11 @@ const schemaEnforcers = {};
 //     default: 5
 //
 // # Then
-// atom.config.set('my-package.someSetting', 'true')
-// atom.config.get('my-package.someSetting') # -> true
+// core.config.set('my-package.someSetting', 'true')
+// core.config.get('my-package.someSetting') # -> true
 //
-// atom.config.set('my-package.someSetting', '12')
-// atom.config.get('my-package.someSetting') # -> 12
+// core.config.set('my-package.someSetting', '12')
+// core.config.get('my-package.someSetting') # -> 12
 // ```
 //
 // #### string
@@ -287,16 +287,16 @@ const schemaEnforcers = {};
 // Usage:
 //
 // ```coffee
-// atom.config.set('my-package.someSetting', '2')
-// atom.config.get('my-package.someSetting') # -> 2
+// core.config.set('my-package.someSetting', '2')
+// core.config.get('my-package.someSetting') # -> 2
 //
 // # will not set values outside of the enum values
-// atom.config.set('my-package.someSetting', '3')
-// atom.config.get('my-package.someSetting') # -> 2
+// core.config.set('my-package.someSetting', '3')
+// core.config.get('my-package.someSetting') # -> 2
 //
 // # If it cannot be coerced, the value will not be set
-// atom.config.set('my-package.someSetting', '4')
-// atom.config.get('my-package.someSetting') # -> 4
+// core.config.set('my-package.someSetting', '4')
+// core.config.get('my-package.someSetting') # -> 4
 // ```
 //
 // #### title and description
@@ -367,8 +367,8 @@ const schemaEnforcers = {};
 // You can still do the following
 //
 // ```coffee
-// let otherSetting  = atom.config.get('some-package.otherSetting')
-// atom.config.set('some-package.stillAnotherSetting', otherSetting * 5)
+// let otherSetting  = core.config.get('some-package.otherSetting')
+// core.config.set('some-package.stillAnotherSetting', otherSetting * 5)
 // ```
 //
 // In other words, if a function asks for a `key-path`, that path doesn't have to
@@ -426,7 +426,7 @@ class Config {
     return value;
   }
 
-  // Created during initialization, available as `atom.config`
+  // Created during initialization, available as `core.config`
   constructor(params = {}) {
     this.clear();
     this.initialize(params);
@@ -478,7 +478,7 @@ class Config {
   // `core.themes` for changes
   //
   // ```coffee
-  // atom.config.observe 'core.themes', (value) ->
+  // core.config.observe 'core.themes', (value) ->
   //   # do stuff with value
   // ```
   //
@@ -570,7 +570,7 @@ class Config {
   // You might want to know what themes are enabled, so check `core.themes`
   //
   // ```coffee
-  // atom.config.get('core.themes')
+  // core.config.get('core.themes')
   // ```
   //
   // With scope descriptors you can get settings within a specific editor
@@ -578,14 +578,14 @@ class Config {
   // files.
   //
   // ```coffee
-  // atom.config.get('editor.tabLength', scope: ['source.ruby']) # => 2
+  // core.config.get('editor.tabLength', scope: ['source.ruby']) # => 2
   // ```
   //
   // This setting in ruby files might be different than the global tabLength setting
   //
   // ```coffee
-  // atom.config.get('editor.tabLength') # => 4
-  // atom.config.get('editor.tabLength', scope: ['source.ruby']) # => 2
+  // core.config.get('editor.tabLength') # => 4
+  // core.config.get('editor.tabLength', scope: ['source.ruby']) # => 2
   // ```
   //
   // You can get the language scope descriptor via
@@ -593,14 +593,14 @@ class Config {
   // for the editor's language.
   //
   // ```coffee
-  // atom.config.get('editor.tabLength', scope: @editor.getRootScopeDescriptor()) # => 2
+  // core.config.get('editor.tabLength', scope: @editor.getRootScopeDescriptor()) # => 2
   // ```
   //
   // Additionally, you can get the setting at the specific cursor position.
   //
   // ```coffee
   // scopeDescriptor = @editor.getLastCursor().getScopeDescriptor()
-  // atom.config.get('editor.tabLength', scope: scopeDescriptor) # => 2
+  // core.config.get('editor.tabLength', scope: scopeDescriptor) # => 2
   // ```
   //
   // * `keyPath` The {String} name of the key to retrieve.
@@ -695,24 +695,24 @@ class Config {
   // You might want to change the themes programmatically:
   //
   // ```coffee
-  // atom.config.set('core.themes', ['atom-light-ui', 'atom-light-syntax'])
+  // core.config.set('core.themes', ['atom-light-ui', 'atom-light-syntax'])
   // ```
   //
   // You can also set scoped settings. For example, you might want change the
   // `editor.tabLength` only for ruby files.
   //
   // ```coffee
-  // atom.config.get('editor.tabLength') # => 4
-  // atom.config.get('editor.tabLength', scope: ['source.ruby']) # => 4
-  // atom.config.get('editor.tabLength', scope: ['source.js']) # => 4
+  // core.config.get('editor.tabLength') # => 4
+  // core.config.get('editor.tabLength', scope: ['source.ruby']) # => 4
+  // core.config.get('editor.tabLength', scope: ['source.js']) # => 4
   //
   // # Set ruby to 2
-  // atom.config.set('editor.tabLength', 2, scopeSelector: '.source.ruby') # => true
+  // core.config.set('editor.tabLength', 2, scopeSelector: '.source.ruby') # => true
   //
   // # Notice it's only set to 2 in the case of ruby
-  // atom.config.get('editor.tabLength') # => 4
-  // atom.config.get('editor.tabLength', scope: ['source.ruby']) # => 2
-  // atom.config.get('editor.tabLength', scope: ['source.js']) # => 4
+  // core.config.get('editor.tabLength') # => 4
+  // core.config.get('editor.tabLength', scope: ['source.ruby']) # => 2
+  // core.config.get('editor.tabLength', scope: ['source.js']) # => 4
   // ```
   //
   // * `keyPath` The {String} name of the key.

--- a/src/context-menu-manager.js
+++ b/src/context-menu-manager.js
@@ -17,7 +17,7 @@ if (buildMetadata != null && buildMetadata._atomMenu != null && buildMetadata._a
 // Extended: Provides a registry for commands that you'd like to appear in the
 // context menu.
 //
-// An instance of this class is always available as the `atom.contextMenu`
+// An instance of this class is always available as the `core.contextMenu`
 // global.
 //
 // ## Context Menu CSON Format
@@ -81,7 +81,7 @@ module.exports = class ContextMenuManager {
   // purposes and not the way the menu is actually configured in Atom by default.
   //
   // ```javascript
-  // atom.contextMenu.add({
+  // core.contextMenu.add({
   //   'atom-workspace': [{label: 'Help', command: 'application:open-documentation'}]
   //   'atom-text-editor': [{
   //     label: 'History',

--- a/src/core-uri-handlers.js
+++ b/src/core-uri-handlers.js
@@ -7,10 +7,10 @@ function getLineColNumber(numStr) {
   return Math.max(num - 1, 0);
 }
 
-function openFile(atom, { query }) {
+function openFile(core, { query }) {
   const { filename, line, column } = query;
 
-  atom.workspace.open(filename, {
+  core.workspace.open(filename, {
     initialLine: getLineColNumber(line),
     initialColumn: getLineColNumber(column),
     searchAllPanes: true

--- a/src/default-directory-provider.js
+++ b/src/default-directory-provider.js
@@ -7,7 +7,7 @@ module.exports = class DefaultDirectoryProvider {
   // Public: Create a Directory that corresponds to the specified URI.
   //
   // * `uri` {String} The path to the directory to add. This is guaranteed not to
-  // be contained by a {Directory} in `atom.project`.
+  // be contained by a {Directory} in `core.project`.
   //
   // Returns:
   // * {Directory} if the given URI is compatible with this provider.
@@ -39,7 +39,7 @@ module.exports = class DefaultDirectoryProvider {
   // Public: Create a Directory that corresponds to the specified URI.
   //
   // * `uri` {String} The path to the directory to add. This is guaranteed not to
-  // be contained by a {Directory} in `atom.project`.
+  // be contained by a {Directory} in `core.project`.
   //
   // Returns a {Promise} that resolves to:
   // * {Directory} if the given URI is compatible with this provider.

--- a/src/default-directory-searcher.js
+++ b/src/default-directory-searcher.js
@@ -45,7 +45,7 @@ class DirectorySearch {
   }
 }
 
-// Default provider for the `atom.directory-searcher` service.
+// Default provider for the `core.directory-searcher` service.
 module.exports = class DefaultDirectorySearcher {
   // Determines whether this object supports search for a `Directory`.
   //

--- a/src/deserializer-manager.js
+++ b/src/deserializer-manager.js
@@ -2,14 +2,14 @@ const { Disposable } = require('event-kit');
 
 // Extended: Manages the deserializers used for serialized state
 //
-// An instance of this class is always available as the `atom.deserializers`
+// An instance of this class is always available as the `core.deserializers`
 // global.
 //
 // ## Examples
 //
 // ```coffee
 // class MyPackageView extends View
-//   atom.deserializers.add(this)
+//   core.deserializers.add(this)
 //
 //   @deserialize: (state) ->
 //     new MyPackageView(state)
@@ -33,7 +33,7 @@ module.exports = class DeserializerManager {
   //   instances by adding a `.deserialize()` class method. When your method is
   //   called, it will be passed serialized state as the first argument and the
   //   {AtomEnvironment} object as the second argument, which is useful if you
-  //   wish to avoid referencing the `atom` global.
+  //   wish to avoid referencing the `core` global.
   add(...deserializers) {
     for (let i = 0; i < deserializers.length; i++) {
       let deserializer = deserializers[i];

--- a/src/dock.js
+++ b/src/dock.js
@@ -692,7 +692,7 @@ module.exports = class Dock {
   // {TextEditor}.
   getActiveTextEditor() {
     Grim.deprecate(
-      'Text editors are not allowed in docks. Use atom.workspace.getActiveTextEditor() instead.'
+      'Text editors are not allowed in docks. Use core.workspace.getActiveTextEditor() instead.'
     );
 
     const activeItem = this.getActivePaneItem();

--- a/src/get-app-name.js
+++ b/src/get-app-name.js
@@ -3,7 +3,7 @@ const getReleaseChannel = require('./get-release-channel');
 
 module.exports = function getAppName() {
   if (process.type === 'renderer') {
-    return atom.getAppName();
+    return core.getAppName();
   }
 
   const releaseChannel = getReleaseChannel(app.getVersion());

--- a/src/git-repository.js
+++ b/src/git-repository.js
@@ -9,7 +9,7 @@ let nextId = 0;
 // Extended: Represents the underlying git operations performed by Pulsar.
 //
 // This class shouldn't be instantiated directly but instead by accessing the
-// `atom.project` global and calling `getRepositories()`. Note that this will
+// `core.project` global and calling `getRepositories()`. Note that this will
 // only be available when the project is backed by a Git repository.
 //
 // This class handles submodules automatically by taking a `path` argument to many
@@ -19,7 +19,7 @@ let nextId = 0;
 // For a repository with submodules this would have the following outcome:
 //
 // ```coffee
-// repo = atom.project.getRepositories()[0]
+// repo = core.project.getRepositories()[0]
 // repo.getShortHead() # 'master'
 // repo.getShortHead('vendor/path/to/a/submodule') # 'dead1234'
 // ```
@@ -29,7 +29,7 @@ let nextId = 0;
 // ### Logging the URL of the origin remote
 //
 // ```coffee
-// git = atom.project.getRepositories()[0]
+// git = core.project.getRepositories()[0]
 // console.log git.getOriginURL()
 // ```
 //

--- a/src/grammar-registry.js
+++ b/src/grammar-registry.js
@@ -15,7 +15,7 @@ const PATH_SPLIT_REGEX = new RegExp('[/.]');
 
 // Extended: This class holds the grammars used for tokenizing.
 //
-// An instance of this class is always available as the `atom.grammars` global.
+// An instance of this class is always available as the `core.grammars` global.
 module.exports = class GrammarRegistry {
   constructor({ config } = {}) {
     this.config = config;
@@ -375,7 +375,7 @@ module.exports = class GrammarRegistry {
   // Returns a {String} such as `"source.js"`.
   grammarOverrideForPath(filePath) {
     Grim.deprecate('Use buffer.getLanguageMode().getLanguageId() instead');
-    const buffer = atom.project.findBufferForPath(filePath);
+    const buffer = core.project.findBufferForPath(filePath);
     if (buffer) return this.getAssignedLanguageId(buffer);
   }
 
@@ -387,9 +387,9 @@ module.exports = class GrammarRegistry {
   // Returns undefined.
   setGrammarOverrideForPath(filePath, languageId) {
     Grim.deprecate(
-      'Use atom.grammars.assignLanguageMode(buffer, languageId) instead'
+      'Use core.grammars.assignLanguageMode(buffer, languageId) instead'
     );
-    const buffer = atom.project.findBufferForPath(filePath);
+    const buffer = core.project.findBufferForPath(filePath);
     if (buffer) {
       const grammar = this.grammarForScopeName(languageId);
       if (grammar)
@@ -403,8 +403,8 @@ module.exports = class GrammarRegistry {
   //
   // Returns undefined.
   clearGrammarOverrideForPath(filePath) {
-    Grim.deprecate('Use atom.grammars.autoAssignLanguageMode(buffer) instead');
-    const buffer = atom.project.findBufferForPath(filePath);
+    Grim.deprecate('Use core.grammars.autoAssignLanguageMode(buffer) instead');
+    const buffer = core.project.findBufferForPath(filePath);
     if (buffer) this.languageOverridesByBufferId.delete(buffer.id);
   }
 

--- a/src/history-manager.js
+++ b/src/history-manager.js
@@ -2,7 +2,7 @@ const { Emitter, CompositeDisposable } = require('event-kit');
 
 // Extended: History manager for remembering which projects have been opened.
 //
-// An instance of this class is always available as the `atom.history` global.
+// An instance of this class is always available as the `core.history` global.
 //
 // The project history is used to enable the 'Reopen Project' menu.
 class HistoryManager {

--- a/src/initialize-application-window.js
+++ b/src/initialize-application-window.js
@@ -68,11 +68,12 @@ const clipboard = new Clipboard();
 TextEditor.setClipboard(clipboard);
 TextEditor.viewForItem = item => atom.views.getView(item);
 
-global.atom = new AtomEnvironment({
+global.core = new AtomEnvironment({
   clipboard,
   applicationDelegate: new ApplicationDelegate(),
   enablePersistence: true
 });
+global.atom = global.core;
 
 TextEditor.setScheduler(global.atom.views);
 global.atom.preloadPackages();

--- a/src/initialize-application-window.js
+++ b/src/initialize-application-window.js
@@ -66,7 +66,7 @@ if (global.isGeneratingSnapshot) {
 
 const clipboard = new Clipboard();
 TextEditor.setClipboard(clipboard);
-TextEditor.viewForItem = item => atom.views.getView(item);
+TextEditor.viewForItem = item => core.views.getView(item);
 
 global.core = new AtomEnvironment({
   clipboard,
@@ -75,8 +75,8 @@ global.core = new AtomEnvironment({
 });
 global.atom = global.core;
 
-TextEditor.setScheduler(global.atom.views);
-global.atom.preloadPackages();
+TextEditor.setScheduler(global.core.views);
+global.core.preloadPackages();
 
 // Like sands through the hourglass, so are the days of our lives.
 module.exports = function({ blobStore }) {
@@ -98,7 +98,7 @@ module.exports = function({ blobStore }) {
     process.env.NODE_ENV = 'production';
   }
 
-  global.atom.initialize({
+  global.core.initialize({
     window,
     document,
     blobStore,
@@ -106,7 +106,7 @@ module.exports = function({ blobStore }) {
     env: process.env
   });
 
-  return global.atom.startEditorWindow().then(function() {
+  return global.core.startEditorWindow().then(function() {
     // Workaround for focus getting cleared upon window creation
     const windowFocused = function() {
       window.removeEventListener('focus', windowFocused);

--- a/src/initialize-benchmark-window.js
+++ b/src/initialize-benchmark-window.js
@@ -68,7 +68,7 @@ module.exports = async function() {
 
     const clipboard = new Clipboard();
     TextEditor.setClipboard(clipboard);
-    TextEditor.viewForItem = item => atom.views.getView(item);
+    TextEditor.viewForItem = item => core.views.getView(item);
 
     const applicationDelegate = new ApplicationDelegate();
     const environmentParams = {
@@ -79,11 +79,12 @@ module.exports = async function() {
       configDirPath: process.env.ATOM_HOME,
       enablePersistence: false
     };
-    global.atom = new AtomEnvironment(environmentParams);
-    global.atom.initialize(environmentParams);
+    global.core = new AtomEnvironment(environmentParams);
+    global.atom = global.core;
+    global.core.initialize(environmentParams);
 
     // Prevent benchmarks from modifying application menus
-    global.atom.menu.sendToBrowserProcess = function() {};
+    global.core.menu.sendToBrowserProcess = function() {};
 
     if (headless) {
       Object.defineProperties(process, {

--- a/src/initialize-test-window.js
+++ b/src/initialize-test-window.js
@@ -116,7 +116,7 @@ module.exports = async function({ blobStore }) {
 
     const clipboard = new Clipboard();
     TextEditor.setClipboard(clipboard);
-    TextEditor.viewForItem = item => atom.views.getView(item);
+    TextEditor.viewForItem = item => core.views.getView(item);
 
     const testRunner = requireModule(testRunnerPath);
     const legacyTestRunner = require(legacyTestRunnerPath);

--- a/src/initialize-test-window.js
+++ b/src/initialize-test-window.js
@@ -81,7 +81,7 @@ module.exports = async function({ blobStore }) {
 
       // Copy: cmd-c / ctrl-c
       if ((event.metaKey || event.ctrlKey) && event.keyCode === 67) {
-        atom.clipboard.write(window.getSelection().toString());
+        core.clipboard.write(window.getSelection().toString());
       }
     };
 

--- a/src/main-process/atom-application.js
+++ b/src/main-process/atom-application.js
@@ -40,11 +40,11 @@ const LocationSuffixRegExp = /(:\d+)(:\d+)?$/;
 const APPLICATION_STATE_VERSION = '1';
 
 const getDefaultPath = () => {
-  const editor = atom.workspace.getActiveTextEditor();
+  const editor = core.workspace.getActiveTextEditor();
   if (!editor || !editor.getPath()) {
     return;
   }
-  const paths = atom.project.getPaths();
+  const paths = core.project.getPaths();
   if (paths) {
     return paths[0];
   }

--- a/src/menu-manager.js
+++ b/src/menu-manager.js
@@ -15,7 +15,7 @@ if (buildMetadata) {
 // Extended: Provides a registry for menu items that you'd like to appear in the
 // application menu.
 //
-// An instance of this class is always available as the `atom.menu` global.
+// An instance of this class is always available as the `core.menu` global.
 //
 // ## Menu CSON Format
 //
@@ -82,7 +82,7 @@ module.exports = MenuManager = class MenuManager {
   //
   // ## Examples
   // ```javascript
-  //   atom.menu.add([
+  //   core.menu.add([
   //     {
   //       label: 'Hello'
   //       submenu : [{label: 'World!', id: 'World!', command: 'hello:world'}]

--- a/src/notification-manager.js
+++ b/src/notification-manager.js
@@ -4,7 +4,7 @@ const Notification = require('../src/notification');
 // Public: A notification manager used to create {Notification}s to be shown
 // to the user.
 //
-// An instance of this class is always available as the `atom.notifications`
+// An instance of this class is always available as the `core.notifications`
 // global.
 module.exports = class NotificationManager {
   constructor() {

--- a/src/package-manager.js
+++ b/src/package-manager.js
@@ -14,7 +14,7 @@ const packageJSON = require('../package.json');
 
 // Extended: Package manager for coordinating the lifecycle of Pulsar packages.
 //
-// An instance of this class is always available as the `atom.packages` global.
+// An instance of this class is always available as the `core.packages` global.
 //
 // Packages can be loaded, activated, and deactivated, and unloaded:
 //  * Loading a package reads and parses the package's metadata and resources

--- a/src/package-manager.js
+++ b/src/package-manager.js
@@ -189,7 +189,7 @@ module.exports = class PackageManager {
   //
   // Return a {String} file path to apm.
   getApmPath() {
-    const configPath = atom.config.get('core.apmPath');
+    const configPath = core.config.get('core.apmPath');
     if (process.env.APM_PATH || configPath || this.apmPath) {
       return process.env.APM_PATH || configPath || this.apmPath;
     }

--- a/src/package.js
+++ b/src/package.js
@@ -1113,11 +1113,11 @@ module.exports = class Package {
     this.workspaceOpenerSubscriptions = new CompositeDisposable();
     for (let opener of this.getWorkspaceOpeners()) {
       this.workspaceOpenerSubscriptions.add(
-        atom.workspace.addOpener(filePath => {
+        core.workspace.addOpener(filePath => {
           if (filePath === opener) {
             this.activateNow();
             this.workspaceOpenerSubscriptions.dispose();
-            return atom.workspace.createItemForURI(opener);
+            return core.workspace.createItemForURI(opener);
           }
         })
       );
@@ -1367,7 +1367,7 @@ module.exports = class Package {
   }
 
   handleError(message, error) {
-    if (atom.inSpecMode()) throw error;
+    if (core.inSpecMode()) throw error;
 
     let detail, location, stack;
     if (error.filename && error.location && error instanceof SyntaxError) {

--- a/src/path-watcher.js
+++ b/src/path-watcher.js
@@ -480,9 +480,9 @@ class PathWatcherManager {
   static active() {
     if (!this.activeManager) {
       this.activeManager = new PathWatcherManager(
-        atom.config.get('core.fileSystemWatcher')
+        core.config.get('core.fileSystemWatcher')
       );
-      this.sub = atom.config.onDidChange(
+      this.sub = core.config.onDidChange(
         'core.fileSystemWatcher',
         ({ newValue }) => {
           this.transitionTo(newValue);

--- a/src/project.js
+++ b/src/project.js
@@ -218,7 +218,7 @@ module.exports = class Project extends Model {
   // project path.
   //
   // ```js
-  // const disposable = atom.project.onDidChangeFiles(events => {
+  // const disposable = core.project.onDidChangeFiles(events => {
   //   for (const event of events) {
   //     // "created", "modified", "deleted", or "renamed"
   //     console.log(`Event action: ${event.action}`)

--- a/src/project.js
+++ b/src/project.js
@@ -12,7 +12,7 @@ const GitRepositoryProvider = require('./git-repository-provider');
 
 // Extended: Represents a project that's opened in Pulsar.
 //
-// An instance of this class is always available as the `atom.project` global.
+// An instance of this class is always available as the `core.project` global.
 module.exports = class Project extends Model {
   /*
   Section: Construction and Destruction
@@ -90,7 +90,7 @@ module.exports = class Project extends Model {
   // on top of the current global config.
   replace(projectSpecification) {
     if (projectSpecification == null) {
-      atom.config.clearProjectSettings();
+      core.config.clearProjectSettings();
       this.setPaths([]);
     } else {
       if (projectSpecification.originPath == null) {
@@ -103,7 +103,7 @@ module.exports = class Project extends Model {
           path.dirname(projectSpecification.originPath)
         ];
       }
-      atom.config.resetProjectSettings(
+      core.config.resetProjectSettings(
         projectSpecification.config,
         projectSpecification.originPath
       );
@@ -127,7 +127,7 @@ module.exports = class Project extends Model {
     const handleBufferState = bufferState => {
       if (bufferState.shouldDestroyOnFileDelete == null) {
         bufferState.shouldDestroyOnFileDelete = () =>
-          atom.config.get('core.closeDeletedFileTabs');
+          core.config.get('core.closeDeletedFileTabs');
       }
 
       // Use a little guilty knowledge of the way TextBuffers are serialized.
@@ -299,8 +299,8 @@ module.exports = class Project extends Model {
   // Prefer the following, which evaluates to a {Promise} that resolves to an
   // {Array} of {GitRepository} objects:
   // ```
-  // Promise.all(atom.project.getDirectories().map(
-  //     atom.project.repositoryForDirectory.bind(atom.project)))
+  // Promise.all(core.project.getDirectories().map(
+  //     core.project.repositoryForDirectory.bind(core.project)))
   // ```
   getRepositories() {
     return this.repositories;
@@ -353,7 +353,7 @@ module.exports = class Project extends Model {
     try {
       return this.rootDirectories.map(rootDirectory => rootDirectory.getPath());
     } catch (e) {
-      atom.notifications.addError(
+      core.notifications.addError(
         "Please clear Pulsar's window state with: pulsar --clear-window-state"
       );
     }
@@ -750,7 +750,7 @@ module.exports = class Project extends Model {
   }
 
   shouldDestroyBufferOnFileDelete() {
-    return atom.config.get('core.closeDeletedFileTabs');
+    return core.config.get('core.closeDeletedFileTabs');
   }
 
   // Still needed when deserializing a tokenized buffer

--- a/src/register-default-commands.js
+++ b/src/register-default-commands.js
@@ -92,17 +92,17 @@ module.exports = function({commandRegistry, commandInstaller, config, notificati
     },
     'application:open': function() {
       var defaultPath, ref, ref1, ref2;
-      defaultPath = (ref = (ref1 = atom.workspace.getActiveTextEditor()) != null ? ref1.getPath() : void 0) != null ? ref : (ref2 = atom.project.getPaths()) != null ? ref2[0] : void 0;
+      defaultPath = (ref = (ref1 = core.workspace.getActiveTextEditor()) != null ? ref1.getPath() : void 0) != null ? ref : (ref2 = core.project.getPaths()) != null ? ref2[0] : void 0;
       return ipcRenderer.send('open-chosen-any', defaultPath);
     },
     'application:open-file': function() {
       var defaultPath, ref, ref1, ref2;
-      defaultPath = (ref = (ref1 = atom.workspace.getActiveTextEditor()) != null ? ref1.getPath() : void 0) != null ? ref : (ref2 = atom.project.getPaths()) != null ? ref2[0] : void 0;
+      defaultPath = (ref = (ref1 = core.workspace.getActiveTextEditor()) != null ? ref1.getPath() : void 0) != null ? ref : (ref2 = core.project.getPaths()) != null ? ref2[0] : void 0;
       return ipcRenderer.send('open-chosen-file', defaultPath);
     },
     'application:open-folder': function() {
       var defaultPath, ref, ref1, ref2;
-      defaultPath = (ref = (ref1 = atom.workspace.getActiveTextEditor()) != null ? ref1.getPath() : void 0) != null ? ref : (ref2 = atom.project.getPaths()) != null ? ref2[0] : void 0;
+      defaultPath = (ref = (ref1 = core.workspace.getActiveTextEditor()) != null ? ref1.getPath() : void 0) != null ? ref : (ref2 = core.project.getPaths()) != null ? ref2[0] : void 0;
       return ipcRenderer.send('open-chosen-folder', defaultPath);
     },
     'application:open-dev': function() {
@@ -112,7 +112,7 @@ module.exports = function({commandRegistry, commandInstaller, config, notificati
       return ipcRenderer.send('command', 'application:open-safe');
     },
     'application:add-project-folder': function() {
-      return atom.addProjectFolder();
+      return core.addProjectFolder();
     },
     'application:minimize': function() {
       return ipcRenderer.send('command', 'application:minimize');
@@ -649,7 +649,7 @@ module.exports = function({commandRegistry, commandInstaller, config, notificati
       return this.toggleLineCommentsInSelection();
     },
     'editor:checkout-head-revision': function() {
-      return atom.workspace.checkoutHeadRevision(this);
+      return core.workspace.checkoutHeadRevision(this);
     },
     'editor:move-line-up': function() {
       return this.moveLineUp();

--- a/src/reopen-project-list-view.js
+++ b/src/reopen-project-list-view.js
@@ -51,7 +51,7 @@ module.exports = class ReopenProjectListView {
   attach() {
     this.previouslyFocusedElement = document.activeElement;
     if (this.panel == null) {
-      this.panel = atom.workspace.addModalPanel({ item: this });
+      this.panel = core.workspace.addModalPanel({ item: this });
     }
     this.selectListView.focus();
     this.selectListView.reset();
@@ -62,8 +62,8 @@ module.exports = class ReopenProjectListView {
       this.cancel();
     } else {
       this.currentProjectName =
-        atom.project != null ? this.makeName(atom.project.getPaths()) : null;
-      const projects = atom.history
+        core.project != null ? this.makeName(core.project.getPaths()) : null;
+      const projects = core.history
         .getProjects()
         .map(p => ({ name: this.makeName(p.paths), value: p.paths }));
       await this.selectListView.update({ items: projects });

--- a/src/selection.js
+++ b/src/selection.js
@@ -459,7 +459,7 @@ module.exports = class Selection {
   // the editor is read-only, require an explicit opt-in option to proceed (`bypassReadOnly`) or throw an Error.
   ensureWritable(methodName, opts) {
     if (!opts.bypassReadOnly && this.editor.isReadOnly()) {
-      if (atom.inDevMode() || atom.inSpecMode()) {
+      if (core.inDevMode() || core.inSpecMode()) {
         const e = new Error(
           'Attempt to mutate a read-only TextEditor through a Selection'
         );

--- a/src/state-store.js
+++ b/src/state-store.js
@@ -14,7 +14,7 @@ module.exports = class StateStore {
         dbOpenRequest.onupgradeneeded = event => {
           let db = event.target.result;
           db.onerror = error => {
-            atom.notifications.addFatalError('Error loading database', {
+            core.notifications.addFatalError('Error loading database', {
               stack: new Error('Error loading database').stack,
               dismissable: true
             });
@@ -27,7 +27,7 @@ module.exports = class StateStore {
           resolve(dbOpenRequest.result);
         };
         dbOpenRequest.onerror = error => {
-          atom.notifications.addFatalError('Could not connect to indexedDB', {
+          core.notifications.addFatalError('Could not connect to indexedDB', {
             stack: new Error('Could not connect to indexedDB').stack,
             dismissable: true
           });

--- a/src/style-manager.js
+++ b/src/style-manager.js
@@ -7,7 +7,7 @@ const selectorParser = require('postcss-selector-parser');
 const { createStylesElement } = require('./styles-element');
 const DEPRECATED_SYNTAX_SELECTORS = require('./deprecated-syntax-selectors');
 
-// Extended: A singleton instance of this class available via `atom.styles`,
+// Extended: A singleton instance of this class available via `core.styles`,
 // which you can use to globally query and observe the set of active style
 // sheets. The `StyleManager` doesn't add any style elements to the DOM on its
 // own, but is instead subscribed to by individual `<atom-styles>` elements,

--- a/src/text-editor-component.js
+++ b/src/text-editor-component.js
@@ -1964,7 +1964,7 @@ module.exports = class TextEditorComponent {
       if (
         platform === 'linux' &&
         this.isInputEnabled() &&
-        atom.config.get('editor.selectionClipboard')
+        core.config.get('editor.selectionClipboard')
       )
         model.insertText(clipboard.readText('selection'));
       return;
@@ -1983,7 +1983,7 @@ module.exports = class TextEditorComponent {
       return;
     }
 
-    const allowMultiCursor = atom.config.get('editor.multiCursorOnClick');
+    const allowMultiCursor = core.config.get('editor.multiCursorOnClick');
     const addOrRemoveSelection =
       allowMultiCursor && (metaKey || (ctrlKey && platform !== 'darwin'));
 

--- a/src/text-editor-registry.js
+++ b/src/text-editor-registry.js
@@ -27,12 +27,12 @@ const EDITOR_PARAMS_BY_SETTING_KEY = [
 // Experimental: This global registry tracks registered `TextEditors`.
 //
 // If you want to add functionality to a wider set of text editors than just
-// those appearing within workspace panes, use `atom.textEditors.observe` to
+// those appearing within workspace panes, use `core.textEditors.observe` to
 // invoke a callback for all current and future registered text editors.
 //
 // If you want packages to be able to add functionality to your non-pane text
 // editors (such as a search field in a custom user interface element), register
-// them for observation via `atom.textEditors.add`. **Important:** When you're
+// them for observation via `core.textEditors.add`. **Important:** When you're
 // done using your editor, be sure to call `dispose` on the returned disposable
 // to avoid leaking editors.
 module.exports = class TextEditorRegistry {
@@ -201,7 +201,7 @@ module.exports = class TextEditorRegistry {
   // Returns a {Disposable} that can be used to stop updating the editor's
   // grammar.
   maintainGrammar(editor) {
-    atom.grammars.maintainLanguageMode(editor.getBuffer());
+    core.grammars.maintainLanguageMode(editor.getBuffer());
   }
 
   // Deprecated: Force a {TextEditor} to use a different grammar than the
@@ -210,7 +210,7 @@ module.exports = class TextEditorRegistry {
   // * `editor` The editor whose gramamr will be set.
   // * `languageId` The {String} language ID for the desired {Grammar}.
   setGrammarOverride(editor, languageId) {
-    atom.grammars.assignLanguageMode(editor.getBuffer(), languageId);
+    core.grammars.assignLanguageMode(editor.getBuffer(), languageId);
   }
 
   // Deprecated: Retrieve the grammar scope name that has been set as a
@@ -221,14 +221,14 @@ module.exports = class TextEditorRegistry {
   // Returns a {String} scope name, or `null` if no override has been set
   // for the given editor.
   getGrammarOverride(editor) {
-    return atom.grammars.getAssignedLanguageId(editor.getBuffer());
+    return core.grammars.getAssignedLanguageId(editor.getBuffer());
   }
 
   // Deprecated: Remove any grammar override that has been set for the given {TextEditor}.
   //
   // * `editor` The editor.
   clearGrammarOverride(editor) {
-    atom.grammars.autoAssignLanguageMode(editor.getBuffer());
+    core.grammars.autoAssignLanguageMode(editor.getBuffer());
   }
 
   async updateAndMonitorEditorSettings(editor, oldLanguageMode) {

--- a/src/text-editor.js
+++ b/src/text-editor.js
@@ -43,12 +43,12 @@ const DEFAULT_NON_WORD_CHARACTERS = '/\\()"\':,.;<>~!@#$%^&*|+=[]{}`?-…';
 // ## Accessing TextEditor Instances
 //
 // The easiest way to get hold of `TextEditor` objects is by registering a callback
-// with `::observeTextEditors` on the `atom.workspace` global. Your callback will
+// with `::observeTextEditors` on the `core.workspace` global. Your callback will
 // then be called with all current editor instances and also when any editor is
 // created in the future.
 //
 // ```js
-// atom.workspace.observeTextEditors(editor => {
+// core.workspace.observeTextEditors(editor => {
 //   editor.insertText('Hello World')
 // })
 // ```
@@ -221,11 +221,11 @@ module.exports = class TextEditor {
     } else {
       this.buffer = new TextBuffer({
         shouldDestroyOnFileDelete() {
-          return atom.config.get('core.closeDeletedFileTabs');
+          return core.config.get('core.closeDeletedFileTabs');
         }
       });
       this.buffer.setLanguageMode(
-        new TextMateLanguageMode({ buffer: this.buffer, config: atom.config })
+        new TextMateLanguageMode({ buffer: this.buffer, config: core.config })
       );
     }
 
@@ -1395,7 +1395,7 @@ module.exports = class TextEditor {
 
       let myPathSegments;
       const openEditorPathSegmentsWithSameFilename = [];
-      for (const textEditor of atom.workspace.getTextEditors()) {
+      for (const textEditor of core.workspace.getTextEditors()) {
         if (textEditor.getFileName() === fileName) {
           const pathSegments = fs
             .tildify(textEditor.getDirectoryPath())
@@ -1498,7 +1498,7 @@ module.exports = class TextEditor {
     if (
       windowCloseRequested &&
       projectHasPaths &&
-      atom.stateStore.isConnected()
+      core.stateStore.isConnected()
     ) {
       return this.buffer.isInConflict();
     } else {
@@ -2390,7 +2390,7 @@ module.exports = class TextEditor {
   // the editor is read-only, require an explicit opt-in option to proceed (`bypassReadOnly`) or throw an Error.
   ensureWritable(methodName, opts) {
     if (!opts.bypassReadOnly && this.isReadOnly()) {
-      if (atom.inDevMode() || atom.inSpecMode()) {
+      if (core.inDevMode() || core.inSpecMode()) {
         const e = new Error('Attempt to mutate a read-only TextEditor');
         e.detail =
           `Your package is attempting to call ${methodName} on an editor that has been marked read-only. ` +
@@ -4502,7 +4502,7 @@ module.exports = class TextEditor {
   setGrammar(grammar) {
     const buffer = this.getBuffer();
     buffer.setLanguageMode(
-      atom.grammars.languageModeForGrammarAndBuffer(grammar, buffer)
+      core.grammars.languageModeForGrammarAndBuffer(grammar, buffer)
     );
   }
 

--- a/src/theme-manager.js
+++ b/src/theme-manager.js
@@ -9,7 +9,7 @@ const LessCompileCache = require('./less-compile-cache');
 
 // Extended: Handles loading and activating available themes.
 //
-// An instance of this class is always available as the `atom.themes` global.
+// An instance of this class is always available as the `core.themes` global.
 module.exports = class ThemeManager {
   constructor({
     packageManager,

--- a/src/tooltip-manager.js
+++ b/src/tooltip-manager.js
@@ -4,7 +4,7 @@ let Tooltip = null;
 
 // Essential: Associates tooltips with HTML elements.
 //
-// You can get the `TooltipManager` via `atom.tooltips`.
+// You can get the `TooltipManager` via `core.tooltips`.
 //
 // ## Examples
 //
@@ -12,7 +12,7 @@ let Tooltip = null;
 //
 // ```js
 // // display it
-// const disposable = atom.tooltips.add(div, {title: 'This is a tooltip'})
+// const disposable = core.tooltips.add(div, {title: 'This is a tooltip'})
 //
 // // remove it
 // disposable.dispose()
@@ -27,8 +27,8 @@ let Tooltip = null;
 //
 // const div1 = document.createElement('div')
 // const div2 = document.createElement('div')
-// subscriptions.add(atom.tooltips.add(div1, {title: 'This is a tooltip'}))
-// subscriptions.add(atom.tooltips.add(div2, {title: 'Another tooltip'}))
+// subscriptions.add(core.tooltips.add(div1, {title: 'This is a tooltip'}))
+// subscriptions.add(core.tooltips.add(div2, {title: 'Another tooltip'}))
 //
 // // remove them all
 // subscriptions.dispose()
@@ -38,7 +38,7 @@ let Tooltip = null;
 // `keyBindingCommand` option.
 //
 // ```js
-// disposable = atom.tooltips.add(this.caseOptionButton, {
+// disposable = core.tooltips.add(this.caseOptionButton, {
 //   title: 'Match Case',
 //   keyBindingCommand: 'find-and-replace:toggle-case-option',
 //   keyBindingTarget: this.findEditor.element

--- a/src/view-registry.js
+++ b/src/view-registry.js
@@ -21,7 +21,7 @@ const AnyConstructor = Symbol('any-constructor');
 // makes [HTML 5 custom elements](http://www.html5rocks.com/en/tutorials/webcomponents/customelements/)
 // an ideal tool for implementing views in Pulsar.
 //
-// You can access the `ViewRegistry` object via `atom.views`.
+// You can access the `ViewRegistry` object via `core.views`.
 module.exports = class ViewRegistry {
   constructor(atomEnvironment) {
     this.animationFrameRequest = null;
@@ -43,12 +43,12 @@ module.exports = class ViewRegistry {
   // ## Examples
   //
   // Text editors are divided into a model and a view layer, so when you interact
-  // with methods like `atom.workspace.getActiveTextEditor()` you're only going
+  // with methods like `core.workspace.getActiveTextEditor()` you're only going
   // to get the model object. We display text editors on screen by teaching the
   // workspace what view constructor it should use to represent them:
   //
   // ```coffee
-  // atom.views.addViewProvider TextEditor, (textEditor) ->
+  // core.views.addViewProvider TextEditor, (textEditor) ->
   //   textEditorElement = new TextEditorElement
   //   textEditorElement.initialize(textEditor)
   //   textEditorElement
@@ -77,7 +77,7 @@ module.exports = class ViewRegistry {
           break;
         case 'object':
           Grim.deprecate(
-            'atom.views.addViewProvider now takes 2 arguments: a model constructor and a createView function. See docs for details.'
+            'core.views.addViewProvider now takes 2 arguments: a model constructor and a createView function. See docs for details.'
           );
           provider = modelConstructor;
           break;

--- a/src/workspace-element.js
+++ b/src/workspace-element.js
@@ -371,7 +371,7 @@ class WorkspaceElement extends HTMLElement {
     const paneView = pane.getElement();
     const box = this.boundingBoxForPaneView(paneView);
 
-    const paneViews = atom.workspace
+    const paneViews = core.workspace
       .getVisiblePanes()
       .map(otherPane => otherPane.getElement())
       .filter(otherPaneView => {

--- a/src/workspace.js
+++ b/src/workspace.js
@@ -21,7 +21,7 @@ const STOPPED_CHANGING_ACTIVE_PANE_ITEM_DELAY = 100;
 const ALL_LOCATIONS = ['center', 'left', 'right', 'bottom'];
 
 // Essential: Represents the state of the user interface for the entire window.
-// An instance of this class is available via the `atom.workspace` global.
+// An instance of this class is available via the `core.workspace` global.
 //
 // Interact with this object to open files, be notified of current and future
 // editors, and manipulate panes. To add panels, use {Workspace::addTopPanel}
@@ -260,7 +260,7 @@ module.exports = class Workspace extends Model {
 
   get paneContainer() {
     Grim.deprecate(
-      '`atom.workspace.paneContainer` has always been private, but it is now gone. Please use `atom.workspace.getCenter()` instead and consult the workspace API docs for public methods.'
+      '`core.workspace.paneContainer` has always been private, but it is now gone. Please use `core.workspace.getCenter()` instead and consult the workspace API docs for public methods.'
     );
     return this.paneContainers.center.paneContainer;
   }
@@ -679,7 +679,7 @@ module.exports = class Workspace extends Model {
   // open.
   updateWindowTitle() {
     let itemPath, itemTitle, projectPath, representedPath;
-    const appName = atom.getAppName();
+    const appName = core.getAppName();
     const left = this.project.getPaths();
     const projectPaths = left != null ? left : [];
     const item = this.getActivePaneItem();
@@ -1099,7 +1099,7 @@ module.exports = class Workspace extends Model {
     }
 
     try {
-      if (!atom.config.get('core.allowPendingPaneItems')) {
+      if (!core.config.get('core.allowPendingPaneItems')) {
         options.pending = false;
       }
 
@@ -1504,7 +1504,7 @@ module.exports = class Workspace extends Model {
   // ## Examples
   //
   // ```coffee
-  // atom.workspace.addOpener (uri) ->
+  // core.workspace.addOpener (uri) ->
   //   if path.extname(uri) is '.toml'
   //     return new TomlEditor(uri)
   // ```
@@ -1733,7 +1733,7 @@ module.exports = class Workspace extends Model {
     } else if (this.getCenter().getPanes().length > 1) {
       this.getCenter().destroyActivePane();
     } else if (this.config.get('core.closeEmptyWindows')) {
-      atom.close();
+      core.close();
     }
   }
 
@@ -1834,7 +1834,7 @@ module.exports = class Workspace extends Model {
 
   getVisiblePaneContainers() {
     const center = this.getCenter();
-    return atom.workspace
+    return core.workspace
       .getPaneContainers()
       .filter(container => container === center || container.isVisible());
   }


### PR DESCRIPTION
This renames the main global to `core`. The old `atom` global is still available. It worked for me without problems.
This is rather a suggestion for the future than a quick fix but I just wanted to show that it works.

To find the occurrences I used the search in files function with these options:
- match case
- use regex: `(?<![a-zA-Z]_"'/\-:)atom(?![a-zA-Z_"'/\-:]|\.io)`
- files pattern: `!node_modules,!ppm/lib,*.js,*.coffee`

There are multiple locations where both `core` and `atom` need to be defined:
- [src/initialize-application-window.js#L71](https://github.com/sertonix/pulsar/blob/core-global/src/initialize-application-window.js#L71)
- [src/initialize-benchmark-window.js#L82](https://github.com/sertonix/pulsar/blob/core-global/src/initialize-benchmark-window.js#L82) (Removed in master)
- [spec/main-process/atom-application.test.js#L799](https://github.com/sertonix/pulsar/blob/core-global/spec/main-process/atom-application.test.js#L799)
- [spec/jasmine-test-runner.js#L63](https://github.com/sertonix/pulsar/blob/core-global/spec/jasmine-test-runner.js#L63)

Error difference to the master branch:
- +3 failed tests in `test development helpers packages`
- error in `test editor related packages`