### PR TITLE
meta: Bump base version to v1.100.0

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -22,7 +22,7 @@ linux_task:
                 xvfb
     - git submodule init
     - git submodule update
-    - sed -i -e "s/[0-9]*-dev/`echo '0-beta'`/g" package.json
+    - sed -i -e "s/[0-9]*-dev/`date -u +%Y%m%d%H`/g" package.json
     - yarn install || yarn install
     - yarn build
     - yarn run build:apm
@@ -73,7 +73,7 @@ arm_linux_task:
     - gem install fpm
     - git submodule init
     - git submodule update
-    - sed -i -e "s/[0-9]*-dev/`echo '0-beta'`/g" package.json
+    - sed -i -e "s/[0-9]*-dev/`date -u +%Y%m%d%H`/g" package.json
     - yarn install || yarn install
     - yarn build
     - yarn run build:apm
@@ -104,7 +104,7 @@ silicon_mac_task:
     - git submodule update
     - ln -s /opt/homebrew/bin/python3 /opt/homebrew/bin/python
     - export PATH="/opt/homebrew/bin:/opt/homebrew/opt/node@16/bin:$PATH"
-    - sed -i -e "s/[0-9]*-dev/`echo '0-beta'`/g" package.json
+    - sed -i -e "s/[0-9]*-dev/`date -u +%Y%m%d%H`/g" package.json
     - yarn install || yarn install
     - yarn build
     - yarn run build:apm
@@ -137,7 +137,7 @@ intel_mac_task:
     - ln -s /usr/local/bin/python3 /usr/local/bin/python
     - git submodule init
     - git submodule update
-    - sed -i -e "s/[0-9]*-dev/`echo '0-beta'`/g" package.json
+    - sed -i -e "s/[0-9]*-dev/`date -u +%Y%m%d%H`/g" package.json
     - arch -x86_64 npx yarn install || arch -x86_64 npx yarn install
     - arch -x86_64 npx yarn build
     - arch -x86_64 yarn run build:apm
@@ -185,7 +185,7 @@ windows_task:
   videos_artifacts:
     path: tests\videos\**
   build_binary_script:
-    - sed -i -e "s/[0-9]*-dev/`echo '0-beta'`/g" package.json
+    - sed -i -e "s/[0-9]*-dev/`date -u +%Y%m%d%H`/g" package.json
     - npx yarn dist || npx yarn dist || npx yarn dist
   binary_artifacts:
     path: .\binaries\*

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -22,7 +22,7 @@ linux_task:
                 xvfb
     - git submodule init
     - git submodule update
-    - sed -i -e "s/[0-9]*-dev/`date -u +%Y%m%d%H`/g" package.json
+    - sed -i -e "s/[0-9]*-dev/`echo '0-beta'`/g" package.json
     - yarn install || yarn install
     - yarn build
     - yarn run build:apm
@@ -73,7 +73,7 @@ arm_linux_task:
     - gem install fpm
     - git submodule init
     - git submodule update
-    - sed -i -e "s/[0-9]*-dev/`date -u +%Y%m%d%H`/g" package.json
+    - sed -i -e "s/[0-9]*-dev/`echo '0-beta'`/g" package.json
     - yarn install || yarn install
     - yarn build
     - yarn run build:apm
@@ -104,7 +104,7 @@ silicon_mac_task:
     - git submodule update
     - ln -s /opt/homebrew/bin/python3 /opt/homebrew/bin/python
     - export PATH="/opt/homebrew/bin:/opt/homebrew/opt/node@16/bin:$PATH"
-    - sed -i -e "s/[0-9]*-dev/`date -u +%Y%m%d%H`/g" package.json
+    - sed -i -e "s/[0-9]*-dev/`echo '0-beta'`/g" package.json
     - yarn install || yarn install
     - yarn build
     - yarn run build:apm
@@ -137,7 +137,7 @@ intel_mac_task:
     - ln -s /usr/local/bin/python3 /usr/local/bin/python
     - git submodule init
     - git submodule update
-    - sed -i -e "s/[0-9]*-dev/`date -u +%Y%m%d%H`/g" package.json
+    - sed -i -e "s/[0-9]*-dev/`echo '0-beta'`/g" package.json
     - arch -x86_64 npx yarn install || arch -x86_64 npx yarn install
     - arch -x86_64 npx yarn build
     - arch -x86_64 yarn run build:apm
@@ -185,7 +185,7 @@ windows_task:
   videos_artifacts:
     path: tests\videos\**
   build_binary_script:
-    - sed -i -e "s/[0-9]*-dev/`date -u +%Y%m%d%H`/g" package.json
+    - sed -i -e "s/[0-9]*-dev/`echo '0-beta'`/g" package.json
     - npx yarn dist || npx yarn dist || npx yarn dist
   binary_artifacts:
     path: .\binaries\*

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "pulsar",
   "author": "Pulsar Community <noreply@pulsar-edit.com>",
   "productName": "Pulsar",
-  "version": "1.63.0-dev",
+  "version": "1.100.0-dev",
   "description": "A Community-led Hyper-Hackable Text Editor",
   "branding": {
     "id": "pulsar",


### PR DESCRIPTION
This does two things:

- Bump the version string to `1.100.0-dev` in `package.json`
- Commits tweaks to `.cirrus.yml` that make it prepare binaries with the version string ending in `0-beta` instead of a date + build number. Leaving this in the commit history as an example of how to do this.
  - Immediately reverts the Cirrus change. Since we won't need it for the ongoing `master` branch builds. Actually, we won't need it at all until we make the next tagged release.

(If that's all too much churn and people want a cleaner history on `master`, then we can drop those last two commits and just have the version bump to `1.100.0-dev` in `package.json`.)

This is in anticipation of the "Beta" tagged version + release we are currently drafting.