### PR TITLE
unmerge menus ignore seperators

### DIFF
--- a/src/menu-helpers.js
+++ b/src/menu-helpers.js
@@ -49,7 +49,7 @@ function unmerge(menu, item) {
     }
   }
 
-  if (matchingItem.submenu == null || matchingItem.submenu.length === 0) {
+  if (matchingItem.submenu == null || matchingItem.submenu.filter( ({type}) => type !== 'separator' ).length === 0) {
     menu.splice(matchingItemIndex, 1);
   }
 }


### PR DESCRIPTION
When menus are removed with the unmerge function menus with only seperators as submenus are now also removed.