### PR TITLE
Update help links

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "id": "pulsar",
     "name": "Pulsar",
     "urlWeb": "https://pulsar-edit.dev/",
-    "urlGH": "https://github.com/pulsar-edit"
+    "urlGH": "https://github.com/pulsar-edit",
+    "urlForum": "https://github.com/orgs/pulsar-edit/discussions"
   },
   "main": "./src/main-process/main.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "branding": {
     "id": "pulsar",
     "name": "Pulsar",
-    "urlWeb": "https://atom.io/",
+    "urlWeb": "https://pulsar-edit.dev/",
     "urlGH": "https://github.com/pulsar-edit"
   },
   "main": "./src/main-process/main.js",

--- a/packages/welcome/lib/welcome-view.js
+++ b/packages/welcome/lib/welcome-view.js
@@ -99,9 +99,8 @@ export default class WelcomeView {
             <ul>
               <li>
                 The{' '}
-                {/* // TODO_PULSAR: Update to our docs or test {atom.branding.urlWeb}+"/docs" */}
                 <a
-                  href="https://www.atom.io/docs"
+                  href="https://pulsar-edit.dev/docs/"
                   dataset={{ event: 'atom-docs' }}
                 >
                   {this.brand} docs
@@ -111,7 +110,7 @@ export default class WelcomeView {
               <li>
                 The {this.brand} forum at{' '}
                 <a
-                  href="https://github.com/pulsar-edit/pulsar/discussions"
+                  href="https://github.com/orgs/pulsar-edit/discussions"
                   dataset={{ event: 'discussions' }}
                 >
                   Github Discussions
@@ -144,12 +143,12 @@ export default class WelcomeView {
 
           <footer className="welcome-footer">
             <a href={atom.branding.urlWeb} dataset={{ event: 'footer-atom-io' }}>
-              atom.io
+              pulsar-edit.dev
             </a>{' '}
             <span className="text-subtle">×</span>{' '}
             <a
-              className="icon icon-octoface"
-              href="https://github.com/"
+              className="icon icon-heart"
+              href="https://pulsar-edit.dev/community.html"
               dataset={{ event: 'footer-octocat' }}
             />
           </footer>

--- a/packages/welcome/lib/welcome-view.js
+++ b/packages/welcome/lib/welcome-view.js
@@ -110,7 +110,7 @@ export default class WelcomeView {
               <li>
                 The {this.brand} forum at{' '}
                 <a
-                  href="https://github.com/orgs/pulsar-edit/discussions"
+                  href={atom.branding.urlForum}
                   dataset={{ event: 'discussions' }}
                 >
                   Github Discussions

--- a/packages/welcome/lib/welcome-view.js
+++ b/packages/welcome/lib/welcome-view.js
@@ -100,7 +100,7 @@ export default class WelcomeView {
               <li>
                 The{' '}
                 <a
-                  href={atom.branding.urlWeb + "\docs"}
+                  href={atom.branding.urlWeb + "docs"}
                   dataset={{ event: 'atom-docs' }}
                 >
                   {this.brand} docs
@@ -148,7 +148,7 @@ export default class WelcomeView {
             <span className="text-subtle">×</span>{' '}
             <a
               className="icon icon-heart"
-              href={atom.branding.urlWeb + "\community"}
+              href={atom.branding.urlWeb + "community"}
               dataset={{ event: 'footer-octocat' }}
             />
           </footer>

--- a/packages/welcome/lib/welcome-view.js
+++ b/packages/welcome/lib/welcome-view.js
@@ -124,7 +124,7 @@ export default class WelcomeView {
                 >
                   {this.brand} org
                 </a>
-                . This is where all GitHub-created {this.brand} packages can be found.
+                . This is where all {this.brand} org packages can be found.
               </li>
             </ul>
           </section>

--- a/packages/welcome/lib/welcome-view.js
+++ b/packages/welcome/lib/welcome-view.js
@@ -100,7 +100,7 @@ export default class WelcomeView {
               <li>
                 The{' '}
                 <a
-                  href="https://pulsar-edit.dev/docs/"
+                  href={atom.branding.urlWeb + "\docs"}
                   dataset={{ event: 'atom-docs' }}
                 >
                   {this.brand} docs
@@ -148,7 +148,7 @@ export default class WelcomeView {
             <span className="text-subtle">×</span>{' '}
             <a
               className="icon icon-heart"
-              href="https://pulsar-edit.dev/community.html"
+              href={atom.branding.urlWeb + "\community"}
               dataset={{ event: 'footer-octocat' }}
             />
           </footer>

--- a/src/atom-environment.js
+++ b/src/atom-environment.js
@@ -225,7 +225,8 @@ class AtomEnvironment {
       id: packagejson.branding.id,
       name: packagejson.branding.name,
       urlWeb: packagejson.branding.urlWeb,
-      urlGH: packagejson.branding.urlGH
+      urlGH: packagejson.branding.urlGH,
+      urlForum: packagejson.branding.urlForum
     };
 
     // Keep instances of HistoryManager in sync

--- a/src/main-process/atom-application.js
+++ b/src/main-process/atom-application.js
@@ -590,24 +590,24 @@ module.exports = class AtomApplication extends EventEmitter {
     });
 
     this.on('application:open-documentation', () =>
-      shell.openExternal('http://flight-manual.atom.io')
+      shell.openExternal('https://pulsar-edit.dev/docs/')
     );
     this.on('application:open-discussions', () =>
-      shell.openExternal('https://github.com/atom/atom/discussions')
+      shell.openExternal('https://github.com/orgs/pulsar-edit/discussions')
     );
     this.on('application:open-faq', () =>
-      shell.openExternal('https://atom.io/faq')
+      shell.openExternal('https://pulsar-edit.dev/docs/launch-manual/sections/faq/')
     );
     this.on('application:open-terms-of-use', () =>
       shell.openExternal('https://atom.io/terms')
     );
     this.on('application:report-issue', () =>
       shell.openExternal(
-        'https://github.com/atom/atom/blob/master/CONTRIBUTING.md#reporting-bugs'
+        'https://github.com/pulsar-edit/pulsar/issues/new/choose'
       )
     );
     this.on('application:search-issues', () =>
-      shell.openExternal('https://github.com/search?q=+is%3Aissue+user%3Aatom')
+      shell.openExternal('https://github.com/pulsar-edit/pulsar/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc')
     );
 
     this.on('application:install-update', () => {


### PR DESCRIPTION
Various links in `Help` lead to Atom areas.
This updates them to various areas of the website, GitHub discussions + issues etc.

Also update links on the welcome package to the new website etc.
Changed the `atom.io` link and its associated brand url in the package.json.

Removed the octocat and added a heart logo because, why not... (If anyone reviewing this thinks of a better one then you can pick from any of the style guide octicons) - or we can remove the `x ...` entirely. Heart logo links to the website "community areas".

Also reworded one section to get rid of the github association.

Added new branding value for "forum" -> `urlForum`.