### PR TITLE
[fix] Postinstall error with rm /usr/bin/pulsar

### DIFF
--- a/script/post-install.sh
+++ b/script/post-install.sh
@@ -1,4 +1,9 @@
 #!/bin/sh
 
-rm /usr/bin/pulsar 2>/dev/null
+if [ -f "/usr/bin/pulsar" ]
+then
+  rm /usr/bin/pulsar
+else
+  echo "File '/usr/bin/pulsar' not found (this is not an error)"
+fi
 cp /opt/Pulsar/resources/pulsar.sh /usr/bin/pulsar

--- a/script/post-install.sh
+++ b/script/post-install.sh
@@ -6,7 +6,5 @@ FILEDEST='/usr/bin/pulsar'
 if [ -f "$FILEDEST" ]
 then
   rm "$FILEDEST"
-else
-  echo "File '$FILEDEST' not found (this is not an error)"
 fi
 cp "$FILESOURCE" "$FILEDEST"

--- a/script/post-install.sh
+++ b/script/post-install.sh
@@ -1,9 +1,12 @@
 #!/bin/sh
 
-if [ -f "/usr/bin/pulsar" ]
+FILESOURCE='/opt/Pulsar/resources/pulsar.sh'
+FILEDEST='/usr/bin/pulsar'
+
+if [ -f "$FILEDEST" ]
 then
-  rm /usr/bin/pulsar
+  rm "$FILEDEST"
 else
-  echo "File '/usr/bin/pulsar' not found (this is not an error)"
+  echo "File '$FILEDEST' not found (this is not an error)"
 fi
-cp /opt/Pulsar/resources/pulsar.sh /usr/bin/pulsar
+cp "$FILESOURCE" "$FILEDEST"

--- a/script/post-install.sh
+++ b/script/post-install.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
-rm /usr/bin/pulsar
+rm /usr/bin/pulsar 2>/dev/null
 cp /opt/Pulsar/resources/pulsar.sh /usr/bin/pulsar


### PR DESCRIPTION
Redirect stderr to /dev/null

Since this is a shell (sh) file and not a bash file, rather than doing an `if [[ -f "" ]]` condition, we can just throw away the error if it doesn't exist

A whole lot safer than using `-f/--force`

Should fix #215 