### PR TITLE
remove find menu

### DIFF
--- a/menus/darwin.cson
+++ b/menus/darwin.cson
@@ -189,11 +189,6 @@
   }
 
   {
-    label: 'Find'
-    submenu: []
-  }
-
-  {
     label: 'Packages'
     submenu: [
       { label: 'Open Package Manager', command: 'settings-view:view-installed-packages' }

--- a/menus/linux.cson
+++ b/menus/linux.cson
@@ -172,11 +172,6 @@
   }
 
   {
-    label: 'F&ind'
-    submenu: []
-  }
-
-  {
     label: '&Packages'
     submenu: [
       { label: 'Open Package Manager', command: 'settings-view:view-installed-packages' }

--- a/menus/win32.cson
+++ b/menus/win32.cson
@@ -171,11 +171,6 @@
   }
 
   {
-    label: 'F&ind'
-    submenu: []
-  }
-
-  {
     label: '&Packages'
     submenu: [
       { label: 'Open Package Manager', command: 'settings-view:view-installed-packages' }


### PR DESCRIPTION
This removes the empty find menus from the core. They were used to position the menu.
The positioning is made independent in [`find-and-replace#6`](https://github.com/pulsar-edit/find-and-replace/pull/6).