### PR TITLE
Fix installing shell commands to path (macOS)

### DIFF
--- a/src/command-installer.js
+++ b/src/command-installer.js
@@ -60,7 +60,7 @@ module.exports = class CommandInstaller {
 
   installAtomCommand(askForPrivilege, callback) {
     this.installCommand(
-      path.join(this.getResourcesDirectory(), 'app', 'pulsar.sh'),
+      path.join(this.getResourcesDirectory(), 'pulsar.sh'),
       this.getCommandNameForChannel('pulsar'),
       askForPrivilege,
       callback
@@ -72,9 +72,8 @@ module.exports = class CommandInstaller {
       path.join(
         this.getResourcesDirectory(),
         'app',
-        'apm',
-        'node_modules',
-        '.bin',
+        'ppm',
+        'bin',
         'apm'
       ),
       this.getCommandNameForChannel('apm'),

--- a/src/command-installer.js
+++ b/src/command-installer.js
@@ -61,7 +61,7 @@ module.exports = class CommandInstaller {
   installAtomCommand(askForPrivilege, callback) {
     this.installCommand(
       path.join(this.getResourcesDirectory(), 'pulsar.sh'),
-      this.getCommandNameForChannel('pulsar'),
+      'pulsar',
       askForPrivilege,
       callback
     );
@@ -76,7 +76,7 @@ module.exports = class CommandInstaller {
         'bin',
         'apm'
       ),
-      this.getCommandNameForChannel('apm'),
+      'ppm',
       askForPrivilege,
       callback
     );


### PR DESCRIPTION
<details><summary><b>Requirements for Contributing a Bug Fix</b> (click to expand):</summary>

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* The pull request must only fix an existing bug. To contribute other changes, you must use a different template. You can see all templates at <https://github.com/atom/.github/tree/master/.github/PULL_REQUEST_TEMPLATE>.
* The pull request must update the test suite to demonstrate the changed functionality. For guidance, please see <https://flight-manual.atom.io/hacking-atom/sections/writing-specs/>.
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution. For more details, please see <https://github.com/atom/.github/tree/master/CONTRIBUTING.md#pull-requests>.

</details>

### Identify the Bug

<!--

Link to the issue describing the bug that you're fixing.

If there is not yet an issue for your bug, please open a new issue and then link to that issue in your pull request.
Note: In some cases, one person's "bug" is another person's "feature." If the pull request does not address an existing issue with the "bug" label, the maintainers have the final say on whether the current behavior is a bug.

-->

Fixes https://github.com/pulsar-edit/pulsar/issues/251 (Part 2)

(Also, note: this is a follow-up to/companion PR to https://github.com/pulsar-edit/pulsar/pull/252)

### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

- Fixes the target paths that we create symlinks to for `pulsar` and `ppm` on the PATH (see #251 for context)
- Updates the previously `apm` symlink name to be a `ppm` symlink, since we want users to be able to run `ppm`, not `apm`. Side benefit: doesn't clobber the valid `apm` symlink users may still have for a parallel Atom install.
- Updates the logic to only make a `pulsar` and `ppm` symlink, not `pulsar-beta` or `pulsar-nightly`, `apm-beta`, etc. symlink, since we actually don't support parallel installs of multiple channels of Pulsar at the moment, and changing the symlink name we create based on the version string/"release channel" would just lead to multiple different symlinks pointing to the same install on disk... We don't effectively have full-fledged "release channels" at the moment, just different version strings and maybe accidentally-activated cosmetic differences. This logic was left-over from the old Atom build scripts and their more involved handling of "release channels".

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

I guess we could delete that now-unused function that constructed the "release channel" names for symlinks based on the "release channel" gleamed from the version string, e.g. `pulsar-beta` or `pulsar-nightly`, `apm-beta`... Or we could re-create the "Release Channels" setup in our CI logic like Atom had...

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

None anticipated, this was creating symlinks to nowhere before. It should be working as intended now.

### Verification Process

<!--

What process did you follow to verify that the change has not introduced any regressions? Describe the actions you performed (including buttons you clicked, text you typed, commands you ran, etc.), and describe the results you observed.

-->

This was just done by confirming where the actual binaries are located on disk, after installing Pulsar from Cirrus DMG on macOS, and verifying in the Dev Tools that the JS logic produces those correct paths.

- **TODO**: Test a Pulsar binary with this PR and https://github.com/pulsar-edit/pulsar/pull/252 merged, with no symlinks before testing. Do `Cmd + Shift + P` --> "Window: Install Shell Commands". (Or "Pulsar" menu in the global menu bar --> "Install Shell Commands").
  - Should be able to confirm that the symlinks point to the real binaries on disk (per this PR),
  - and that the launcher shell script works correctly (per https://github.com/pulsar-edit/pulsar/pull/252).

Note: On a quick look, I couldn't see anywhere this command can be invoked on Linux. It is specifically defined in `menus/darwin.cson`. So, I believe testing on Linux and Windows should be unnecessary, but the logic looks about right on Linux as well.

### Release Notes

<!--

Please describe the changes in a single line that explains this improvement in
terms that a user can understand. This text will be used in Atom's release notes.

If this change is not user-facing or notable enough to be included in release notes
you may use the strings "Not applicable" or "N/A" here.

Examples:

- The GitHub package now allows you to add co-authors to commits.
- Fixed an issue where multiple cursors did not work in a file with a single line.
- Increased the performance of searching and replacing across a whole project.

-->

Fix the "Install Shell Commands" command on macOS