### PR TITLE
rebrand package publish domain

### DIFF
--- a/packages/settings-view/lib/install-panel.js
+++ b/packages/settings-view/lib/install-panel.js
@@ -86,7 +86,7 @@ export default class InstallPanel {
             <div className='text native-key-bindings' tabIndex='-1'>
               <span className='icon icon-question' />
               <span ref='publishedToText'>Packages are published to </span>
-              <a className='link' onclick={this.didClickOpenAtomIo.bind(this)}>pulsar-edit.dev</a>
+              <a className='link' onclick={this.didClickOpenAtomIo.bind(this)}>web.pulsar-edit.dev</a>
               <span> and are installed to {path.join(process.env.ATOM_HOME, 'packages')}</span>
             </div>
 

--- a/packages/settings-view/lib/install-panel.js
+++ b/packages/settings-view/lib/install-panel.js
@@ -86,7 +86,7 @@ export default class InstallPanel {
             <div className='text native-key-bindings' tabIndex='-1'>
               <span className='icon icon-question' />
               <span ref='publishedToText'>Packages are published to </span>
-              <a className='link' onclick={this.didClickOpenAtomIo.bind(this)}>atom.io</a>
+              <a className='link' onclick={this.didClickOpenAtomIo.bind(this)}>pulsar-edit.dev</a>
               <span> and are installed to {path.join(process.env.ATOM_HOME, 'packages')}</span>
             </div>
 


### PR DESCRIPTION
This is a small rebrand in the install tab in the settings-view.
It is only a static rebrand for now. I hope that as soon as pulsar is more stable we can make a really generic branding system.