### PR TITLE
provide global core as alias to the global atom

### DIFF
--- a/spec/jasmine-test-runner.js
+++ b/spec/jasmine-test-runner.js
@@ -60,7 +60,7 @@ module.exports = function({logFile, headless, testPaths, buildAtomEnvironment}) 
   const applicationDelegate = new ApplicationDelegate();
   applicationDelegate.setRepresentedFilename = function() {};
   applicationDelegate.setWindowDocumentEdited = function() {};
-  window.atom = buildAtomEnvironment({
+  window.core = window.atom = buildAtomEnvironment({
     applicationDelegate, window, document,
     configDirPath: atomHome,
     enablePersistence: false

--- a/spec/main-process/atom-application.test.js
+++ b/spec/main-process/atom-application.test.js
@@ -796,7 +796,7 @@ describe('AtomApplication', function() {
         app = scenario.getApplication(0);
         app.removeWindow(w);
         sinon.stub(app, 'promptForPathToOpen');
-        global.atom = { workspace: { getActiveTextEditor() {} } };
+        global.core = global.atom = { workspace: { getActiveTextEditor() {} } };
       });
 
       it('opens a new file', function() {

--- a/src/initialize-application-window.js
+++ b/src/initialize-application-window.js
@@ -68,7 +68,7 @@ const clipboard = new Clipboard();
 TextEditor.setClipboard(clipboard);
 TextEditor.viewForItem = item => atom.views.getView(item);
 
-global.atom = new AtomEnvironment({
+global.core = global.atom = new AtomEnvironment({
   clipboard,
   applicationDelegate: new ApplicationDelegate(),
   enablePersistence: true


### PR DESCRIPTION
This provides an alias to the global `atom` named `core`. It is intended to be a more generic name for the future of pulsar and potential forks. This is based of #104 and there you can find more information.