### PR TITLE
Initial commit of optional hooks + manage_hook script

### DIFF
--- a/hooks/HOW_TO_USE.md
+++ b/hooks/HOW_TO_USE.md
@@ -1,0 +1,22 @@
+### Contents
+| Filename | Description |
+| - | - |
+| post-checkout | This hook executes after a branch checkout, or branch switch has occurred. |
+| post-merge | This hook executes after a branch merge has occurred |
+| update_editor.sh | The actual brains of the hooks. Performs a yarn install, yarn build, yarn build:apm, and syncs all submodules. |
+
+### Usage
+There are several ways to apply these hooks:
+- You can manually copy the files over to the `<pulsar-repo-root>/.git/hooks` folder and validate that they are executable - the effect should be immediate. This is the preferred option for Windows.
+- You can use manage_hooks.sh to copy/symlink the hooks you choose. This is the preferred option for Linux/MacOS.
+  - Your mileage may vary on MacOS as it has not been tested outright, but should work in theory.
+
+### Instructions
+- Open your favorite terminal
+- Navigate to `<pulsar-repo-root>/hooks`.
+  - IMPORTANT: The bash completions will only work within this directory, and are activated when using exactly `./manage-hooks.sh`.
+- If you have bash-completions, source the `manage_hooks-completion.bash` file to allow for auto-complete ie `source manage_hooks-completion.bash`.
+- Allow the auto-complete responses to guide you.
+- Standard commands are `list`, `install` and `remove`
+- The `install` and `remove` commands require the hook you wish to install, followed by an optional parameter for `hardlink` vs `symlink` with symlink being the default.
+  - A symbolically linked hook allows you to receive updates in the future. If you plan on adjusting your hook(s), you probably want to `hardlink` ie copy the files to the `<pulsar-repo-root>/.git/hooks` directory

--- a/hooks/README.md
+++ b/hooks/README.md
@@ -5,6 +5,9 @@
 | post-merge | This hook executes after a branch merge has occurred |
 | update_editor.sh | The actual brains of the hooks. Performs a yarn install, yarn build, yarn build:apm, and syncs all submodules. |
 
+### Disclaimer
+These hooks are not guaranteed. These were made out of convenience and presented to the org as an optional tool for usage.
+
 ### Usage
 There are several ways to apply these hooks:
 - You can manually copy the files over to the `<pulsar-repo-root>/.git/hooks` folder and validate that they are executable - the effect should be immediate. This is the preferred option for Windows.
@@ -18,5 +21,5 @@ There are several ways to apply these hooks:
 - If you have bash-completions, source the `manage_hooks-completion.bash` file to allow for auto-complete ie `source manage_hooks-completion.bash`.
 - Allow the auto-complete responses to guide you.
 - Standard commands are `list`, `install` and `remove`
-- The `install` and `remove` commands require the hook you wish to install, followed by an optional parameter for `hardlink` vs `symlink` with symlink being the default.
-  - A symbolically linked hook allows you to receive updates in the future. If you plan on adjusting your hook(s), you probably want to `hardlink` ie copy the files to the `<pulsar-repo-root>/.git/hooks` directory
+- The `install` and `remove` commands require the hook you wish to install, followed by an optional parameter for `copy` vs `symlink` with symlink being the default.
+  - A symbolically linked hook allows you to receive updates in the future. If you plan on adjusting your hook(s), you probably want to `copy` the files to the `<pulsar-repo-root>/.git/hooks` directory

--- a/hooks/manage_hooks-completion.bash
+++ b/hooks/manage_hooks-completion.bash
@@ -44,10 +44,10 @@ function __completion() {
     3)
       case "${COMP_WORDS[COMP_CWORD-2]}" in
         install)
-          #When attempting to autocomplete for the third parameter ie hardlink
+          #When attempting to autocomplete for the third parameter ie copy
           #/symbolic AND the command is install
           #Generate a list of Words from the provded string
-          COMPREPLY=( $(compgen -W "hardlink symbolic" -- ${cur}) )
+          COMPREPLY=( $(compgen -W "copy symbolic" -- ${cur}) )
           ;;
       esac
       ;;

--- a/hooks/manage_hooks-completion.bash
+++ b/hooks/manage_hooks-completion.bash
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-#Not gonna lie, this is some black magic, but I will try to explain it
+#Not gonna lie, this is some magical stuff, but I will try to explain it
 
 #Automatic variables used by complete
 #COMPREPLY = An array of autocompletions to pass back to the shell

--- a/hooks/manage_hooks-completion.bash
+++ b/hooks/manage_hooks-completion.bash
@@ -1,21 +1,42 @@
 #!/bin/bash
 
+#Not gonna lie, this is some black magic, but I will try to explain it
+
+#Automatic variables used by complete
+#COMPREPLY = An array of autocompletions to pass back to the shell
+#COMP_WORDS = The passed-in list of parameters
+#COMP_CWORD = The index of the current word as related to the count of
+#parameters
+
+#compgen = Generates an array of autocompletions to pass back to the shell
+#based on provided parameters
+
 function __completion() {
   COMPREPLY=()
   cur="${COMP_WORDS[COMP_CWORD]}"
   prev="${COMP_WORDS[COMP_CWORD-1]}"
   opts="list install remove"
 
+  #Determine what "level" of autocomplete we are operating on
+  #1 is no params
+  #2 is 1 param, in this instance the command
+  #3 etc
   case ${COMP_CWORD} in
     1)
+      #Generate a Word-list from opts from the current word
       COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
       ;;
     2)
       case ${prev} in
         install)
+          #Generate a list of filenames (and append "all") based on the current
+          #directory and current word while ignoring select files
           COMPREPLY=( $(compgen -W "all $(ls --ignore='*.md' --ignore='*.sh' --ignore='*.bash')" -- ${cur}) )
           ;;
         remove)
+          #Generate a list of filenames (and append "all") based on the
+          #.git/hooks directory and current word while ignoring the sample
+          #files
           COMPREPLY=( $(compgen -W "all $(ls ../.git/hooks --ignore='*.sample')" -- ${cur}) )
           ;;
       esac
@@ -23,6 +44,9 @@ function __completion() {
     3)
       case "${COMP_WORDS[COMP_CWORD-2]}" in
         install)
+          #When attempting to autocomplete for the third parameter ie hardlink
+          #/symbolic AND the command is install
+          #Generate a list of Words from the provded string
           COMPREPLY=( $(compgen -W "hardlink symbolic" -- ${cur}) )
           ;;
       esac
@@ -30,4 +54,6 @@ function __completion() {
   esac
 }
 
+#Use the function defined above, when an autocomplete event for
+#./manage_hooks.sh is fired. This is why you must be in the proper directory
 complete -F __completion ./manage_hooks.sh

--- a/hooks/manage_hooks-completion.bash
+++ b/hooks/manage_hooks-completion.bash
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+function __completion() {
+  COMPREPLY=()
+  cur="${COMP_WORDS[COMP_CWORD]}"
+  prev="${COMP_WORDS[COMP_CWORD-1]}"
+  opts="list install remove"
+
+  case ${COMP_CWORD} in
+    1)
+      COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
+      ;;
+    2)
+      case ${prev} in
+        install)
+          COMPREPLY=( $(compgen -W "all $(ls --ignore='*.md' --ignore='*.sh' --ignore='*.bash')" -- ${cur}) )
+          ;;
+        remove)
+          COMPREPLY=( $(compgen -W "all $(ls ../.git/hooks --ignore='*.sample')" -- ${cur}) )
+          ;;
+      esac
+      ;;
+    3)
+      case "${COMP_WORDS[COMP_CWORD-2]}" in
+        install)
+          COMPREPLY=( $(compgen -W "hardlink symbolic" -- ${cur}) )
+          ;;
+      esac
+      ;;
+  esac
+}
+
+complete -F __completion ./manage_hooks.sh

--- a/hooks/manage_hooks.sh
+++ b/hooks/manage_hooks.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+
+cd "$(dirname "$(readlink -f "$0")")"
+
+USAGEMSG="Usage: manage_hooks <action> <hook> <option>"
+
+if [[ $# -lt 1 ]] || [[ $# -gt 3 ]]; then
+  echo "$USAGEMSG"
+  exit 1
+fi
+
+action="$1"
+
+case $1 in
+  list)
+    ls --color=if-tty -l ../.git/hooks --ignore='*.sample'
+    ;;
+  install)
+    if [[ "$2" == "all" ]]; then
+      hooks=( $(readlink -f $(ls --ignore='*.md' --ignore='*.sh' --ignore='*.bash')) )
+    else
+      hooks=( $(readlink -f "$2") )
+    fi
+
+    if [[ -z $3 ]]; then
+      option="symbolic"
+    else
+      option="$3"
+    fi
+
+    case $option in
+      hardlink)
+        hooks+=( "$(readlink -f "update_editor.sh")" "${hooks[@]}" )
+        for hook in "${hooks[@]}"; do
+          if [[ ! -f "../.git/hooks/$(basename "$hook")" ]]; then
+            echo "$hook"
+            cp "$hook" "../.git/hooks"
+          fi
+        done
+        ;;
+      symbolic)
+        cd "../.git/hooks"
+        for hook in "${hooks[@]}"; do
+          if [[ ! -f "$(basename $hook)" ]]; then
+            echo "$(readlink -f .)/$(basename $hook)"
+            ln --symbolic --relative "../../hooks/$(basename "$hook")"
+          fi
+        done
+        ;;
+    esac
+    ;;
+  remove)
+    cd "../.git/hooks"
+    if [[ "$2" == "all" ]]; then
+      hooks=( $(realpath --no-symlinks $(ls --ignore='*.sample' --ignore='*.sh')) )
+    else
+      hooks=( $(realpath --no-symlinks "$2") )
+    fi
+
+    for hook in "${hooks[@]}"; do
+      echo "$hook"
+      rm "$hook"
+    done
+    ;;
+  *)
+    echo "$USAGEMSG"
+    exit 1
+    ;;
+esac

--- a/hooks/manage_hooks.sh
+++ b/hooks/manage_hooks.sh
@@ -31,8 +31,8 @@ case $1 in
     fi
 
     case $option in
-      hardlink)
-        #If hardlinking, copy the update_editor file as well
+      copy)
+        #If copying, copy the update_editor file as well
         hooks+=( "$(readlink -f "update_editor.sh")" "${hooks[@]}" )
 
         for hook in "${hooks[@]}"; do

--- a/hooks/manage_hooks.sh
+++ b/hooks/manage_hooks.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-cd "$(dirname "$(readlink -f "$0")")"
-
 USAGEMSG="Usage: manage_hooks <action> <hook> <option>"
 
 if [[ $# -lt 1 ]] || [[ $# -gt 3 ]]; then
@@ -15,13 +13,17 @@ case $1 in
   list)
     ls --color=if-tty -l ../.git/hooks --ignore='*.sample'
     ;;
+
   install)
+    #Grab our list of files if all was passed.
+    #Couldn't get * to function without globbing
     if [[ "$2" == "all" ]]; then
       hooks=( $(readlink -f $(ls --ignore='*.md' --ignore='*.sh' --ignore='*.bash')) )
     else
       hooks=( $(readlink -f "$2") )
     fi
 
+    #Default to symbolic
     if [[ -z $3 ]]; then
       option="symbolic"
     else
@@ -30,17 +32,25 @@ case $1 in
 
     case $option in
       hardlink)
+        #If hardlinking, copy the update_editor file as well
         hooks+=( "$(readlink -f "update_editor.sh")" "${hooks[@]}" )
+
         for hook in "${hooks[@]}"; do
+          #If the file doesnt already exist copy it over
           if [[ ! -f "../.git/hooks/$(basename "$hook")" ]]; then
             echo "$hook"
             cp "$hook" "../.git/hooks"
           fi
         done
         ;;
+
       symbolic)
+        #Switch to the git hook directory, because symlink hooks are required
+        #to be relative
         cd "../.git/hooks"
+
         for hook in "${hooks[@]}"; do
+          #If the file doesnt already exist, symlink it
           if [[ ! -f "$(basename $hook)" ]]; then
             echo "$(readlink -f .)/$(basename $hook)"
             ln --symbolic --relative "../../hooks/$(basename "$hook")"
@@ -50,7 +60,11 @@ case $1 in
     esac
     ;;
   remove)
+    #Switch to the git hook directory, so we dont have to deal with
+    #relative file paths
     cd "../.git/hooks"
+
+    #Grab the canonical path to the file, readlink always follows symlinks
     if [[ "$2" == "all" ]]; then
       hooks=( $(realpath --no-symlinks $(ls --ignore='*.sample' --ignore='*.sh')) )
     else

--- a/hooks/post-checkout
+++ b/hooks/post-checkout
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+#This hook launches after a branch change, or branch checkout. It cannot affect
+#the outcome of a git switch or git checkout with the exception that the hook
+#exit status becomes the exit status of the antecedent command
+#See https://git-scm.com/docs/githooks#_post_checkout
+
+if [[ -L "$0" ]]; then
+    #If our launched script is a link, grab the root
+    hookRoot="$(dirname $(readlink --canonicalize "$0"))"
+else
+    #Otherwise use the launched script directory
+    hookRoot="$(dirname "$0")"
+fi
+
+if [[ "$1" == "$2" ]]; then
+    #Previous HEAD and new HEAD are the same, ignore
+    exit 0
+fi
+
+if [[ "$3" == '1' ]]; then
+    #A branch checkout will always be flagged as 1, and a file checkout as 0
+    "${hookRoot}/update_editor.sh" $0
+fi

--- a/hooks/post-merge
+++ b/hooks/post-merge
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+#This hook launches after a git pull. It cannot affect a git merge, and will not
+#be executed if a merge fails
+#See https://git-scm.com/docs/githooks#_post_merge
+
+if [[ -L "$0" ]]; then
+    #If our launched script is a link, grab the root
+    hookRoot="$(dirname $(readlink --canonicalize $0))"
+else
+    #Otherwise use the launched script directory
+    hookRoot="$(dirname "$0")"
+fi
+
+"${hookRoot}/update_editor.sh" $0

--- a/hooks/update_editor.sh
+++ b/hooks/update_editor.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+case $1 in
+    *post-checkout)
+        ACTION='Branch change'
+        ;;
+    *post-merge)
+        ACTION='Remote pull'
+        ;;
+    *)
+        ACTION="Unknown event ($1)"
+        ;;
+esac
+
+echo "${ACTION} occurred, rebuilding editor"
+
+export ATOM_ELECTRON_VERSION=$(cat package.json | rg --trim --replace "" '"electronVersion": "' | rg --replace "" '",')
+
+replacement="1.100.$(date +'%Y%m%d%H%k%M')"
+filter='("version": ")[0-9\.]+(",)'
+regex="s/$filter/\1$replacement\2/"
+
+sed --regexp-extended --in-place "$regex" package.json
+
+echo '  Installing editor packages'
+yarn install &> /dev/null
+if [[ $? == 0 ]]; then
+    echo '    Install completed successfully'
+else
+    echo '    Install failed'
+    exit 1
+fi
+
+echo '  Rebuilding modules'
+yarn build &> /dev/null
+if [[ $? == 0 ]]; then
+    echo '    Module build completed successfully'
+else
+    echo '    Module build failed'
+    exit 1
+fi
+
+echo '  Rebuilding PPM'
+if [[ -d "ppm" ]]; then
+    yarn build:apm &> /dev/null
+    if [[ $? == 0 ]]; then
+        echo '    PPM build completed successfully'
+    else
+        echo '    PPM build failed'
+        exit 1
+    fi
+else
+    echo '    PPM folder not found'
+fi
+
+git submodule sync && git submodule update


### PR DESCRIPTION
Two hooks are available at the moment: post-checkout and post-merge.

- post-checkout fires when the branch changes, or when you checkout a new branch
- post-merge fires when you merge a branch into your existing branch

HOW_TO_USE.md contains some generic information on how to use `manage_hooks.sh`

`manage_hooks.sh` needs to be tested on MacOS, and also needs to be tested more thoroughly on other Linux builds

`update_editor.sh` is the actual brain. the post-* files are simply wrappers around update_editor.sh because of [Don't Repeat Yourself](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself)