### PR TITLE
Update README badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,11 +43,11 @@
 
 <!---------------------------{ Files }--------------------------->
 
-[Documentation]: docs/Documentation.md 'Information how to use & work with Pulsar.'
-[Install]: docs/Installation.md 'How to install Pulsar on your system.'
-[Retired]: docs/Retirement.md 'Check out what happened to the original Atom project.'
+[Documentation]: https://pulsar-edit.dev/docs/ 'Information how to use & work with Pulsar.'
+[Install]: https://pulsar-edit.dev/docs/launch-manual/sections/getting-started/#installing-pulsar 'How to install Pulsar on your system.'
+[Retired]: https://github.blog/2022-06-08-sunsetting-atom/ 'Check out what happened to the original Atom project.'
 [License]: LICENSE.md
-[Build]: docs/Building.md 'Instructions on how to build Pulsar by yourself.'
+[Build]: https://pulsar-edit.dev/docs/launch-manual/sections/core-hacking/ 'Instructions on how to build Pulsar by yourself.'
 
 
 <!---------------------------{ Images }--------------------------->


### PR DESCRIPTION
To prevent confusion with the existing Atom Community documentation I have updated the badge urls to point to the pulsar-edit.dev site. Regardless of whether the site information is up-to-date, we still need to move away from the incorrect Atom Community information.

- Point `Documentation`, `Install`, and `Build` badges to pulsar-edit.dev
- Point `Retired` badge to the GitHub blog post

If we so desire, we can also get rid of the Atom Community MDs, however, I figured that might be better off on it's own PR - but I'm not opposed to including their removing in this PR.
