### PR TITLE
exclude directories from build

### DIFF
--- a/script/electron-builder.js
+++ b/script/electron-builder.js
@@ -72,6 +72,8 @@ let options = {
     "!keymaps/",
     "!menus/",
     "!script/",
+    "!integration/",
+    "!hooks/",
 
     // Git Related Exclusions
     "!**/{.git,.gitignore,.gitattributes,.git-keep,.github}",


### PR DESCRIPTION
This excludes the `hooks` and `integration` directory from the build.