### PR TITLE
Add tar.gz target to electron-builder

### DIFF
--- a/script/electron-builder.js
+++ b/script/electron-builder.js
@@ -95,7 +95,8 @@ let options = {
     "target": [
       { target: "appimage" },
       { target: "deb" },
-      { target: "rpm" }
+      { target: "rpm" },
+      { target: "tar.gz" }
     ],
   },
   "mac": {


### PR DESCRIPTION
This just adds a tar.gz target.

Useful for a truly universal distribution (appimage actually needs some pre-requisites missing from some distros) as well as easy testing of a binary without needing to install à la .deb or .rpm.

This is pretty standard of many projects and actually one that Atom distributed as on their GH releases.