### PR TITLE
Add `--no-sandbox` to Linux Launch

### DIFF
--- a/pulsar.sh
+++ b/pulsar.sh
@@ -149,7 +149,7 @@ elif [ $OS == 'Linux' ]; then
   [ -x "$PULSAR_PATH" ] || PULSAR_PATH="$TMPDIR/pulsar-build/Pulsar/pulsar"
 
   if [ $EXPECT_OUTPUT ]; then
-    "$PULSAR_PATH" --executed-from="$(pwd)" --pid=$$ "$@"
+    "$PULSAR_PATH" --executed-from="$(pwd)" --pid=$$ "$@" --no-sandbox
     ATOM_EXIT=$?
     if [ ${ATOM_EXIT} -eq 0 ] && [ -n "${EXIT_CODE_OVERRIDE}" ]; then
       exit "${EXIT_CODE_OVERRIDE}"
@@ -158,7 +158,7 @@ elif [ $OS == 'Linux' ]; then
     fi
   else
     (
-    nohup "$PULSAR_PATH" --executed-from="$(pwd)" --pid=$$ "$@" > "$ATOM_HOME/nohup.out" 2>&1
+    nohup "$PULSAR_PATH" --executed-from="$(pwd)" --pid=$$ "$@" --no-sandbox > "$ATOM_HOME/nohup.out" 2>&1
     if [ $? -ne 0 ]; then
       cat "$ATOM_HOME/nohup.out"
       exit $?


### PR DESCRIPTION
While I know there were talks about properly detecting what Linux Graphic Drivers were in use, and much more elegant solutions to this problem.

But realistically as those haven't been done yet, I feel it's likely in our best interest to find a solution to this problem rather than the perfect one.

That is until someone can come along and do this much more properly, which I highly implore anyone else to.

But otherwise this change will likely resolve the following:

* PR #260 
* PR #205
* PR #174 
* PR #199 