### PR TITLE
Update/rebrand About package

### DIFF
--- a/packages/about/lib/components/about-view.js
+++ b/packages/about/lib/components/about-view.js
@@ -1,7 +1,7 @@
 const { Disposable } = require('atom');
 const etch = require('etch');
 const { shell } = require('electron');
-const AtomLogo = require('./atom-logo');
+const AtomLogo = require('./atom-logo'); //Update to new Pulsar logo (L#83)
 const EtchComponent = require('../etch-component');
 const UpdateView = require('./update-view');
 
@@ -31,7 +31,7 @@ module.exports = class AboutView extends EtchComponent {
   handleReleaseNotesClick(e) {
     e.preventDefault();
     shell.openExternal(
-      this.props.updateManager.getReleaseNotesURLForAvailableVersion()
+      this.props.updateManager.getReleaseNotesURLForAvailableVersion() //update-manager.js will need updating when we decide how to do the changelog
     );
   }
 
@@ -45,13 +45,13 @@ module.exports = class AboutView extends EtchComponent {
 
   handleTermsOfUseClick(e) {
     e.preventDefault();
-    shell.openExternal('https://atom.io/terms');
+    shell.openExternal('https://atom.io/terms'); //If we use this then this URL will need updating but button disabled (L#182)
   }
 
   handleHowToUpdateClick(e) {
     e.preventDefault();
     shell.openExternal(
-      'https://flight-manual.atom.io/getting-started/sections/installing-atom/'
+            'https://pulsar-edit.dev/docs/launch-manual/sections/getting-started/#installing-pulsar'
     );
   }
 
@@ -79,8 +79,9 @@ module.exports = class AboutView extends EtchComponent {
         $.header(
           { className: 'about-header' },
           $.a(
-            { className: 'about-atom-io', href: 'https://atom.io' },
-            $(AtomLogo)
+            { className: 'about-atom-io', href: `${atom.branding.urlWeb}`, },
+            //$(AtomLogo)
+            'Pulsar' //Remove and reinstate above line when available
           ),
           $.div(
             { className: 'about-header-info' },
@@ -177,33 +178,26 @@ module.exports = class AboutView extends EtchComponent {
             },
             'License'
           ),
-          $.button(
+          //Disabled the below as we don't have this but can reuse if there is the need
+          /*$.button(
             {
               className: 'btn terms-of-use',
               onclick: this.handleTermsOfUseClick.bind(this)
             },
             'Terms of Use'
-          )
+          )*/
         )
       ),
 
       $.div(
         { className: 'about-love group-start' },
-        $.span({ className: 'icon icon-code' }),
+        $.a({ className: 'icon icon-code', href: `${atom.branding.urlGH}` }),
         $.span({ className: 'inline' }, ' with '),
-        $.span({ className: 'icon icon-heart' }),
+        $.a({ className: 'icon icon-heart', href: `${atom.branding.urlWeb}` + "community" }),
         $.span({ className: 'inline' }, ' by '),
-        $.a({ className: 'icon icon-logo-github', href: 'https://github.com' })
+        //$.a({ className: 'icon icon-logo-github', href: `${atom.branding.urlWeb}` }) Replace icon with Pulsar word logo and delete following line
+        $.a({ className: 'inline', href: `${atom.branding.urlWeb}` }, 'Pulsar Team')
       ),
-
-      $.div(
-        { className: 'about-credits group-item' },
-        $.span({ className: 'inline' }, 'And the awesome '),
-        $.a(
-          { href: 'https://github.com/pulsar-edit/pulsar/contributors' },
-          'Pulsar community'
-        )
-      )
     );
   }
 
@@ -230,3 +224,4 @@ module.exports = class AboutView extends EtchComponent {
     return 'info';
   }
 };
+


### PR DESCRIPTION
An "interim" update/rebrand of the about package.

This updates the links into the `atom.branding` values for the Pulsar sites and GH.

This also removes the Atom logo in preparation for adding the Pulsar one (just replaced with a simple "Pulsar" string for the moment).

I've removed the section to "Pulsar Community" as it is kind of unnecessary now it isn't handled by a big company - the community *is* the team and vice versa.

The little logos have been changed into links like in the welcome package.

There are a bunch of comments I've added indicating what areas still need to be updated with the new branding (like the logos).

The "terms of use" button has been commented out entirely, we can re-use it later if we need but it currently serves no purpose. 