### PR TITLE
Fix `dugite` 

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -172,8 +172,10 @@ windows_task:
     - npm config set python 'C:\Python310\python.exe'
   build_apm_script:
     - cd ppm; npm install
-  install_without_scripts_script:
-    - npx yarn install --ignore-scripts --ignore-engines || sleep 1 && npx yarn install --ignore-engines --ignore-scripts || sleep 2 && npx yarn cache clean; npx yarn install --ignore-engines --ignore-scripts || sleep 2 && npx yarn install --ignore-engines --ignore-scripts || echo "Giving up"
+  install_with_scripts_script:
+    - npx yarn install --ignore-engines || sleep 1 && npx yarn install --ignore-engines || echo "There is a reason for so many tries"
+  #install_without_scripts_script:
+  #  - npx yarn install --ignore-scripts --ignore-engines || sleep 1 && npx yarn install --ignore-engines --ignore-scripts || sleep 2 && npx yarn cache clean; npx yarn install --ignore-engines --ignore-scripts || sleep 2 && npx yarn install --ignore-engines --ignore-scripts || echo "Giving up"
   rebuild_for_electron_script:
     - npx yarn build || npx yarn build || npx yarn build
   # install_only_electron_script:

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,0 +1,2 @@
+nodeLinker: "node-modules"
+pnpMode: "loose"

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,2 +1,0 @@
-nodeLinker: "node-modules"
-pnpMode: "loose"

--- a/script/electron-builder.js
+++ b/script/electron-builder.js
@@ -85,10 +85,14 @@ let options = {
     "!**/less/dist",
     "!**/npm/{doc,html,man}",
     "!**/pegjs/examples",
-    "!**/get-parameter-names/node_modules/{testla,.bin}",
+    "!**/get-parameter-names/node_modules/testla",
+    "!**/get-parameter-names/node_modules/.bin/testla",
+    "!**/jasmine-reporters/ext",
+    "!**/node_modules/native-mate",
     "!**/build/{binding.Makefile,config.gypi,gyp-mac-tool,Makefile}",
     "!**/build/Release/{obj.target,obj,.deps}",
     "!**/deps/libgit2",
+    "!**/node_modules/spellchecker/vendor/hunspell/.*",
     // These are only required in dev-mode, when pegjs grammars aren't precompiled
     "!node_modules/loophole",
     "!node_modules/pegjs",
@@ -98,8 +102,16 @@ let options = {
     // Ignore *.cc and *.h files from native modules
     "!**/*.{cc,h}",
     // Handpicked spec folders
-    "!**/{oniguruma,dev-live-reload,deprecation-cop,one-dark-ui,incompatible-packages,git-diff,line-ending-selector,link,json-schema-traverse}/spec"
+    "!**/{oniguruma,dev-live-reload,deprecation-cop,one-dark-ui,incompatible-packages,git-diff,line-ending-selector}/spec",
+    "!**/{link,grammar-selector,json-schema-traverse,exception-reporting,one-light-ui,autoflow,about,go-to-line,sylvester,apparatus}/spec",
+    // Ignore babel-core spec
+    "!**/node_modules/babel-core/lib/transformation/transforers/spec",
 
+    // The following are cherry-picked for Pulsar
+    "!**/{archive-view,autocomplete-plus,autocomplete-atom-api,autocomplete-css,autosave}/spec",
+    "!**/{.eslintignore,PULL_REQUEST_TEMPLATE.md,ISSUE_TEMPLATE.md,CONTRIBUTING.md,SECURITY.md}",
+    "!**/{Makefile,.editorconfig,.nycrc,.coffeelint.json,.github,.vscode}",
+    "!**/*.js.map"
   ],
   "extraResources": [
     {

--- a/script/electron-builder.js
+++ b/script/electron-builder.js
@@ -120,7 +120,10 @@ let options = {
   "extraMetadata": {
   },
   "asarUnpack": [
-    "node_modules/github/bin/*, node_modules/dugite/git"
+    "node_modules/github/bin/*",
+    "node_modules/github/lib/*",
+    "node_modules/dugite/git/**/*" // The git folder isn't created during the install.
+    // As we can see it's not included in the asarArchive, meaning dugite/git doesn't exist
   ]
 
 }

--- a/script/electron-builder.js
+++ b/script/electron-builder.js
@@ -54,6 +54,7 @@ let options = {
     "keymaps/**/*",
     "menus/**/*",
     "node_modules/**/*",
+    "node_modules/dugite/git/cmd/git.exe",
     "resources/**/*",
     "script/**/*",
     "src/**/*",

--- a/script/electron-builder.js
+++ b/script/electron-builder.js
@@ -53,7 +53,7 @@ let options = {
     "exports/**/*",
     "keymaps/**/*",
     "menus/**/*",
-    "node_modules/**/*",
+    "node_modules/**/**",
     "resources/**/*",
     "script/**/*",
     "src/**/*",
@@ -121,7 +121,7 @@ let options = {
   },
   "asarUnpack": [
     "node_modules/github/bin/*",
-    "node_modules/dugite/git/cmd/git.exe"
+    "node_modules/dugite/git/**/**"
   ]
 
 }

--- a/script/electron-builder.js
+++ b/script/electron-builder.js
@@ -54,7 +54,6 @@ let options = {
     "keymaps/**/*",
     "menus/**/*",
     "node_modules/**/*",
-    "node_modules/dugite/git/cmd/git.exe",
     "resources/**/*",
     "script/**/*",
     "src/**/*",
@@ -120,7 +119,10 @@ let options = {
   },
   "extraMetadata": {
   },
-  "asarUnpack": ["node_modules/github/bin/*"]
+  "asarUnpack": [
+    "node_modules/github/bin/*",
+    "node_modules/dugite/git/cmd/git.exe"
+  ]
 
 }
 

--- a/script/electron-builder.js
+++ b/script/electron-builder.js
@@ -76,6 +76,30 @@ let options = {
     "spec/spec-helper-functions.js",
     "spec/atom-reporter.js",
     "spec/jasmine-list-reporter.js",
+
+    // The following are taken directly from Atom (Hoping they still apply)
+    "!**/{.jshintrc,.npmignore,.pairs,.lint,.lintignore,.eslintrc,.jshintignore}",
+    "!**/{.coffeelintignore,.git-keep}",
+    "!**/git-utils/deps",
+    "!**/oniguruma/deps",
+    "!**/less/dist",
+    "!**/npm/{doc,html,man}",
+    "!**/pegjs/examples",
+    "!**/get-parameter-names/node_modules/{testla,.bin}",
+    "!**/build/{binding.Makefile,config.gypi,gyp-mac-tool,Makefile}",
+    "!**/build/Release/{obj.target,obj,.deps}",
+    "!**/deps/libgit2",
+    // These are only required in dev-mode, when pegjs grammars aren't precompiled
+    "!node_modules/loophole",
+    "!node_modules/pegjs",
+    "!node_modules/.bin/pegjs",
+    // node_modules of the fuzzy-native package are only required for building it
+    "!node_modules/fuzzy-native/node_modules",
+    // Ignore *.cc and *.h files from native modules
+    "!**/*.{cc,h}",
+    // Handpicked spec folders
+    "!**/{oniguruma,dev-live-reload,deprecation-cop,one-dark-ui,incompatible-packages,git-diff,line-ending-selector,link,json-schema-traverse}/spec"
+
   ],
   "extraResources": [
     {
@@ -121,9 +145,9 @@ let options = {
   },
   "asarUnpack": [
     "node_modules/github/bin/*",
-    "node_modules/github/lib/*",
-    "node_modules/dugite/git/**/*" // The git folder isn't created during the install.
-    // As we can see it's not included in the asarArchive, meaning dugite/git doesn't exist
+    "node_modules/github/lib/*", // Resolves Error in console
+    "**/node_modules/dugite/git/**", // Include dugite postInstall output (matching glob used for Atom)
+    "**/node_modules/spellchecker/**", // Matching Atom Glob
   ]
 
 }

--- a/script/electron-builder.js
+++ b/script/electron-builder.js
@@ -48,14 +48,14 @@ let options = {
   "publish": null,
   files: [
     "package.json",
-    "docs/**/*",
+    "!docs/",
     "dot-atom/**/*",
     "exports/**/*",
-    "keymaps/**/*",
-    "menus/**/*",
+    "!keymaps/",
+    "!menus/",
     "node_modules/**/*",
     "resources/**/*",
-    "script/**/*",
+    "!script/",
     "src/**/*",
     "static/**/*",
     "vendor/**/*",
@@ -110,8 +110,8 @@ let options = {
     // The following are cherry-picked for Pulsar
     "!**/{archive-view,autocomplete-plus,autocomplete-atom-api,autocomplete-css,autosave}/spec",
     "!**/{.eslintignore,PULL_REQUEST_TEMPLATE.md,ISSUE_TEMPLATE.md,CONTRIBUTING.md,SECURITY.md}",
-    "!**/{Makefile,.editorconfig,.nycrc,.coffeelint.json,.github,.vscode}",
-    "!**/*.js.map"
+    "!**/{Makefile,.editorconfig,.nycrc,.coffeelint.json,.github,.vscode,coffeelint.json}",
+    "!**/*.js.map",
   ],
   "extraResources": [
     {

--- a/script/electron-builder.js
+++ b/script/electron-builder.js
@@ -53,7 +53,7 @@ let options = {
     "exports/**/*",
     "keymaps/**/*",
     "menus/**/*",
-    "node_modules/**/**",
+    "node_modules/**/*",
     "resources/**/*",
     "script/**/*",
     "src/**/*",
@@ -120,8 +120,7 @@ let options = {
   "extraMetadata": {
   },
   "asarUnpack": [
-    "node_modules/github/bin/*",
-    "node_modules/dugite/git/**/**"
+    "node_modules/github/bin/*, node_modules/dugite/git"
   ]
 
 }


### PR DESCRIPTION
EDIT:

As helpful pointed out by @DeeDeeG we are using `yarn` v1.x.x and the `.yarnrc.yml` file isn't actually making any changes. So in all reality, `yarn` will be just as stable as before, and I'll cross out where this PR mentions the possibility of anything different.

---

TLDR:

This PR fixes the below errors that would appear in the console, as reported by users on Discord, and seen by me. ~~While also aiming to improve our `yarn install` stability~~, try and lock down what's included in our `app.asar` and unpacked from the asar archive. While additionally increasing our final install size a little bit more.

### Issue 1

```shell
Uncaught (in promise) Error: Git could not be found at the expected path: 'C:\Users<user>\AppData\Local\Programs\pulsar\resources\app.asar.unpacked\node_modules\dugite\git\cmd\git.exe'. This might be a problem with how the application is packaged, so confirm this folder hasn't been removed when packaging.
    at C:\Users\<user>\AppData\Local\Programs\pulsar\resources\app.asar\node_modules\dugite\build\lib\git-process.js:87:39
    at exithandler (child_process.js:324:5)
    at ChildProcess.errorhandler (child_process.js:336:5)
    at ChildProcess.emit (events.js:315:20)
    at Process.ChildProcess._handle.onexit (internal/child_process.js:275:12)
    at onErrorNT (internal/child_process.js:465:16)
    at processTicksAndRejections (internal/process/task_queues.js:80:21)
```

### Issue 2

```shell
Uncaught (in promise) Error: ERR_FILE_NOT_FOUND (-6) loading 'file:///C:/Users/<user>/AppData/Local/Programs/pulsar/resources/app.asar.unpacked/node_modules/github/lib/renderer.html?js=C%3A%5CUsers%5Cantho%5CAppData%5CLocal%5CPrograms%5Cpulsar%5Cresources%5Capp.asar.unpacked%5Cnode_modules%5Cgithub%5Clib%5Cworker.js&managerWebContentsId=1&operationCountLimit=10&channelName=github%3Arenderer-ipc'
    at rejectAndCleanup (electron/js2c/browser_init.js:217:1457)
    at Object.failListener (electron/js2c/browser_init.js:217:1670)
    at Object.emit (events.js:315:20)
```

---

So mainly this PR was aimed at fixing the above issues, but while doing so ended up taking a bit of a deeper dive into our build process than originally intended. Where I wanted to try and make as many optimizations as possible, and try to increase our installation stability.

The main fix for the above error, was firstly running the Windows binary installation while using scripts, since `dugite` uses a `postInstall` script to install it's bundled `git`, and without scripts this wasn't happening, which would cause the file to not appear in our asar. Additionally though we needed to unpack this file from our asar to allow it to be imported. The second error shown was also fixed by adding more items to be unpacked.

But beyond these immediate fixes, I'll detail the other changes made.

Otherwise essentially this PR modifies what's included in our asar bundle, and what's unpacked from the asar archive. ~~While again trying to increase the `yarn install` stability.~~ Since as it is currently the CI has it written to try installing multiple times.

## For what is now unpacked

* "node_modules/github/lib/*" - Resolves Issue 2
* "**/node_modules/dugite/git/**" - Resolves Issue 1
* "**/node_modules/spellchecker/**" - Matches more of what [Atom originally unpacked](https://github.com/atom/atom/blob/1c3bd35ce238dc0491def9e1780d04748d8e18af/script/lib/package-application.js#L189), in the hopes of avoiding an issue in the future.

## ~~Attempting to Help `yarn install`~~

~~I've added a `.yarnrc.yml` file to the root of the project.~~

This file has been removed due to incompatibility with `yarn` v1.x.x as helpfully pointed out.

In it I've set two values:

```yaml
nodeLinker: "node-modules"
pnpMode: "loose"
```

~~The first is [recommended by yarn](https://yarnpkg.com/getting-started/migration) when migrating from NPM to Yarn, the second value [`pnpMode`](https://yarnpkg.com/configuration/yarnrc#pnpMode) seemed to help ensure some of the modules we are unpacking were available in my environment. And seems to more closely mirror the behavior of `npm` which obviously we can assume many of our packages will expect. More details about what this changes in how our dependencies are linked is available on the [yarn website](https://yarnpkg.com/features/pnp#pnp-loose-mode).~~

## Excludes

From here I went through and started adding some values to what we exclude from our asar archive. Since after running the scripts and including their output into our asar bundle, once installed Pulsar (at least on Windows) went from ~900MB to 1.10GB. Which obviously is not ideal. But after adding these additional excludes I was able to cut down that size to 1.05GB and likely with more optimization on what we exclude we can decrease the size further.

So taking a look at what Atom had originally thought to [exclude](https://github.com/atom/atom/blob/master/script/lib/include-path-in-packaged-app.js) I mirrored many of those decisions back into our exclusions. Including a couple of things that where previously set to include. Namely things like our main repos `docs` and `scripts`. 

So feel free to review and provide feedback if this isn't a change we want, ~~especially for things like the `.yarnrc.yml`.~~(This file has been removed from this PR)
I just thought this was a method we could try to prevent additional issues from popping up. But really if we wanted to prioritize only solving the issue at hand, we could look at allowing `dugite` scripts to run by providing some [`dependenciesMeta`](https://yarnpkg.com/configuration/manifest#dependenciesMeta) or something along those lines.

But thanks for any review if anyone's able to take a look at this. 

---

Beyond that while doing all of this research I found some other interesting things which I wanted to detail here for posterity or future reference.

<details>

## Atom Asar Archive 

* benchmarks/
* dot-atom/
* exports/
* less-compile-cache/
* node_modules/
* resources/
* spec/
* src/
* static/
* vendor/
* package.json

## Pulsar Asar Archive (Before PR)

* docs/
* dot-atom/
* exports/
* keymaps/
* menus/
* node_modules/
* resources/
* scipt/
* spec/
* src/
* static/
* vendor/
* package.json

## Atom Unpacked Asar 

node_modules/
* @atom
* ctags
* dugite
* fs-admin
* fswin
* github
* git-utils
* keyboard-layout
* keytar
* nslog
* oniguruma
* pathwatcher
* scrollbar-style
* spellchecker
* superstring
* symbols-view
* text-buffer
* tree-sitter
* tree-sitter-bash
* tree-sitter-c
* tree-sitter-cpp
* tree-sitter-css
* tree-sitter-embeded-template
* tree-sitter-go
* tree-sitter-html
* tree-sitter-java-dev
* tree-sitter-javascript
* tree-sitter-jsdoc
* tree-sitter-json
* tree-sitter-python
* tree-sitter-regex
* tree-sitter-rub
* tree-sitter-rust
* tree-sitter-typescript
* vscode-ripgrep

## Pulsar Unpacked Asar (After PR)

node_modules/
* dugite
* github
* spellchecker
* symbols-view
* vscode-ripgrep
* whats-my-line

</details>