### PR TITLE
fix codacy exclude paths [skip-editor-ci]

### DIFF
--- a/.codacy.yaml
+++ b/.codacy.yaml
@@ -3,8 +3,8 @@ engines:
   duplication:
     minTokenMatch: 80
 exclude_paths:
-  - "./specs/fixtures"
-  - "./packages/*/spec/fixtures/*"
+  - "./spec/fixtures"
+  - "./packages/*/spec/fixtures"
 
 # Since Codacy exposes significantly little on the config.
 # We can use the rest of this document to solidify our settings.

--- a/.codacy.yaml
+++ b/.codacy.yaml
@@ -3,8 +3,8 @@ engines:
   duplication:
     minTokenMatch: 80
 exclude_paths:
-  - "./spec/fixtures"
-  - "./packages/*/spec/fixtures"
+  - "./spec/fixtures/**"
+  - "./packages/*/spec/fixtures/**"
 
 # Since Codacy exposes significantly little on the config.
 # We can use the rest of this document to solidify our settings.


### PR DESCRIPTION
doesn't look like `specs` exists so changing to `spec`

I'm excluding the whole `fixtures` folders including subdirectories so that's why I removed `/*`
