### PR TITLE
remove `standard` linter from packages

### DIFF
--- a/packages/about/package.json
+++ b/packages/about/package.json
@@ -7,18 +7,12 @@
   "keywords": [],
   "repository": "https://github.com/pulsar-edit/pulsar",
   "license": "MIT",
-  "scripts": {
-    "lint": "standard"
-  },
   "engines": {
     "atom": ">=1.7 <2.0.0"
   },
   "dependencies": {
     "etch": "0.9.0",
     "semver": "^5.5.0"
-  },
-  "devDependencies": {
-    "standard": "^11.0.0"
   },
   "consumedServices": {
     "status-bar": {
@@ -29,16 +23,5 @@
   },
   "deserializers": {
     "AboutView": "deserializeAboutView"
-  },
-  "standard": {
-    "env": [
-      "browser",
-      "node",
-      "atomtest",
-      "jasmine"
-    ],
-    "globals": [
-      "atom"
-    ]
   }
 }

--- a/packages/dalek/package.json
+++ b/packages/dalek/package.json
@@ -15,15 +15,6 @@
   },
   "devDependencies": {
     "atom-mocha-test-runner": "^1.0.0",
-    "sinon": "9.0.3",
-    "standard": "^8.6.0"
-  },
-  "standard": {
-    "env": {
-      "jasmine": true
-    },
-    "globals": [
-      "atom"
-    ]
+    "sinon": "9.0.3"
   }
 }

--- a/packages/dev-live-reload/package.json
+++ b/packages/dev-live-reload/package.json
@@ -10,19 +10,5 @@
   },
   "engines": {
     "atom": "*"
-  },
-  "devDependencies": {
-    "standard": "^10.0.3"
-  },
-  "standard": {
-    "env": {
-      "atomtest": true,
-      "browser": true,
-      "jasmine": true,
-      "node": true
-    },
-    "globals": [
-      "atom"
-    ]
   }
 }

--- a/packages/go-to-line/package.json
+++ b/packages/go-to-line/package.json
@@ -4,9 +4,6 @@
   "main": "./lib/go-to-line-view",
   "description": "Jump to a specific editor line number with `ctrl-g`.",
   "license": "MIT",
-  "scripts": {
-    "lint": "standard"
-  },
   "activationCommands": {
     "atom-text-editor": [
       "go-to-line:toggle"
@@ -15,17 +12,5 @@
   "repository": "https://github.com/pulsar-edit/pulsar",
   "engines": {
     "atom": "*"
-  },
-  "devDependencies": {
-    "standard": "^8.6.0"
-  },
-  "standard": {
-    "globals": [
-      "atom",
-      "waitsForPromise"
-    ],
-    "ignore": [
-      "spec/fixtures"
-    ]
   }
 }

--- a/packages/grammar-selector/package.json
+++ b/packages/grammar-selector/package.json
@@ -18,20 +18,6 @@
       }
     }
   },
-  "devDependencies": {
-    "standard": "^10.0.3"
-  },
-  "standard": {
-    "globals": [
-      "atom",
-      "beforeEach",
-      "describe",
-      "expect",
-      "it",
-      "jasmine",
-      "spyOn"
-    ]
-  },
   "configSchema": {
     "showOnRightSideOfStatusBar": {
       "type": "boolean",

--- a/packages/line-ending-selector/package.json
+++ b/packages/line-ending-selector/package.json
@@ -19,9 +19,6 @@
       }
     }
   },
-  "devDependencies": {
-    "standard": "^5.1.0"
-  },
   "configSchema": {
     "defaultLineEnding": {
       "title": "Default line ending",
@@ -34,22 +31,5 @@
         "CRLF"
       ]
     }
-  },
-  "standard": {
-    "globals": [
-      "advanceClock",
-      "atom",
-      "beforeEach",
-      "expect",
-      "describe",
-      "it",
-      "jasmine",
-      "MouseEvent",
-      "runs",
-      "spyOn",
-      "waits",
-      "waitsFor",
-      "waitsForPromise"
-    ]
   }
 }

--- a/packages/link/package.json
+++ b/packages/link/package.json
@@ -15,19 +15,5 @@
   },
   "dependencies": {
     "underscore-plus": "^1.7.0"
-  },
-  "devDependencies": {
-    "standard": "^10.0.3"
-  },
-  "standard": {
-    "env": {
-      "atomtest": true,
-      "browser": true,
-      "jasmine": true,
-      "node": true
-    },
-    "globals": [
-      "atom"
-    ]
   }
 }

--- a/packages/one-dark-ui/package.json
+++ b/packages/one-dark-ui/package.json
@@ -14,9 +14,6 @@
   "engines": {
     "atom": ">0.40.0"
   },
-  "devDependencies": {
-    "standard": "^11.0.0"
-  },
   "configSchema": {
     "fontSize": {
       "title": "Font Size",

--- a/packages/one-light-ui/package.json
+++ b/packages/one-light-ui/package.json
@@ -14,9 +14,6 @@
   "engines": {
     "atom": ">0.40.0"
   },
-  "devDependencies": {
-    "standard": "^11.0.0"
-  },
   "configSchema": {
     "fontSize": {
       "title": "Font Size",

--- a/packages/update-package-dependencies/package.json
+++ b/packages/update-package-dependencies/package.json
@@ -21,19 +21,5 @@
       }
     }
   },
-  "dependencies": {},
-  "devDependencies": {
-    "standard": "^10.0.3"
-  },
-  "standard": {
-    "env": {
-      "atomtest": true,
-      "browser": true,
-      "jasmine": true,
-      "node": true
-    },
-    "globals": [
-      "atom"
-    ]
-  }
+  "dependencies": {}
 }

--- a/packages/welcome/package.json
+++ b/packages/welcome/package.json
@@ -10,7 +10,6 @@
     "atom": ">0.50.0"
   },
   "scripts": {
-    "lint": "standard",
     "test": "atom --test test/*.test.js"
   },
   "consumedServices": {
@@ -32,12 +31,6 @@
     "etch": "0.9.0"
   },
   "devDependencies": {
-    "atom-mocha-test-runner": "^1.0.0",
-    "standard": "^8.6.0"
-  },
-  "standard": {
-    "globals": [
-      "atom"
-    ]
+    "atom-mocha-test-runner": "^1.0.0"
   }
 }


### PR DESCRIPTION
This removes the linter `standard` from the packages since they were not used anymore.