### PR TITLE
Fix install on packaged code

### DIFF
--- a/pulsar.sh
+++ b/pulsar.sh
@@ -16,7 +16,7 @@ ATOM_ADD=false
 ATOM_NEW_WINDOW=false
 EXIT_CODE_OVERRIDE=
 
-while getopts ":anwtfvh-:" opt; do
+while getopts ":anwtfvhp-:" opt; do
   case "$opt" in
     -)
       case "${OPTARG}" in
@@ -30,10 +30,9 @@ while getopts ":anwtfvh-:" opt; do
           WAIT=1
           ;;
         help|version)
-          REDIRECT_STDERR=1
           EXPECT_OUTPUT=1
           ;;
-        foreground|benchmark|benchmark-test|test)
+        foreground|benchmark|benchmark-test|test|package)
           EXPECT_OUTPUT=1
           ;;
         enable-electron-logging)
@@ -50,11 +49,7 @@ while getopts ":anwtfvh-:" opt; do
     w)
       WAIT=1
       ;;
-    h|v)
-      REDIRECT_STDERR=1
-      EXPECT_OUTPUT=1
-      ;;
-    f|t)
+    f|t|h|v|p)
       EXPECT_OUTPUT=1
       ;;
   esac

--- a/src/main-process/parse-command-line.js
+++ b/src/main-process/parse-command-line.js
@@ -149,7 +149,12 @@ module.exports = function parseCommandLine(processArgs) {
     const PackageManager = require('../package-manager');
     const cp = require('child_process');
     const ppmPath = PackageManager.possibleApmPaths();
-    const ppmArgs = args['_'];
+
+    let ppmArgs = [...processArgs]
+    while(true) {
+      const arg = ppmArgs.shift()
+      if(arg === '-p' || arg === '--package' || ppmArgs.length === 0) break;
+    }
     const exitCode = cp.spawnSync(ppmPath, ppmArgs, {stdio: 'inherit'}).status;
     process.exit(exitCode);
     return;


### PR DESCRIPTION
When we generate a binary with `electron-builder` or other tool, the argument parser gets weird and we lose the ability to detect that, after `install <git-package>` we have a `-t` that needs to be sent to `ppm`, etc.

This PR fixes this.