### PR TITLE
Add options for [skip-ci], [skip-editor-ci], and [skip-package-ci] on PR

### DIFF
--- a/.github/workflows/editor-tests.yml
+++ b/.github/workflows/editor-tests.yml
@@ -5,9 +5,9 @@ on:
 jobs:
   tests:
     name: tests
-    if:
-      ${{ !contains(github.event.head_commit.message, '[skip-ci]') }}
-      ${{ !contains(github.event.head_commit.message, '[skip-editor-ci]') }}
+    if: |
+      !startsWith(github.event.pull_request.title, '[skip-ci]') &&
+      !startsWith(github.event.pull_request.title, '[skip-editor-ci]')
     strategy:
       matrix:
         os: [ubuntu-20.04, macos-latest, windows-2019]

--- a/.github/workflows/editor-tests.yml
+++ b/.github/workflows/editor-tests.yml
@@ -5,7 +5,9 @@ on:
 jobs:
   tests:
     name: tests
-    if: ${{ !contains(github.event.head_commit.message, '[skip-ci]') }}
+    if:
+      ${{ !contains(github.event.head_commit.message, '[skip-ci]') }}
+      ${{ !contains(github.event.head_commit.message, '[skip-editor-ci]') }}
     strategy:
       matrix:
         os: [ubuntu-20.04, macos-latest, windows-2019]

--- a/.github/workflows/editor-tests.yml
+++ b/.github/workflows/editor-tests.yml
@@ -5,6 +5,7 @@ on:
 jobs:
   tests:
     name: tests
+    if: ${{ !contains(github.event.head_commit.message, '[skip-ci]') }}
     strategy:
       matrix:
         os: [ubuntu-20.04, macos-latest, windows-2019]

--- a/.github/workflows/package-tests-linux.yml
+++ b/.github/workflows/package-tests-linux.yml
@@ -6,7 +6,7 @@ env:
   APM_PATH: ./apm/node_modules/atom-package-manager/bin/apm
 jobs:
   setup:
-    name: setup
+    name: Build Editor
     if: |
       !startsWith(github.event.pull_request.title, '[skip-ci]') &&
       !startsWith(github.event.pull_request.title, '[skip-package-ci]')
@@ -50,9 +50,9 @@ jobs:
         key: linux-apm-${{ hashFiles('apm/package.json') }}
 
   test:
-    if:
-      ${{ !contains(github.event.head_commit.message, '[skip-ci]') }}
-      ${{ !contains(github.event.head_commit.message, '[skip-package-ci]') }}
+    name: Test packages
+    if: 
+      jobs.setup.result == 'success'
     strategy:
       matrix:
         include:

--- a/.github/workflows/package-tests-linux.yml
+++ b/.github/workflows/package-tests-linux.yml
@@ -7,9 +7,9 @@ env:
 jobs:
   setup:
     name: setup
-    if:
-      ${{ !contains(github.event.head_commit.message, '[skip-ci]') }}
-      ${{ !contains(github.event.head_commit.message, '[skip-package-ci]') }}
+    if: |
+      !startsWith(github.event.pull_request.title, '[skip-ci]') &&
+      !startsWith(github.event.pull_request.title, '[skip-package-ci]')
     runs-on: ubuntu-20.04
     steps:
     - name: Install windows-build-tools

--- a/.github/workflows/package-tests-linux.yml
+++ b/.github/workflows/package-tests-linux.yml
@@ -26,23 +26,23 @@ jobs:
       with:
         node-version: 16
 
-    - name: install dependencies
+    - name: Install Dependencies
       run: yarn install
 
-    - name: build dependencies
+    - name: Build Dependencies
       run: yarn build
 
     - name: build dependencies
       run: yarn build:apm
 
-    - name: cache node module
+    - name: Cache node_modules
       id: cache-node
       uses: actions/cache@v3
       with:
         path: node_modules
         key: linux-modules-${{ hashFiles('package.json') }}
 
-    - name: cache APM module
+    - name: Cache apm 
       id: cache-apm
       uses: actions/cache@v3
       with:
@@ -50,10 +50,11 @@ jobs:
         key: linux-apm-${{ hashFiles('apm/package.json') }}
 
   test:
-    name: Test packages
-    if: 
-      jobs.setup.result == 'success'
+    name: Test Packages
+    needs: setup
+    runs-on: ubuntu-20.04
     strategy:
+      fail-fast: false
       matrix:
         include:
           - filter: autocomplete|language
@@ -68,30 +69,26 @@ jobs:
             descr: UI elements
           - filter: image-view|bookmarks|keybinding-resolver|link|timecop
             descr: others
-      fail-fast: false
 
-    name: test ${{ matrix.descr }} packages
-    runs-on: ubuntu-20.04
-    needs: setup
     steps:
     - name: Checkout the latest code
       uses: actions/checkout@v2
 
-    - name: restore node module
+    - name: Restore node_modules from Cache
       id: restore-node
       uses: actions/cache@v3
       with:
         path: node_modules
         key: linux-modules-${{ hashFiles('package.json') }}
 
-    - name: cache APM module
+    - name: Restore apm from Cache
       id: restore-apm
       uses: actions/cache@v3
       with:
         path: apm
         key: linux-apm-${{ hashFiles('apm/package.json') }}
 
-    - name: Run ${{ matrix.descr }} packages' tests
+    - name: Run Package Tests for ${{ matrix.descr }}
       uses: GabrielBB/xvfb-action@v1
       with:
         run: node -e "require('./script/run-package-tests')(/${{ matrix.filter }}/)"

--- a/.github/workflows/package-tests-linux.yml
+++ b/.github/workflows/package-tests-linux.yml
@@ -7,6 +7,7 @@ env:
 jobs:
   setup:
     name: setup
+    if: ${{ !contains(github.event.head_commit.message, '[skip-ci]') }}
     runs-on: ubuntu-20.04
     steps:
     - name: Install windows-build-tools
@@ -47,6 +48,7 @@ jobs:
         key: linux-apm-${{ hashFiles('apm/package.json') }}
 
   test:
+    if: ${{ !contains(github.event.head_commit.message, '[skip-ci]') }}
     strategy:
       matrix:
         include:

--- a/.github/workflows/package-tests-linux.yml
+++ b/.github/workflows/package-tests-linux.yml
@@ -7,7 +7,9 @@ env:
 jobs:
   setup:
     name: setup
-    if: ${{ !contains(github.event.head_commit.message, '[skip-ci]') }}
+    if:
+      ${{ !contains(github.event.head_commit.message, '[skip-ci]') }}
+      ${{ !contains(github.event.head_commit.message, '[skip-package-ci]') }}
     runs-on: ubuntu-20.04
     steps:
     - name: Install windows-build-tools
@@ -48,7 +50,9 @@ jobs:
         key: linux-apm-${{ hashFiles('apm/package.json') }}
 
   test:
-    if: ${{ !contains(github.event.head_commit.message, '[skip-ci]') }}
+    if:
+      ${{ !contains(github.event.head_commit.message, '[skip-ci]') }}
+      ${{ !contains(github.event.head_commit.message, '[skip-package-ci]') }}
     strategy:
       matrix:
         include:


### PR DESCRIPTION
Allow skipping tests when not required, for example, when only making changes to MD files.

The conditions are only set up to skip during the `pull_request` event. What that means in practice, is that the workflows will still execute when you merge a PR, regardless of whether the title starts with one of the 3 options above
