### PR TITLE
add warning when settings-view is disabled

### DIFF
--- a/packages/settings-view/lib/main.js
+++ b/packages/settings-view/lib/main.js
@@ -63,6 +63,7 @@ module.exports = {
     settingsView = null
     packageManager = null
     statusView = null
+    atom.notifications.addWarning("Warning! You have disabled the settings-view package. If you want to enable it again you have to edit the [`config.cson`](https://pulsar-edit.dev/docs/launch-manual/sections/using-pulsar/#global-configuration-settings)");
   },
 
   consumeStatusBar (statusBar) {

--- a/packages/settings-view/lib/main.js
+++ b/packages/settings-view/lib/main.js
@@ -63,7 +63,7 @@ module.exports = {
     settingsView = null
     packageManager = null
     statusView = null
-    atom.notifications.addWarning("Warning! You have disabled the settings-view package. If you want to enable it again you have to edit the [`config.cson`](https://pulsar-edit.dev/docs/launch-manual/sections/using-pulsar/#global-configuration-settings)");
+    atom.notifications.addWarning("Warning! You have disabled the settings-view package. To enable it again, edit the [`config.cson`](https://pulsar-edit.dev/docs/launch-manual/sections/using-pulsar/#global-configuration-settings) by removing the `settings-view` entry from `core: disabled packages:`");
   },
 
   consumeStatusBar (statusBar) {


### PR DESCRIPTION
This adds a warning when the settings-view package is disabled.
It is an idea to fix #203 .
It includes a link to the documentation of the `config.cson` file so that it can be enabled again.