### PR TITLE
Add --no-sandbox to start script

### DIFF
--- a/package.json
+++ b/package.json
@@ -272,7 +272,7 @@
     "preinstall": "node -e 'process.exit(0)'",
     "build": "electron-rebuild",
     "build:apm": "cd ppm && yarn install",
-    "start": "electron --enable-logging . -f",
+    "start": "electron --no-sandbox --enable-logging . -f",
     "dist": "node script/electron-builder.js"
   },
   "devDependencies": {


### PR DESCRIPTION
This PR might come from ignorance in which case please tell me but essentially this forces the `--no-sandbox` option to always be used when calling `yarn start` as this has been causing no end of problems with dev tools not opening or people being unable to start Pulsar in a vm.

Alternatively we could create a new script e.g.
`"startns": ...` which has the option in it if editing the main start script is a no go.

It also means we don't need to put this into the build instructions which makes it just look like a cludge that might not always be needed, this removes the ambiguity.
