### PR TITLE
add style to selected text by default

### DIFF
--- a/packages/base16-tomorrow-dark-theme/styles/editor.less
+++ b/packages/base16-tomorrow-dark-theme/styles/editor.less
@@ -49,10 +49,6 @@ atom-text-editor {
     color: @syntax-cursor-color;
   }
 
-  .selection .region {
-    background-color: @syntax-selection-color;
-  }
-
   .bracket-matcher .region {
     border-color: @syntax-result-marker-color;
   }

--- a/packages/base16-tomorrow-light-theme/styles/editor.less
+++ b/packages/base16-tomorrow-light-theme/styles/editor.less
@@ -49,10 +49,6 @@ atom-text-editor {
     color: @syntax-cursor-color;
   }
 
-  .selection .region {
-    background-color: @syntax-selection-color;
-  }
-
   .bracket-matcher .region {
     border-color: @syntax-result-marker-color;
   }

--- a/static/core-ui/text-editor.less
+++ b/static/core-ui/text-editor.less
@@ -98,6 +98,10 @@ atom-text-editor {
     z-index: -1;
   }
 
+  .selection .region {
+    background-color: @syntax-selection-color;
+  }
+
   .line {
     white-space: pre;
     contain: @contain_except_size;


### PR DESCRIPTION
Add a style for text selections by default. It doesn't make sense that it is not provided by default because a syntax variable is defined for it.