### PR TITLE
cleanup `packages/*/package.json`

### DIFF
--- a/packages/about/package.json
+++ b/packages/about/package.json
@@ -4,7 +4,6 @@
   "main": "./lib/main",
   "version": "1.9.1",
   "description": "View useful information about your Pulsar installation.",
-  "keywords": [],
   "repository": "https://github.com/pulsar-edit/pulsar",
   "license": "MIT",
   "scripts": {

--- a/packages/dalek/package.json
+++ b/packages/dalek/package.json
@@ -3,7 +3,6 @@
   "main": "./lib/main",
   "version": "0.2.2",
   "description": "EXTERMINATEs built-in packages installed in ~/.pulsar/packages",
-  "keywords": [],
   "repository": "https://github.com/pulsar-edit/pulsar",
   "license": "MIT",
   "atomTestRunner": "./test/runner",

--- a/packages/language-c/package.json
+++ b/packages/language-c/package.json
@@ -6,15 +6,8 @@
     "tree-sitter"
   ],
   "main": "lib/main",
-  "homepage": "https://atom.github.io/language-c",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/atom/language-c.git"
-  },
+  "repository": "https://github.com/pulsar-edit/pulsar",
   "license": "MIT",
-  "bugs": {
-    "url": "https://github.com/atom/language-c/issues"
-  },
   "engines": {
     "atom": "*",
     "node": "*"

--- a/packages/language-clojure/package.json
+++ b/packages/language-clojure/package.json
@@ -6,15 +6,8 @@
     "atom": "*",
     "node": "*"
   },
-  "homepage": "http://atom.github.io/language-clojure",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/atom/language-clojure"
-  },
+  "repository": "https://github.com/pulsar-edit/pulsar",
   "license": "MIT",
-  "bugs": {
-    "url": "https://github.com/atom/language-clojure/issues"
-  },
   "devDependencies": {
     "coffeelint": "^1.10.1"
   }

--- a/packages/language-coffee-script/package.json
+++ b/packages/language-coffee-script/package.json
@@ -7,14 +7,7 @@
     "atom": "*",
     "node": "*"
   },
-  "homepage": "http://atom.github.io/language-coffee-script",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/atom/language-coffee-script.git"
-  },
-  "bugs": {
-    "url": "https://github.com/atom/language-coffee-script/issues"
-  },
+  "repository": "https://github.com/pulsar-edit/pulsar",
   "devDependencies": {
     "coffeelint": "^1.10.1"
   }

--- a/packages/language-csharp/package.json
+++ b/packages/language-csharp/package.json
@@ -3,7 +3,7 @@
   "version": "1.1.0",
   "private": true,
   "description": "C# language support for Atom",
-  "repository": "https://github.com/atom/language-csharp",
+  "repository": "https://github.com/pulsar-edit/pulsar",
   "keywords": [
     "C#",
     "csharp",
@@ -12,6 +12,5 @@
   "license": "MIT",
   "engines": {
     "atom": ">0.50.0"
-  },
-  "dependencies": {}
+  }
 }

--- a/packages/language-css/package.json
+++ b/packages/language-css/package.json
@@ -9,15 +9,8 @@
     "atom": "*",
     "node": "*"
   },
-  "homepage": "http://atom.github.io/language-css",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/atom/language-css.git"
-  },
+  "repository": "https://github.com/pulsar-edit/pulsar",
   "license": "MIT",
-  "bugs": {
-    "url": "https://github.com/atom/language-css/issues"
-  },
   "devDependencies": {
     "coffeelint": "^1.10.1"
   },

--- a/packages/language-gfm/package.json
+++ b/packages/language-gfm/package.json
@@ -2,7 +2,7 @@
   "name": "language-gfm",
   "version": "0.90.8",
   "description": "Syntax highlighting and snippets for GitHub Flavored Markdown (GFM).",
-  "repository": "https://github.com/atom/language-gfm",
+  "repository": "https://github.com/pulsar-edit/pulsar",
   "license": "MIT",
   "engines": {
     "atom": "*"

--- a/packages/language-git/package.json
+++ b/packages/language-git/package.json
@@ -6,15 +6,8 @@
     "atom": "*",
     "node": "*"
   },
-  "homepage": "http://atom.github.io/language-git",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/atom/language-git.git"
-  },
+  "repository": "https://github.com/pulsar-edit/pulsar",
   "license": "MIT",
-  "bugs": {
-    "url": "https://github.com/atom/language-git/issues"
-  },
   "devDependencies": {
     "coffeelint": "^1.10.1"
   }

--- a/packages/language-go/package.json
+++ b/packages/language-go/package.json
@@ -10,14 +10,7 @@
     "atom": "*",
     "node": "*"
   },
-  "homepage": "http://atom.github.io/language-go",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/atom/language-go.git"
-  },
-  "bugs": {
-    "url": "https://github.com/atom/language-go/issues"
-  },
+  "repository": "https://github.com/pulsar-edit/pulsar",
   "dependencies": {
     "tree-sitter-go": "0.19.1"
   },

--- a/packages/language-html/package.json
+++ b/packages/language-html/package.json
@@ -10,15 +10,8 @@
     "atom": "*",
     "node": "*"
   },
-  "homepage": "http://atom.github.io/language-html",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/atom/language-html.git"
-  },
+  "repository": "https://github.com/pulsar-edit/pulsar",
   "license": "MIT",
-  "bugs": {
-    "url": "https://github.com/atom/language-html/issues"
-  },
   "dependencies": {
     "atom-grammar-test": "^0.6.3",
     "tree-sitter-embedded-template": "0.19.0",

--- a/packages/language-hyperlink/package.json
+++ b/packages/language-hyperlink/package.json
@@ -6,15 +6,8 @@
     "atom": "*",
     "node": "*"
   },
-  "homepage": "http://atom.github.io/language-hyperlink",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/atom/language-hyperlink.git"
-  },
+  "repository": "https://github.com/pulsar-edit/pulsar",
   "license": "MIT",
-  "bugs": {
-    "url": "https://github.com/atom/language-hyperlink/issues"
-  },
   "devDependencies": {
     "coffeelint": "^1.10.1"
   }

--- a/packages/language-java/package.json
+++ b/packages/language-java/package.json
@@ -6,15 +6,8 @@
     "atom": "*",
     "node": "*"
   },
-  "homepage": "http://atom.github.io/language-java",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/atom/language-java.git"
-  },
+  "repository": "https://github.com/pulsar-edit/pulsar",
   "license": "MIT",
-  "bugs": {
-    "url": "https://github.com/atom/language-java/issues"
-  },
   "dependencies": {
     "tree-sitter-java": "0.19.1"
   },

--- a/packages/language-javascript/package.json
+++ b/packages/language-javascript/package.json
@@ -7,15 +7,8 @@
     "node": "*"
   },
   "main": "lib/main",
-  "homepage": "http://atom.github.io/language-javascript",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/atom/language-javascript.git"
-  },
+  "repository": "https://github.com/pulsar-edit/pulsar",
   "license": "MIT",
-  "bugs": {
-    "url": "https://github.com/atom/language-javascript/issues"
-  },
   "keywords": [
     "tree-sitter"
   ],

--- a/packages/language-json/package.json
+++ b/packages/language-json/package.json
@@ -6,15 +6,8 @@
     "atom": "*",
     "node": "*"
   },
-  "homepage": "http://atom.github.io/language-json",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/atom/language-json.git"
-  },
+  "repository": "https://github.com/pulsar-edit/pulsar",
   "license": "MIT",
-  "bugs": {
-    "url": "https://github.com/atom/language-json/issues"
-  },
   "devDependencies": {
     "coffeelint": "^1.10.1"
   },

--- a/packages/language-less/package.json
+++ b/packages/language-less/package.json
@@ -7,14 +7,7 @@
     "atom": "*",
     "node": "*"
   },
-  "homepage": "http://atom.github.io/language-less",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/atom/language-less.git"
-  },
-  "bugs": {
-    "url": "https://github.com/atom/language-less/issues"
-  },
+  "repository": "https://github.com/pulsar-edit/pulsar",
   "devDependencies": {
     "bluebird": "^2.9.25",
     "coffeelint": "^1.10.1",

--- a/packages/language-make/package.json
+++ b/packages/language-make/package.json
@@ -6,15 +6,8 @@
     "atom": "*",
     "node": "*"
   },
-  "homepage": "http://atom.github.io/language-make",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/atom/language-make.git"
-  },
+  "repository": "https://github.com/pulsar-edit/pulsar",
   "license": "MIT",
-  "bugs": {
-    "url": "https://github.com/atom/language-make/issues"
-  },
   "devDependencies": {
     "coffeelint": "^1.10.1"
   }

--- a/packages/language-mustache/package.json
+++ b/packages/language-mustache/package.json
@@ -7,14 +7,7 @@
     "atom": "*",
     "node": "*"
   },
-  "homepage": "http://atom.github.io/language-mustache",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/atom/language-mustache.git"
-  },
-  "bugs": {
-    "url": "https://github.com/atom/language-mustache/issues"
-  },
+  "repository": "https://github.com/pulsar-edit/pulsar",
   "devDependencies": {
     "coffeelint": "^1.10.1"
   }

--- a/packages/language-objective-c/package.json
+++ b/packages/language-objective-c/package.json
@@ -6,15 +6,8 @@
     "atom": "*",
     "node": "*"
   },
-  "homepage": "http://atom.github.io/language-objective-c",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/atom/language-objective-c.git"
-  },
+  "repository": "https://github.com/pulsar-edit/pulsar",
   "license": "MIT",
-  "bugs": {
-    "url": "https://github.com/atom/language-objective-c/issues"
-  },
   "devDependencies": {
     "coffeelint": "^1.10.1"
   }

--- a/packages/language-perl/package.json
+++ b/packages/language-perl/package.json
@@ -6,15 +6,8 @@
     "atom": "*",
     "node": "*"
   },
-  "homepage": "http://atom.github.io/language-perl",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/atom/language-perl.git"
-  },
+  "repository": "https://github.com/pulsar-edit/pulsar",
   "license": "MIT",
-  "bugs": {
-    "url": "https://github.com/atom/language-perl/issues"
-  },
   "devDependencies": {
     "coffeelint": "^1.10.1"
   }

--- a/packages/language-php/package.json
+++ b/packages/language-php/package.json
@@ -6,15 +6,8 @@
     "atom": "*",
     "node": "*"
   },
-  "homepage": "http://atom.github.io/language-php",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/atom/language-php.git"
-  },
+  "repository": "https://github.com/pulsar-edit/pulsar",
   "license": "MIT",
-  "bugs": {
-    "url": "https://github.com/atom/language-php/issues"
-  },
   "devDependencies": {
     "coffeelint": "^1.10.1"
   }

--- a/packages/language-property-list/package.json
+++ b/packages/language-property-list/package.json
@@ -6,15 +6,8 @@
     "atom": "*",
     "node": "*"
   },
-  "homepage": "http://atom.github.io/language-property-list",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/atom/language-property-list.git"
-  },
+  "repository": "https://github.com/pulsar-edit/pulsar",
   "license": "MIT",
-  "bugs": {
-    "url": "https://github.com/atom/language-property-list/issues"
-  },
   "devDependencies": {
     "coffeelint": "^1.10.1"
   }

--- a/packages/language-python/package.json
+++ b/packages/language-python/package.json
@@ -9,15 +9,8 @@
   "keywords": [
     "tree-sitter"
   ],
-  "homepage": "https://atom.github.io/language-python",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/atom/language-python.git"
-  },
+  "repository": "https://github.com/pulsar-edit/pulsar",
   "license": "MIT",
-  "bugs": {
-    "url": "https://github.com/atom/language-python/issues"
-  },
   "dependencies": {
     "atom-grammar-test": "^0.6.4",
     "tree-sitter-python": "0.19.0"

--- a/packages/language-ruby-on-rails/package.json
+++ b/packages/language-ruby-on-rails/package.json
@@ -7,14 +7,7 @@
     "atom": "*",
     "node": "*"
   },
-  "homepage": "http://atom.github.io/language-ruby-on-rails",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/atom/language-ruby-on-rails.git"
-  },
-  "bugs": {
-    "url": "https://github.com/atom/language-ruby-on-rails/issues"
-  },
+  "repository": "https://github.com/pulsar-edit/pulsar",
   "devDependencies": {
     "coffeelint": "^1.10.1"
   }

--- a/packages/language-ruby/package.json
+++ b/packages/language-ruby/package.json
@@ -11,7 +11,7 @@
   },
   "main": "lib/main",
   "license": "MIT",
-  "repository": "https://github.com/atom/language-ruby",
+  "repository": "https://github.com/pulsar-edit/pulsar",
   "dependencies": {
     "tree-sitter-ruby": "^0.19.0"
   },

--- a/packages/language-sass/package.json
+++ b/packages/language-sass/package.json
@@ -7,14 +7,7 @@
     "atom": "*",
     "node": "*"
   },
-  "homepage": "http://atom.github.io/language-sass",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/atom/language-sass.git"
-  },
-  "bugs": {
-    "url": "https://github.com/atom/language-sass/issues"
-  },
+  "repository": "https://github.com/pulsar-edit/pulsar",
   "devDependencies": {
     "coffeelint": "^1.10.1",
     "dedent": "^0.7.0"

--- a/packages/language-shellscript/package.json
+++ b/packages/language-shellscript/package.json
@@ -9,15 +9,8 @@
     "atom": "*",
     "node": "*"
   },
-  "homepage": "http://atom.github.io/language-shellscript",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/atom/language-shellscript.git"
-  },
+  "repository": "https://github.com/pulsar-edit/pulsar",
   "license": "MIT",
-  "bugs": {
-    "url": "https://github.com/atom/language-shellscript/issues"
-  },
   "dependencies": {
     "tree-sitter-bash": "0.19.0"
   },

--- a/packages/language-source/package.json
+++ b/packages/language-source/package.json
@@ -6,15 +6,8 @@
     "node": "*"
   },
   "description": "Source code support in Atom",
-  "homepage": "http://atom.github.io/language-source",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/atom/language-source.git"
-  },
+  "repository": "https://github.com/pulsar-edit/pulsar",
   "license": "MIT",
-  "bugs": {
-    "url": "https://github.com/atom/language-source/issues"
-  },
   "devDependencies": {
     "coffeelint": "^1.10.1"
   }

--- a/packages/language-sql/package.json
+++ b/packages/language-sql/package.json
@@ -6,15 +6,8 @@
     "atom": "*",
     "node": "*"
   },
-  "homepage": "http://atom.github.io/language-sql",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/atom/language-sql.git"
-  },
+  "repository": "https://github.com/pulsar-edit/pulsar",
   "license": "MIT",
-  "bugs": {
-    "url": "https://github.com/atom/language-sql/issues"
-  },
   "devDependencies": {
     "coffeelint": "^1.10.1"
   }

--- a/packages/language-text/package.json
+++ b/packages/language-text/package.json
@@ -6,15 +6,8 @@
     "atom": "*",
     "node": "*"
   },
-  "homepage": "http://atom.github.io/language-text",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/atom/language-text.git"
-  },
+  "repository": "https://github.com/pulsar-edit/pulsar",
   "license": "MIT",
-  "bugs": {
-    "url": "https://github.com/atom/language-text/issues"
-  },
   "devDependencies": {
     "coffeelint": "^1.10.1"
   }

--- a/packages/language-todo/package.json
+++ b/packages/language-todo/package.json
@@ -6,15 +6,8 @@
     "atom": "*",
     "node": "*"
   },
-  "homepage": "http://atom.github.io/language-todo",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/atom/language-todo.git"
-  },
+  "repository": "https://github.com/pulsar-edit/pulsar",
   "license": "MIT",
-  "bugs": {
-    "url": "https://github.com/atom/language-todo/issues"
-  },
   "devDependencies": {
     "coffeelint": "^1.10.1"
   }

--- a/packages/language-toml/package.json
+++ b/packages/language-toml/package.json
@@ -2,7 +2,7 @@
   "name": "language-toml",
   "version": "0.20.0",
   "description": "Syntax highlighting for Tom's Obvious, Minimal Language (TOML).",
-  "repository": "https://github.com/atom/language-toml",
+  "repository": "https://github.com/pulsar-edit/pulsar",
   "license": "MIT",
   "engines": {
     "atom": "*"

--- a/packages/language-typescript/package.json
+++ b/packages/language-typescript/package.json
@@ -10,15 +10,8 @@
     "node": "*"
   },
   "main": "lib/main",
-  "homepage": "https://atom.io/packages/language-typescript",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/atom/language-typescript.git"
-  },
+  "repository": "https://github.com/pulsar-edit/pulsar",
   "license": "MIT",
-  "bugs": {
-    "url": "https://github.com/atom/language-typescript/issues"
-  },
   "dependencies": {
     "tree-sitter-typescript": "0.20.1"
   }

--- a/packages/language-xml/package.json
+++ b/packages/language-xml/package.json
@@ -6,15 +6,8 @@
     "atom": "*",
     "node": "*"
   },
-  "homepage": "http://atom.github.io/language-xml",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/atom/language-xml.git"
-  },
+  "repository": "https://github.com/pulsar-edit/pulsar",
   "license": "MIT",
-  "bugs": {
-    "url": "https://github.com/atom/language-xml/issues"
-  },
   "devDependencies": {
     "coffeelint": "^1.10.1"
   }

--- a/packages/language-yaml/package.json
+++ b/packages/language-yaml/package.json
@@ -6,15 +6,8 @@
     "atom": "*",
     "node": "*"
   },
-  "homepage": "http://atom.github.io/language-yaml",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/atom/language-yaml.git"
-  },
+  "repository": "https://github.com/pulsar-edit/pulsar",
   "license": "MIT",
-  "bugs": {
-    "url": "https://github.com/atom/language-yaml/issues"
-  },
   "devDependencies": {
     "coffeelint": "^1.10.1"
   }


### PR DESCRIPTION
This changes the repository url of the packages to `https://github.com/pulsar-edit/pulsar` in a more compact way and also removes some useless json parts.