### PR TITLE
meta: Don't exclude 'loophole' or 'pegjs' packages

### DIFF
--- a/script/electron-builder.js
+++ b/script/electron-builder.js
@@ -94,9 +94,9 @@ let options = {
     "!**/deps/libgit2",
     "!**/node_modules/spellchecker/vendor/hunspell/.*",
     // These are only required in dev-mode, when pegjs grammars aren't precompiled
-    "!node_modules/loophole",
-    "!node_modules/pegjs",
-    "!node_modules/.bin/pegjs",
+      // "!node_modules/loophole", // Note: We do need these packages. Because our PegJS files _aren't_ all pre-compiled.
+      // "!node_modules/pegjs",    // Note: if these files are excluded, 'snippets' package breaks.
+      // "!node_modules/.bin/pegjs",
     // node_modules of the fuzzy-native package are only required for building it
     "!node_modules/fuzzy-native/node_modules",
     // Ignore *.cc and *.h files from native modules


### PR DESCRIPTION
<details><summary><b>Requirements for Contributing a Bug Fix</b> (click to expand):</summary>

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* The pull request must only fix an existing bug. To contribute other changes, you must use a different template. You can see all templates at <https://github.com/atom/.github/tree/master/.github/PULL_REQUEST_TEMPLATE>.
* The pull request must update the test suite to demonstrate the changed functionality. For guidance, please see <https://flight-manual.atom.io/hacking-atom/sections/writing-specs/>.
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution. For more details, please see <https://github.com/atom/.github/tree/master/CONTRIBUTING.md#pull-requests>.

</details>

### Identify the Bug

<!--

Link to the issue describing the bug that you're fixing.

If there is not yet an issue for your bug, please open a new issue and then link to that issue in your pull request.
Note: In some cases, one person's "bug" is another person's "feature." If the pull request does not address an existing issue with the "bug" label, the maintainers have the final say on whether the current behavior is a bug.

-->

When trying to type a tab character in a document or file, after https://github.com/pulsar-edit/pulsar/pull/201 was merged, there is an error:

```
Uncaught Error: Cannot find module 'loophole'
```

<details><summary>Screenshot (click to expand):</summary>

![Cannot Find Module 'loophole'](https://user-images.githubusercontent.com/20157115/206785479-ac9ffece-9c42-4c7d-904e-179ec6ef610b.png)

</details>

```
Uncaught Error: Cannot find module 'pegjs'
```

<details><summary>Screenshot (click to expand):</summary>

![Cannot Find Module 'pegjs'](https://user-images.githubusercontent.com/20157115/206785546-abc9c2ab-ea72-4437-af5b-a57eeed65ccb.png)

</details>

Explanation as for why this happens:

There is a file which 'snippets' expects to have been compiled from .pegjs to .js. If it can't require the plain .js file successfully (it assumes this is because the .pegjs file hasn't been transpiled to plain JS yet, which is correct in our case)... then if appears to fall back on live-transpiling the file with the 'pegjs' module.

So we need to have the 'pegjs' module (and 'loophole', whatever that is) in order to load 'snippets' package properly and restore the ability to type tab characters. (The app appears to trigger the 'snippets' package to activate every time you type a Tab? Which I understand is for code autocompletion purposes.)

### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

Don't exclude 'loophole' or 'pegjs' packages from the app bundle. Allows the 'snippets' package to work again.

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

We can attempt to compile the PegJS files to plain JS, like the old build scripts used to do. See: [script/lib/transpile-peg-js-paths.js at Atom core repo](https://github.com/atom/atom/blob/1c3bd35ce238dc0491def9e1780d04748d8e18af/script/lib/transpile-peg-js-paths.js).

At which point we apparently wouldn't need these packages.

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

Increases the final app bundle size by some 0.2 Megabytes, after compression, adds more files to the final bundle.

### Verification Process

<!--

What process did you follow to verify that the change has not introduced any regressions? Describe the actions you performed (including buttons you clicked, text you typed, commands you ran, etc.), and describe the results you observed.

-->

Tested CI binaries with/without these changes on my Windows 10 machine:

- `master` with [#201](https://github.com/pulsar-edit/pulsar/pull/201): Affected by the tab bug described at the top of this PR. :x: 
- This branch: Not affected by bug :heavy_check_mark: 

### Release Notes

<!--

Please describe the changes in a single line that explains this improvement in
terms that a user can understand. This text will be used in Atom's release notes.

If this change is not user-facing or notable enough to be included in release notes
you may use the strings "Not applicable" or "N/A" here.

Examples:

- The GitHub package now allows you to add co-authors to commits.
- Fixed an issue where multiple cursors did not work in a file with a single line.
- Increased the performance of searching and replacing across a whole project.

-->

Fix a bug when typing a tab character in a document or file