### PR TITLE
CI (Windows): Use npm (not yarn) to install ppm

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -171,7 +171,7 @@ windows_task:
     - git submodule update
     - npm config set python 'C:\Python310\python.exe'
   build_apm_script:
-    - cd ppm; npx yarn install --ignore-engines || npx yarn install --ignore-engines || npx yarn cache clean; npx yarn install --ignore-engines || npx yarn install --ignore-engines
+    - cd ppm; npm install
   install_without_scripts_script:
     - npx yarn install --ignore-scripts --ignore-engines || sleep 1 && npx yarn install --ignore-engines --ignore-scripts || sleep 2 && npx yarn cache clean; npx yarn install --ignore-engines --ignore-scripts || sleep 2 && npx yarn install --ignore-engines --ignore-scripts || echo "Giving up"
   rebuild_for_electron_script:


### PR DESCRIPTION
<details><summary><b>Requirements for Contributing a Bug Fix (from template, click to expand):</b></summary>

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* The pull request must only fix an existing bug. To contribute other changes, you must use a different template. You can see all templates at <https://github.com/atom/.github/tree/master/.github/PULL_REQUEST_TEMPLATE>.
* The pull request must update the test suite to demonstrate the changed functionality. For guidance, please see <https://flight-manual.atom.io/hacking-atom/sections/writing-specs/>.
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution. For more details, please see <https://github.com/atom/.github/tree/master/CONTRIBUTING.md#pull-requests>.

</details>

### Identify the Bug

<!--

Link to the issue describing the bug that you're fixing.

If there is not yet an issue for your bug, please open a new issue and then link to that issue in your pull request.
Note: In some cases, one person's "bug" is another person's "feature." If the pull request does not address an existing issue with the "bug" label, the maintainers have the final say on whether the current behavior is a bug.

-->

ppm has its dependencies built for Node 14 in Windows CI (and CI artifacts). This makes ppm fail, because the bundled copy of Node in ppm is Node 16 now.

Those dependencies should be built for Node 16 now, after the recent bump to bundled Node 16 in the ppm repo, which was done for Apple Silicon compatibility reasons.

<details><summary>Details of the error message (click to expand):</summary>

This PR should fix this particular occurrence of the semi-infamous `NODE_MODULE_VERSION` error -- which indicates when you're trying to run native C/C++ code compiled against the wrong version of Node/Electron -- a different version than you're currently running.

```
Error: The module '\\?\C:\Users\user\AppData\Local\Programs\pulsar\resources\app\ppm\node_modules\git-utils\build\Release\git.node'
was compiled against a different Node.js version using
NODE_MODULE_VERSION 83. This version of Node.js requires
NODE_MODULE_VERSION 93. Please try re-compiling or re-installing
the module (for instance, using `npm rebuild` or `npm install`).
```

This is saying the module was built for Node 14, but you're attempting to run it with Node 16.

(To decode the meaning of the different `NODE_ABI_VERSION` numbers, refer to this metadata file: https://github.com/electron/node-abi/blob/main/abi_registry.json. ABI 83 is Node 14, ABI 93 is Node 16.)

</details>

### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

Use npm, not Yarn, to install ppm's dependencies.

(Fixes an obscure thing where Yarn exits the postinstall script early, earlier than NPM does.)

<details><summary>Speculating on why this happens in Yarn but not NPM? (Click to expand):</summary>

(Probably has something to do with Yarn handling process.exit() differently than NPM does, in ppm's `postinstall.cmd`. Specifically, ppm's `script/download-node.js` has a bit where it calls `process.exit()`, which I assume is handled differently when run under Yarn compared to running it under NPM? Since that's right where postinstall.js exits "early" under Yarn. Npm keeps going till the later part of `postinstall.cmd`.)

(Perhaps Yarn avoids running sub-processes of Node nested as deeply as NPM does? Thus process.exit() exiting a higher Node process that we expect to still have work to do later in the main postinstall script? Not totally sure. This is just a guess.)

</details>

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

N/A. I didn't consider any alternatives, running it under Yarn didn't work for me locally, but running it under NPM did work for me locally.

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

None expected.

The ppm (previously apm) repo was traditionally developed with NPM, and I don't think it has any particular thing that necessitates the use of Yarn, unlike the workarounds Yarn was able to provide for installing the main Pulsar dependencies.

### Verification Process

<!--

What process did you follow to verify that the change has not introduced any regressions? Describe the actions you performed (including buttons you clicked, text you typed, commands you ran, etc.), and describe the results you observed.

-->

Worked for me locally, hopefully CI produces an artifact with working ppm.

Update:

```
> pulsar-package-manager@2.7.0 postinstall C:\Users\ContainerAdministrator\AppData\Local\Temp\cirrus-ci-build\ppm
> node script/postinstall.js
>> Downloading bundled Node
>> Rebuilding apm dependencies with bundled Node v16.0.0 x64
```

Noice. (The "Rebuilding apm dependencies with bundled Node" part is working with NPM now in Cirrus CI Windows.) 

### Release Notes

<!--

Please describe the changes in a single line that explains this improvement in
terms that a user can understand. This text will be used in Atom's release notes.

If this change is not user-facing or notable enough to be included in release notes
you may use the strings "Not applicable" or "N/A" here.

Examples:

- The GitHub package now allows you to add co-authors to commits.
- Fixed an issue where multiple cursors did not work in a file with a single line.
- Increased the performance of searching and replacing across a whole project.

-->

Fixed ppm (package manager) in Windows CI builds