### PR TITLE
Improve MacOS Builds

### DIFF
--- a/script/electron-builder.js
+++ b/script/electron-builder.js
@@ -2,6 +2,7 @@ const path = require('path')
 const normalizePackageData = require('normalize-package-data');
 const fs = require("fs/promises");
 const generateMetadata = require('./generate-metadata-for-builder')
+const macBundleDocumentTypes = require("./mac-bundle-document-types.js");
 
 // Monkey-patch to not remove things I explicitly didn't say so
 // See: https://github.com/electron-userland/electron-builder/issues/6957
@@ -43,7 +44,7 @@ const pngIcon = 'resources/app-icons/beta.png'
 const icoIcon = 'resources/app-icons/beta.ico'
 
 let options = {
-  "appId": "com.pulsar-edit.pulsar",
+  "appId": "dev.pulsar-edit.pulsar",
   "npmRebuild": false,
   "publish": null,
   files: [
@@ -162,14 +163,10 @@ let options = {
     "extendInfo": {
       // This contains extra values that will be inserted into the App's plist
       "CFBundleExecutable": "Pulsar",
-      "CFBundleIdentifier": "dev.pulsar-edit.pulsar",
       "NSAppleScriptEnabled": "YES",
       "NSMainNibFile": "MainMenu",
       "NSRequiresAquaSystemAppearance": "NO",
-      "CFBundleDocumentTypes": [
-        { "CFBundleTypeExtensions": [ "adb", "ads" ] },
-        { "CFBundleTypeIconFile": "file.icns" }
-      ]
+      "CFBundleDocumentTypes": macBundleDocumentTypes.create()
     },
   },
   "win": {

--- a/script/electron-builder.js
+++ b/script/electron-builder.js
@@ -166,7 +166,11 @@ let options = {
       "NSAppleScriptEnabled": "YES",
       "NSMainNibFile": "MainMenu",
       "NSRequiresAquaSystemAppearance": "NO",
-      "CFBundleDocumentTypes": macBundleDocumentTypes.create()
+      "CFBundleDocumentTypes": macBundleDocumentTypes.create(),
+      "CFBundleURLTypes": [
+        { "CFBundleURLSchemes": [ "atom" ] },
+        {"CFBundleURLName": "Atom Shared Session Protocol" }
+      ]
     },
   },
   "win": {

--- a/script/electron-builder.js
+++ b/script/electron-builder.js
@@ -159,14 +159,18 @@ let options = {
     "icon": pngIcon,
     "category": "public.app-category.developer-tools",
     "minimumSystemVersion": "10.8",
-    "extendInfo": [
+    "extendInfo": {
       // This contains extra values that will be inserted into the App's plist
-      { "CFBundleExecutable": "Pulsar" },
-      { "CFBundleIdentifier": "dev.pulsar-edit.pulsar" },
-      { "NSAppleScriptEnabled": "YES" },
-      { "NSMainNibFile": "MainMenu" },
-      { "NSRequiresAquaSystemAppearance": "NO" },
-    ]
+      "CFBundleExecutable": "Pulsar",
+      "CFBundleIdentifier": "dev.pulsar-edit.pulsar",
+      "NSAppleScriptEnabled": "YES",
+      "NSMainNibFile": "MainMenu",
+      "NSRequiresAquaSystemAppearance": "NO",
+      "CFBundleDocumentTypes": [
+        { "CFBundleTypeExtensions": [ "adb", "ads" ] },
+        { "CFBundleTypeIconFile": "file.icns" }
+      ]
+    },
   },
   "win": {
     "icon": icoIcon,

--- a/script/electron-builder.js
+++ b/script/electron-builder.js
@@ -157,7 +157,16 @@ let options = {
   },
   "mac": {
     "icon": pngIcon,
-    "category": "Development"
+    "category": "public.app-category.developer-tools",
+    "minimumSystemVersion": "10.8",
+    "extendInfo": [
+      // This contains extra values that will be inserted into the App's plist
+      { "CFBundleExecutable": "Pulsar" },
+      { "CFBundleIdentifier": "dev.pulsar-edit.pulsar" },
+      { "NSAppleScriptEnabled": "YES" },
+      { "NSMainNibFile": "MainMenu" },
+      { "NSRequiresAquaSystemAppearance": "NO" },
+    ]
   },
   "win": {
     "icon": icoIcon,

--- a/script/mac-bundle-document-types.js
+++ b/script/mac-bundle-document-types.js
@@ -418,7 +418,7 @@ const docs = [
     "name": "Source"
   },
   {
-    "ext": [ "cfm", "cfml", "dbm", "dist", "dot", "ics", "ifb", "dwt", "g", "in" "l", "m4", "mp", "mtml", "orig", "pde", "rej", "servlet", "s5", "tmp", "tpl", "tt", "xql", "yy", "*" ],
+    "ext": [ "cfm", "cfml", "dbm", "dist", "dot", "ics", "ifb", "dwt", "g", "in", "l", "m4", "mp", "mtml", "orig", "pde", "rej", "servlet", "s5", "tmp", "tpl", "tt", "xql", "yy", "*" ],
     "name": "Document"
   },
   {
@@ -427,7 +427,7 @@ const docs = [
     "LSItemContentTypes": [ "public.data" ]
   },
   {
-    // Adds Folder Support 
+    // Adds Folder Support
     "LSItemContentTypes": [ "public.directory", "com.apple.bundle", "com.apple.resolvable" ]
   }
 ];

--- a/script/mac-bundle-document-types.js
+++ b/script/mac-bundle-document-types.js
@@ -1,0 +1,474 @@
+/**
+  The MacOS configuration MUST be passed this exact object structure in order to
+  build the plist file as expected and accepted.
+  mac.extendInfo.CFBundleDocumentTypes is a plist entry that MUST receive an array.
+
+  This array then accepts objects of the below values, with the required configuration.
+  Since the majority of the file repeats itself we can use the below create() builder
+  to minimize file size, and changes that must occur if we ever want to add additional
+  values or replace existing values.
+
+  But I do not recommend changing the structure of the object without careful testing.
+
+  The Extensions and Names of the files have all been taken from a Known working
+  configuration of Atom's plist that was included with the MacOS build.
+
+  But as we now build this for ourselves we will take advantage of our new methods
+  and ensure we use the wins electron-builder provides by staying on platform.
+
+  @see https://github.com/atom/atom/blob/master/resources/mac/atom-Info.plist
+*/
+
+/**
+  When creating this document the syntax is as follows:
+
+  `ext` - An array of file extensions to identify, each being a string
+          This value is optional, but in most cases will be needed.
+
+  `name` - A string of the friendly file name.
+           This value is optional, but generally should have a name unless relating to bundles or folders.
+
+  Then if needed some additional types are available:
+    * "CFBundleTypeMIMETypes" - An array of strings, containing the MIME type of the file.
+    * "CFBundleTypeOSTypes" - An array of Strings, for the OS types of the file.
+    * "LSItemContentTypes" - An array of Strings
+*/
+
+const docs = [
+  {
+    "ext": [ "adb", "ads" ],
+    "name": "ADA source"
+  },
+  {
+    "ext": [ "scpt" ],
+    "name": "Compile AppleScript"
+  },
+  {
+    "ext": [ "applescript" ],
+    "name": "AppleScript source"
+  },
+  {
+    "ext": [ "as" ],
+    "name": "ActionScript source"
+  },
+  {
+    "ext": [ "asp", "asa" ],
+    "name": "ASP document"
+  },
+  {
+    "ext": [ "aspx", "ascx", "asmx", "ashx" ],
+    "name": "ASP.NET document"
+  },
+  {
+    "ext": [ "bib" ],
+    "name": "BibTeX bibliography"
+  },
+  {
+    "ext": [ "c" ],
+    "name": "C source"
+  },
+  {
+    "ext": [ "cc", "cp", "cpp", "cxx", "c++" ],
+    "name": "C++ source"
+  },
+  {
+    "ext": [ "cs" ],
+    "name": "C# source"
+  },
+  {
+    "ext": [ "coffee" ],
+    "name": "CoffeeScript source"
+  },
+  {
+    "ext": [ "COMMIT_EDITMSG" ],
+    "name": "Commit message"
+  },
+  {
+    "ext": [ "cfdg" ],
+    "name": "Context Free Design Grammar"
+  },
+  {
+    "ext": [ "clj", "cljs" ],
+    "name": "Clojure source"
+  },
+  {
+    "ext": [ "csv" ],
+    "name": "Comma separated values"
+  },
+  {
+    "ext": [ "tsv" ],
+    "name": "Tab separated values"
+  },
+  {
+    "ext": [ "cgi", "fcgi" ],
+    "name": "CGI script"
+  },
+  {
+    "ext": [ "cfg", "conf", "config", "htaccess" ],
+    "name": "Configuration file"
+  },
+  {
+    "ext": [ "css" ],
+    "name": "Cascading style sheet"
+  },
+  {
+    "ext": [ "diff" ],
+    "name": "Differences file"
+  },
+  {
+    "ext": [ "dtd" ],
+    "name": "Document Type Definition"
+  },
+  {
+    "ext": [ "dylan" ],
+    "name": "Dylan source"
+  },
+  {
+    "ext": [ "erl", "hrl" ],
+    "name": "Erlang source"
+  },
+  {
+    "ext": [ "fscript" ],
+    "name": "F-Script source"
+  },
+  {
+    "ext": [ "f", "for", "fpp", "f77", "f90", "f95" ],
+    "name": "Fortran source"
+  },
+  {
+    "ext": [ "h", "pch" ],
+    "name": "Header"
+  },
+  {
+    "ext": [ "hh", "hpp", "hxx", "h++" ],
+    "name": "C++ header"
+  },
+  {
+    "ext": [ "go" ],
+    "name": "Go source"
+  },
+  {
+    "ext": [ "gtd", "gtdlog" ],
+    "name": "GTD document"
+  },
+  {
+    "ext": [ "h", "hls" ],
+    "name": "Haskell source"
+  },
+  {
+    "ext": [ "htm", "html", "phtml", "shtml" ],
+    "name": "HTML document"
+  },
+  {
+    "ext": [ "inc" ],
+    "name": "Include file"
+  },
+  {
+    "ext": [ "ics" ],
+    "name": "iCalendar schedule"
+  },
+  {
+    "ext": [ "ini" ],
+    "name": "MS Windows initialization file"
+  },
+  {
+    "ext": [ "io" ],
+    "name": "Io source"
+  },
+  {
+    "ext": [ "java" ],
+    "name": "Java source"
+  },
+  {
+    "ext": [ "bsh" ],
+    "name": "BeanShell script"
+  },
+  {
+    "ext": [ "properties" ],
+    "name": "Java properties file"
+  },
+  {
+    "ext": [ "js", "htc" ],
+    "name": "JavaScript source"
+  },
+  {
+    "ext": [ "jsp" ],
+    "name": "Java Server Page"
+  },
+  {
+    "ext": [ "json" ],
+    "name": "JSON file"
+  },
+  {
+    "ext": [ "ldif" ],
+    "name": "LDAP Data Interchange Format"
+  },
+  {
+    "ext": [ "less" ],
+    "name": "Less source"
+  },
+  {
+    "ext": [ "lisp", "cl", "l", "lsp", "mud", "el" ],
+    "name": "Lisp source"
+  },
+  {
+    "ext": [ "log" ],
+    "name": "Log file"
+  },
+  {
+    "ext": [ "logo" ],
+    "name": "Logo source"
+  },
+  {
+    "ext": [ "lua" ],
+    "name": "Lua source"
+  },
+  {
+    "ext": [ "markdown", "mdown", "markdn", "md" ],
+    "name": "Markdown document"
+  },
+  {
+    "ext": [ "mk" ],
+    "name": "Makefile source"
+  },
+  {
+    "ext": [ "wiki", "wikipedia", "mediawiki" ],
+    "name": "Mediawiki document"
+  },
+  {
+    "ext": [ "s", "mips", "spim", "asm" ],
+    "name": "MIPS assembler source"
+  },
+  {
+    "ext": [ "m3", "cm3" ],
+    "name": "Modula-3 source"
+  },
+  {
+    "ext": [ "moinmoin" ],
+    "name": "MoinMoin document"
+  },
+  {
+    "ext": [ "m" ],
+    "name": "Objective-C source"
+  },
+  {
+    "ext": [ "mm" ],
+    "name": "Objective-C++ source"
+  },
+  {
+    "ext": [ "ml", "mli", "mll", "mly" ],
+    "name": "OCaml source"
+  },
+  {
+    "ext": [ "mustache", "hbs" ],
+    "name": "Mustache document"
+  },
+  {
+    "ext": [ "pas", "p" ],
+    "name": "Pascal source"
+  },
+  {
+    "ext": [ "patch" ],
+    "name": "Patch file"
+  },
+  {
+    "ext": [ "pl", "pod", "perl" ],
+    "name": "Perl source"
+  },
+  {
+    "ext": [ "pm" ],
+    "name": "Perl module"
+  },
+  {
+    "ext": [ "php", "php3", "php4", "php5" ],
+    "name": "PHP source"
+  },
+  {
+    "ext": [ "ps", "eps" ],
+    "name": "PostScript source"
+  },
+  {
+    "ext": [ "dict", "plist", "scriptSuite", "scriptTerminology" ],
+    "name": "Property list"
+  },
+  {
+    "ext": [ "py", "rpy", "cpy", "python" ],
+    "name": "Python source"
+  },
+  {
+    "ext": [ "r", "s" ],
+    "name": "R source"
+  },
+  {
+    "ext": [ "rl", "ragel" ],
+    "name": "Ragel source"
+  },
+  {
+    "ext": [ "rem", "remind" ],
+    "name": "Remind document"
+  },
+  {
+    "ext": [ "rst", "rest" ],
+    "name": "reStructuredText document"
+  },
+  {
+    "ext": [ "rhtml", "erb" ],
+    "name": "HTML with embedded Ruby"
+  },
+  {
+    "ext": [ "erbsql" ],
+    "name": "SQL with embedded Ruby"
+  },
+  {
+    "ext": [ "rb", "rbx", "rjs", "rxml" ],
+    "name": "Ruby source"
+  },
+  {
+    "ext": [ "sass", "scss" ],
+    "name": "Sass source"
+  },
+  {
+    "ext": [ "scm", "sch" ],
+    "name": "Scheme source"
+  },
+  {
+    "ext": [ "ext" ],
+    "name": "Setext document"
+  },
+  {
+    "ext": [ "sh", "ss", "bashrc", "bash_profile", "bash_login", "profile", "bash_logout" ],
+    "name": "Shell script"
+  },
+  {
+    "ext": [ "slate" ],
+    "name": "Slate source"
+  },
+  {
+    "ext": [ "sql" ],
+    "name": "SQL source"
+  },
+  {
+    "ext": [ "sml" ],
+    "name": "Standard ML source"
+  },
+  {
+    "ext": [ "strings" ],
+    "name": "Strings document"
+  },
+  {
+    "ext": [ "svg" ],
+    "name": "Scalable vector graphics"
+  },
+  {
+    "ext": [ "i", "swg" ],
+    "name": "SWIG source"
+  },
+  {
+    "ext": [ "tcl" ],
+    "name": "Tcl source"
+  },
+  {
+    "ext": [ "tex", "sty", "cls" ],
+    "name": "TeX document"
+  },
+  {
+    "ext": [ "text", "txt", "utf8" ],
+    "name": "Plain text document",
+    "CFBundleTypeMIMETypes": [ "text/plain" ],
+    "CFBundleTypeOSTypes": [ "TEXT", "sEXT", "ttro" ]
+  },
+  {
+    "ext": [ "textile" ],
+    "name": "Textile document"
+  },
+  {
+    "ext": [ "toml" ],
+    "name": "TOML file"
+  },
+  {
+    "ext": [ "xhtml" ],
+    "name": "XHTML document"
+  },
+  {
+    "ext": [ "xml", "xsd", "xib", "rss", "tld", "pt", "cpt", "dtml" ],
+    "name": "XML document"
+  },
+  {
+    "ext": [ "xsl", "xslt" ],
+    "name": "XSL stylesheet"
+  },
+  {
+    "ext": [ "vcf", "vcard" ],
+    "name": "Electronic business card"
+  },
+  {
+    "ext": [ "vb" ],
+    "name": "Visual Basic source"
+  },
+  {
+    "ext": [ "yaml", "yml" ],
+    "name": "YAML document"
+  },
+  {
+    "ext": [ "nfo" ],
+    "name": "Text document"
+  },
+  {
+    "ext": [ "g", "vss", "d", "e", "gri", "inf", "mel", "build", "re", "textmate", "fxscript", "lgt" ],
+    "name": "Source"
+  },
+  {
+    "ext": [ "cfm", "cfml", "dbm", "dist", "dot", "ics", "ifb", "dwt", "g", "in" "l", "m4", "mp", "mtml", "orig", "pde", "rej", "servlet", "s5", "tmp", "tpl", "tt", "xql", "yy", "*" ],
+    "name": "Document"
+  },
+  {
+    "name": "Document",
+    "CFBundleTypeOSTypes": [ "****" ],
+    "LSItemContentTypes": [ "public.data" ]
+  },
+  {
+    // Adds Folder Support 
+    "LSItemContentTypes": [ "public.directory", "com.apple.bundle", "com.apple.resolvable" ]
+  }
+];
+
+function create() {
+  let obj;
+
+  for (let i = 0; i < docs.length; i++) {
+    let tmp = {
+      "CFBundleTypeIconFile": "file.icns",
+      "CFBundleTypeRole": "Editor",
+      "LSHandlerRank": "Alternate"
+    };
+
+    if (docs[i].name) {
+      tmp["CFBundleTypeName"] = docs[i].name;
+    }
+
+    if (docs[i].ext) {
+      tmp["CFBundleTypeExtensions"] = docs[i].ext;
+    }
+
+    if (docs[i]["CFBundleTypeMIMETypes"]) {
+      // If this type is specified
+      tmp["CFBundleTypeMIMETypes"] = docs[i]["CFBundleTypeMIMETypes"];
+    }
+
+    if (docs[i]["CFBundleTypeOSTypes"]) {
+      tmp["CFBundleTypeOSTypes"] = docs[i]["CFBundleTypeOSTypes"];
+    }
+
+    if (docs[i]["LSItemContentTypes"]) {
+      tmp["LSItemContentTypes"] = docs[i]["LSItemContentTypes"];
+    }
+
+    obj.push(tmp);
+  }
+
+  return obj;
+}
+
+module.exports = {
+  create,
+};

--- a/script/mac-bundle-document-types.js
+++ b/script/mac-bundle-document-types.js
@@ -433,7 +433,7 @@ const docs = [
 ];
 
 function create() {
-  let obj;
+  let obj = [];
 
   for (let i = 0; i < docs.length; i++) {
     let tmp = {


### PR DESCRIPTION
This PR improves the MacOS build:
* Fixes an incorrectly set Category
* Fixed our `appId` for all systems to point to our actual domain
* Sets the minimum compatible version correctly
* Enables `atom://` URI to function on MacOS
* Fixes MacOS Open File and Drag and Drop file #278 

In order to implement MacOS opening file capabilities, we had to specify the files we are able to open in the `plist`.

Originally Atom had used a hardcoded plist file to accomplish this, but since we are using `electron-builder` I've taken advantage of the `extendInfo` property to inject values into the plist file. For most options this was able to be done rather simply, but because as you might imagine the list of files Atom had set in the plist that we can open is quite long, I've moved that into `mac-bundle-document-types.js` as a function to build the object to  be injected during build time. This means it can be much simpler in the future to modify the files we do or don't support, as well as being much more understandable and easy to read.
