### PR TITLE
Remove benchmark mode, part two

### DIFF
--- a/spec/main-process/atom-application.test.js
+++ b/spec/main-process/atom-application.test.js
@@ -767,8 +767,9 @@ describe('AtomApplication', function() {
 
       await scenario.open(parseCommandLine(['a/1.md']));
 
-      // Test and benchmark StubWindows are visible as empty editor windows here
-      await scenario.assert('[_ _] [_ 1.md] [_ _] [_ _]');
+      // Test StubWindows are visible as empty editor windows here.
+      // (Benchmark mode has been removed, and will no-longer open new windows.)
+      await scenario.assert('[_ _] [_ 1.md] [_ _]');
     });
   });
 

--- a/src/main-process/atom-application.js
+++ b/src/main-process/atom-application.js
@@ -382,6 +382,10 @@ module.exports = class AtomApplication extends EventEmitter {
       // Printing a message saying benchmarks are removed will help avoid
       // confusion about the editor failing to launch in this mode.
       console.log("The benchmarking feature has been removed.");
+      if (this.getAllWindows().length === 0) {
+        console.log("Quitting.");
+        app.quit();
+      };
     } else if (
       (pathsToOpen && pathsToOpen.length > 0) ||
       (foldersToOpen && foldersToOpen.length > 0)

--- a/src/main-process/atom-application.js
+++ b/src/main-process/atom-application.js
@@ -305,7 +305,7 @@ module.exports = class AtomApplication extends EventEmitter {
     let optionsForWindowsToOpen = [];
     let shouldReopenPreviousWindows = false;
 
-    if (options.test) {
+    if (options.test || options.benchmark || options.benchmarkTest) {
       optionsForWindowsToOpen.push(options);
     } else if (options.newWindow) {
       shouldReopenPreviousWindows = false;

--- a/src/main-process/atom-application.js
+++ b/src/main-process/atom-application.js
@@ -172,6 +172,15 @@ module.exports = class AtomApplication extends EventEmitter {
       return createApplication(options);
     }
 
+    // We haven't returned yet, so another editor main process must be running.
+    if (options.benchmark || options.benchmarkTest) {
+      // We have to log this quite early -- here is the latest we can log this
+      // and have it show in the same terminal where the second instance of the
+      // editor is being launched. The Promise below hands things off
+      // to the existing, older editor main process that is already running.
+      console.log('The benchmarking feature has been removed.');
+    }
+
     return new Promise(resolve => {
       const client = net.connect({ path: socketPath }, () => {
         client.write(encryptOptions(options, socketSecret), () => {


### PR DESCRIPTION
Follow-up to PR https://github.com/pulsar-edit/pulsar/pull/105.

This resolves a mistake I made on that PR, where the `benchmark` (`--benchmark`) and `benchmarkTest` (`--benchmark-test`) launch options were _not_ passed anymore to the later parts of the startup process.

That prevented us doing checks, so as to print the relevant messages or decide based on the context whether to launch a new window or not.

- So first and foremost, this restores the passing of those options to later in the launch process. (Which I had accidentally deleted in https://github.com/pulsar-edit/pulsar/pull/105).
- Also fixes a spec I wasn't sure about at the time of https://github.com/pulsar-edit/pulsar/pull/105 being merged.
- And ensures we log a message about benchmark mode removal _on the second terminal_ if a second instance of the editor is launched with `--benchmark` or `--benchmark-test` mode. (Without this, it could be confusing why no new window was launched.)

cc @confused-Techie since you were the one who started https://github.com/pulsar-edit/pulsar/pull/105, and the one most likely to know what this is about. Thank you for starting the work on this!