### PR TITLE
remove `coffeescript` as generatable package language

### DIFF
--- a/packages/package-generator/package.json
+++ b/packages/package-generator/package.json
@@ -30,7 +30,6 @@
       "default": "javascript",
       "type": "string",
       "enum": [
-        "coffeescript",
         "javascript"
       ],
       "description": "The syntax to generate packages with."

--- a/packages/package-generator/spec/package-generator-spec.js
+++ b/packages/package-generator/spec/package-generator-spec.js
@@ -180,15 +180,6 @@ describe('Package Generator', () => {
           })
         })
 
-        describe(`when the ${type} is a coffeescript package`, () => {
-          it('calls `apm init` with the correct syntax option', async () => {
-            atom.config.set('package-generator.packageSyntax', 'coffeescript')
-            await generatePackage(true)
-            expect(apmExecute.argsForCall[0][0]).toBe(atom.packages.getApmPath())
-            expect(apmExecute.argsForCall[0][1]).toEqual(packageInitCommandFor(`${packagePath}`, type, 'coffeescript'))
-          })
-        })
-
         describe(`when the ${type} is a javascript package`, () => {
           it('calls `apm init` with the correct syntax option', async () => {
             atom.config.set('package-generator.packageSyntax', 'javascript')


### PR DESCRIPTION
Since we want to get rid of coffeescript it only makes sence to remove support for new coffeescript packages. Therefore I would remove the option in the `package-generator` to generate coffeescript packages.
I would not remove this option completly since it might be good to support a setup with typescript or pre configured babel.

Idea:
Also might be good to allow other packages to add possible packages. This would require quite a rewrite since currently the package generation is handled by ppm and therefor not accessable.