### PR TITLE
add `underscore-plus` to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -170,6 +170,7 @@
     "tree-sitter": "0.20.0",
     "tree-view": "https://codeload.github.com/atom/tree-view/legacy.tar.gz/refs/tags/v0.229.1",
     "typescript-simple": "8.0.6",
+    "underscore-plus": "^1.7.0",
     "update-package-dependencies": "file:./packages/update-package-dependencies",
     "vscode-ripgrep": "1.9.0",
     "welcome": "file:packages/welcome",


### PR DESCRIPTION
`underscore-plus` is used a lot in the code but is not listed in the dependencies. I added it here