### PR TITLE
Fix a spec to expect the app title to start with "Pulsar", not "Atom"

### DIFF
--- a/spec/main-process/atom-window.test.js
+++ b/spec/main-process/atom-window.test.js
@@ -96,7 +96,7 @@ describe('AtomWindow', function() {
       const { browserWindow } = w;
 
       assert.isFalse(browserWindow.isVisible());
-      assert.isTrue(browserWindow.getTitle().startsWith('Atom'));
+      assert.isTrue(browserWindow.getTitle().startsWith('Pulsar'));
 
       const settings = JSON.parse(browserWindow.loadSettingsJSON);
       assert.strictEqual(settings.userSettings, 'stub-config');


### PR DESCRIPTION
Fixes a single spec, by expecting the app title to start with "Pulsar", not "Atom".

With this and the other spec fix from https://github.com/pulsar-edit/pulsar/pull/115, I was able to get the core main process tests passing locally.

_(Note/caveats: My environment was rather non-standard at the time... I had downgraded to Electron 10.4.7 in order to work around an Electron GPU process issue that, as I understand it, happens on newer Linux kernels with Electron <=12. (The issue may have been exacerbated by my old computer with extremely basic integrated graphics.) I had built with a hacked-on `script/build` and run the tests with `script/test`... all that is to say, your mileage may vary as to how exactly to get the tests to run at the moment? Independent testing is welcome to confirm this and https://github.com/pulsar-edit/pulsar/pull/115 cause all the core main process tests to pass elsewhere besides just on my machine.)_