### PR TITLE
:apple: Fix wrong app name resolution in `pulsar.sh` on Mac

### DIFF
--- a/pulsar.sh
+++ b/pulsar.sh
@@ -78,7 +78,11 @@ if [ $OS == 'Mac' ]; then
   else
     SCRIPT="$0"
   fi
-  ATOM_APP="$(dirname "$(dirname "$(dirname "$(dirname "$SCRIPT")")")")"
+
+  # NOTE: We may have to check macos versions for backwards compatibility
+  # ATOM_APP="$(dirname $(dirname "$(dirname "$(dirname "$SCRIPT")")")")"
+  ATOM_APP="$(dirname "$(dirname "$(dirname "$SCRIPT")")")"
+
   if [ "$ATOM_APP" == . ]; then
     unset ATOM_APP
   else
@@ -121,7 +125,7 @@ if [ $OS == 'Mac' ]; then
       exit ${ATOM_EXIT}
     fi
   else
-    open -a "$PULSAR_PATH/$ATOM_APP_NAME" -n --args --executed-from="$(pwd)" --pid=$$ --path-environment="$PATH" "$@"
+    open -a "$PULSAR_PATH/$ATOM_APP_NAME" -n -g --args --executed-from="$(pwd)" --pid=$$ --path-environment="$PATH" "$@"
   fi
 elif [ $OS == 'Linux' ]; then
   SCRIPT=$(readlink -f "$0")

--- a/pulsar.sh
+++ b/pulsar.sh
@@ -79,8 +79,6 @@ if [ $OS == 'Mac' ]; then
     SCRIPT="$0"
   fi
 
-  # NOTE: We may have to check macos versions for backwards compatibility
-  # ATOM_APP="$(dirname $(dirname "$(dirname "$(dirname "$SCRIPT")")")")"
   ATOM_APP="$(dirname "$(dirname "$(dirname "$SCRIPT")")")"
 
   if [ "$ATOM_APP" == . ]; then


### PR DESCRIPTION
Aims to fix #251. On the attempt to open Pulsar using the script it would error out with:
```
The application //Applications cannot be opened for an unexpected reason,
error=Error Domain=NSOSStatusErrorDomain Code=-10827 "kLSNoExecutableErr: 
The executable is missing" UserInfo={_LSLine=4101, _LSFunction=_LSOpenStuffCallLocal}
``` 
This error is reported by `open`.

The script was changed to only perform 3 instead of 4 `dirname` calls which enables the script to resolve the correct app name. It is unknown whether or not the issue is exclusive to Ventura because it seems like it has worked before. We may have to include MacOS version checks to maintain backwards compatibility.

Additionally, the `open` call now includes the `-g` flag. Not using the `-g` flag would cause MacOS (maybe exclusive to Ventura too?) to select a random app and (re-)focus it before Pulsar is even visible. It is now starting in the background without claiming focus.