### PR TITLE
Rebranding and relinking to new site

### DIFF
--- a/dot-atom/init.js
+++ b/dot-atom/init.js
@@ -11,3 +11,7 @@
 //     console.log(`Saved! ${editor.getPath()}`)
 //   )
 // );
+//
+// See the Pulsar Launch manual for more information on this file and how to
+// customize it.
+// https://pulsar-edit.dev/docs/launch-manual/sections/core-hacking/#the-init-file

--- a/dot-atom/keymap.cson
+++ b/dot-atom/keymap.cson
@@ -18,15 +18,15 @@
 #   'ctrl-p': 'core:move-down'
 #
 # You can find more information about keymaps in these guides:
-# * http://flight-manual.atom.io/using-atom/sections/basic-customization/#customizing-keybindings
-# * http://flight-manual.atom.io/behind-atom/sections/keymaps-in-depth/
+# * https://pulsar-edit.dev/docs/launch-manual/sections/using-pulsar/#customizing-keybindings
+# * https://pulsar-edit.dev/docs/launch-manual/sections/behind-pulsar#keymaps-in-depth
 #
 # If you're having trouble with your keybindings not working, try the
 # Keybinding Resolver: `Cmd+.` on macOS and `Ctrl+.` on other platforms. See the
 # Debugging Guide for more information:
-# * http://flight-manual.atom.io/hacking-atom/sections/debugging/#check-the-keybindings
+# * https://pulsar-edit.dev/docs/launch-manual/sections/core-hacking/#check-your-keybindings
 #
 # This file uses CoffeeScript Object Notation (CSON).
 # If you are unfamiliar with CSON, you can read more about it in the
-# Pulsar Flight Manual:
-# http://flight-manual.atom.io/using-atom/sections/basic-customization/#configuring-with-cson
+# Pulsar Launch Manual:
+# https://pulsar-edit.dev/docs/launch-manual/sections/using-pulsar/#configuring-with-cson

--- a/dot-atom/snippets.cson
+++ b/dot-atom/snippets.cson
@@ -17,5 +17,5 @@
 #
 # This file uses CoffeeScript Object Notation (CSON).
 # If you are unfamiliar with CSON, you can read more about it in the
-# Pulsar Flight Manual:
-# http://flight-manual.atom.io/using-atom/sections/basic-customization/#_cson
+# Pulsar Launch Manual:
+# https://pulsar-edit.dev/docs/launch-manual/sections/using-pulsar/#configuring-with-cson

--- a/dot-atom/styles.less
+++ b/dot-atom/styles.less
@@ -1,10 +1,10 @@
 /*
  * Your Stylesheet
  *
- * This stylesheet is loaded when Atom starts up and is reloaded automatically
+ * This stylesheet is loaded when Pulsar starts up and is reloaded automatically
  * when it is changed and saved.
  *
- * Add your own CSS or Less to fully customize Atom.
+ * Add your own CSS or Less to fully customize Pulsar.
  * If you are unfamiliar with Less, you can read more about it here:
  * http://lesscss.org
  */

--- a/packages/about/lib/update-manager.js
+++ b/packages/about/lib/update-manager.js
@@ -125,7 +125,7 @@ let UpdateManager = class UpdateManager {
   getReleaseNotesURLForVersion(appVersion) {
     // Dev versions will not have a releases page
     if (appVersion.indexOf('dev') > -1) {
-      return 'https://atom.io/releases';
+      return 'https://pulsar-edit.dev/download.html';
     }
 
     if (!appVersion.startsWith('v')) {

--- a/packages/settings-view/lib/error-view.js
+++ b/packages/settings-view/lib/error-view.js
@@ -67,13 +67,11 @@ class CompileToolsErrorView {
         <div className='icon icon-alert compile-tools-heading compile-tools-message'>Compiler tools not found</div>
         <div className='compile-tools-message'>Packages that depend on modules that contain C/C++ code will fail to install.</div>
         <div className='compile-tools-message'>
-          <span>Read </span>
-          <a className='link' href='https://github.com/atom/atom/blob/master/docs/build-instructions/windows.md'>here</a>
-          <span> for instructions on installing Python and Visual Studio.</span>
+          <span>Please install Python and Visual Studio to continue.</span>
         </div>
         <div className='compile-tools-message'>
           <span>Run </span>
-          <code className='alert-danger'>apm install --check</code>
+          <code className='alert-danger'>pulsar -p install --check</code>
           <span> after installing to test compiling a native module.</span>
         </div>
       </div>

--- a/packages/settings-view/lib/general-panel.js
+++ b/packages/settings-view/lib/general-panel.js
@@ -33,7 +33,7 @@ export default class GeneralPanel {
           ref='panel'
           namespace='core'
           icon='settings'
-          note={`<div class="text icon icon-question" id="core-settings-note" tabindex="-1">These are Atom's core settings which affect behavior unrelated to text editing. Individual packages may have their own additional settings found within their package card in the <a class="link packages-open">Packages list</a>.</div>`} />
+          note={`<div class="text icon icon-question" id="core-settings-note" tabindex="-1">These are Pulsar's core settings which affect behavior unrelated to text editing. Individual packages may have their own additional settings found within their package card in the <a class="link packages-open">Packages list</a>.</div>`} />
       </div>
     )
   }

--- a/packages/settings-view/lib/install-panel.js
+++ b/packages/settings-view/lib/install-panel.js
@@ -19,7 +19,7 @@ export default class InstallPanel {
     this.packageManager = packageManager
     this.disposables = new CompositeDisposable()
     this.client = this.packageManager.getClient()
-    this.atomIoURL = 'https://pulsar-edit.dev/packages'
+    this.atomIoURL = 'https://web.pulsar-edit.dev/'
 
     etch.initialize(this)
 

--- a/packages/settings-view/lib/package-card.js
+++ b/packages/settings-view/lib/package-card.js
@@ -143,7 +143,7 @@ export default class PackageCard {
         if (packageVersion !== this.pack.version) {
           this.refs.versionValue.classList.add('text-warning')
           this.refs.packageMessage.classList.add('text-warning')
-          this.refs.packageMessage.textContent = `Version ${packageVersion} is not the latest version available for this package, but it's the latest that is compatible with your version of Atom.`
+          this.refs.packageMessage.textContent = `Version ${packageVersion} is not the latest version available for this package, but it's the latest that is compatible with your version of Pulsar.`
         }
 
         this.installablePack = pack
@@ -154,9 +154,9 @@ export default class PackageCard {
         this.refs.packageMessage.classList.add('text-error')
         this.refs.packageMessage.insertAdjacentText(
           'beforeend',
-          `There's no version of this package that is compatible with your Atom version. The version must satisfy ${this.pack.engines.atom}.`
+          `There's no version of this package that is compatible with your Pulsar version. The version must satisfy ${this.pack.engines.atom}.`
         )
-        console.error(`No available version compatible with the installed Atom version: ${atom.getVersion()}`)
+        console.error(`No available version compatible with the installed Pulsar version: ${atom.getVersion()}`)
       }
 
       callback()
@@ -212,7 +212,7 @@ export default class PackageCard {
           detail = `${oldVersion} -> ${newVersion}`
         }
 
-        const notification = atom.notifications.addSuccess(`Restart Atom to complete the update of \`${this.pack.name}\`.`, {
+        const notification = atom.notifications.addSuccess(`Restart Pulsar to complete the update of \`${this.pack.name}\`.`, {
           dismissable: true,
           buttons: [{
             text: 'Restart now',
@@ -238,7 +238,7 @@ export default class PackageCard {
 
     const packageAuthorClickHandler = (event) => {
       event.stopPropagation()
-      shell.openExternal(`https://pulsar-edit.dev/users/${ownerFromRepository(this.pack.repository)}`)
+      shell.openExternal(`https://web.pulsar-edit.dev/users/${ownerFromRepository(this.pack.repository)}`) //TODO: Fix - This does not current exist but this will at least be more accurate
     }
     this.refs.loginLink.addEventListener('click', packageAuthorClickHandler)
     this.disposables.add(new Disposable(() => { this.refs.loginLink.removeEventListener('click', packageAuthorClickHandler) }))

--- a/packages/settings-view/lib/package-detail-view.js
+++ b/packages/settings-view/lib/package-detail-view.js
@@ -42,7 +42,7 @@ export default class PackageDetailView {
       event.preventDefault()
       const repoUrl = this.packageManager.getRepositoryUrl(this.pack)
       if (typeof repoUrl === 'string') {
-        if (url.parse(repoUrl).pathname === '/atom/atom') {
+        if (url.parse(repoUrl).pathname === '/pulsar-edit/pulsar') {
           shell.openExternal(`${repoUrl}/tree/master/packages/${this.pack.name}`)
         } else {
           shell.openExternal(repoUrl)

--- a/packages/settings-view/lib/themes-panel.js
+++ b/packages/settings-view/lib/themes-panel.js
@@ -97,7 +97,7 @@ export default class ThemesPanel extends CollapsibleSectionPanel {
             <div className='section-heading icon icon-paintcan'>Choose a Theme</div>
 
             <div className='text native-key-bindings' tabIndex='-1'>
-              <span className='icon icon-question'>You can also style Atom by editing </span>
+              <span className='icon icon-question'>You can also style Pulsar by editing </span>
               <a className='link' onclick={this.didClickOpenUserStyleSheet}>your stylesheet</a>
             </div>
 
@@ -202,7 +202,7 @@ export default class ThemesPanel extends CollapsibleSectionPanel {
 
     for (let pack of packages.core) {
       if (pack.repository == null) {
-        pack.repository = `https://github.com/atom/${pack.name}`
+        pack.repository = `https://github.com/pulsar-edit/${pack.name}`
       }
     }
 

--- a/packages/settings-view/lib/uri-handler-panel.js
+++ b/packages/settings-view/lib/uri-handler-panel.js
@@ -59,7 +59,7 @@ export default class UriHandlerPanel {
           <div className='settings-panel'>
             <div className='section-container'>
               <div className='block section-heading icon icon-device-desktop'>URI Handling</div>
-              <div className='text icon icon-question'>These settings determine how Atom handles atom:// URIs.</div>
+              <div className='text icon icon-question'>These settings determine how Pulsar handles atom:// URIs.</div>
               <div className='section-body'>
                 <div className='control-group'>
                   <div className='controls'>
@@ -154,9 +154,9 @@ export default class UriHandlerPanel {
 
   renderRegistrationDescription () {
     if (this.isDefaultProtocolClient) {
-      return 'Atom is already the default handler for atom:// URIs.'
+      return 'Pulsar is already the default handler for atom:// URIs.'
     } else if (isSupported()) {
-      return 'Register Atom as the default handler for atom:// URIs.'
+      return 'Register Pulsar as the default handler for atom:// URIs.'
     } else {
       return 'Registration as the default handler for atom:// URIs is only supported on Windows and macOS.'
     }

--- a/packages/welcome/lib/guide-view.js
+++ b/packages/welcome/lib/guide-view.js
@@ -254,8 +254,7 @@ export default class GuideView {
                 </p>
                 <p>
                   The init script is a bit of JavaScript or CoffeeScript run at
-                  startup. You can use it to quickly change the behaviour of
-                  {this.brand}.
+                  startup. You can use it to quickly change the behaviour of {this.brand}.
                 </p>
                 <p>
                   <button

--- a/src/config-file.js
+++ b/src/config-file.js
@@ -92,8 +92,8 @@ module.exports = class ConfigFile {
         On linux there are currently problems with watch sizes.
         See [this document][watches] for more info.
 
-        [watches]:https://github.com/atom/atom/blob/master/docs/build-instructions/linux.md#typeerror-unable-to-watch-path\
-      `
+        [watches]:https://pulsar-edit.dev/docs/atom-archive/hacking-atom/#typeerror-unable-to-watch-path
+      `//TODO: Update the above to the pulsar docs if we choose to add this
       );
       return new Disposable();
     }

--- a/src/config-schema.js
+++ b/src/config-schema.js
@@ -1,5 +1,5 @@
 // This is loaded by atom-environment.coffee. See
-// https://atom.io/docs/api/latest/Config for more information about config
+// https://atom.io/docs/api/latest/Config for more information about config TODO: Link to Pulsar API site when documented
 // schemas.
 const configSchema = {
   core: {
@@ -312,7 +312,7 @@ const configSchema = {
         enum: ['no', 'yes', 'always'],
         default: 'yes',
         description:
-          "When selected 'no', a blank environment is loaded. When selected 'yes' and Pulsar is started from the icon or `atom` by itself from the command line, restores the last state of all Pulsar windows; otherwise a blank environment is loaded. When selected 'always', restores the last state of all Pulsar windows always, no matter how Pulsar is started."
+          "When selected 'no', a blank environment is loaded. When selected 'yes' and Pulsar is started from the icon or `pulsar` by itself from the command line, restores the last state of all Pulsar windows; otherwise a blank environment is loaded. When selected 'always', restores the last state of all Pulsar windows always, no matter how Pulsar is started."
       },
       reopenProjectMenuCount: {
         description:
@@ -322,14 +322,14 @@ const configSchema = {
       },
       automaticallyUpdate: {
         description:
-          'Automatically update Pulsar when a new release is available.',
+          'Automatically update Pulsar when a new release is available. **Note**: Currently not functional, please download new releases from [pulsar-edit.dev](https://pulsar-edit.dev/download.html)',
         type: 'boolean',
-        default: true
+        default: false
       },
       useProxySettingsWhenCallingApm: {
-        title: 'Use Proxy Settings When Calling APM',
+        title: 'Use Proxy Settings When Calling PPM',
         description:
-          'Use detected proxy settings when calling the `apm` command-line tool.',
+          'Use detected proxy settings when calling the `pulsar -p` or `ppm` command-line tool.',
         type: 'boolean',
         default: true
       },
@@ -621,7 +621,7 @@ if (process.platform === 'darwin') {
     type: 'boolean',
     default: false,
     description:
-      'Use pre-Lion fullscreen on macOS. This does not create a new desktop space for the atom on fullscreen mode.'
+      'Use pre-Lion fullscreen on macOS. This does not create a new desktop space for Pulsar on fullscreen mode.'
   };
 }
 

--- a/src/config.js
+++ b/src/config.js
@@ -79,7 +79,7 @@ const schemaEnforcers = {};
 //   # ...
 // ```
 //
-// See [package docs](http://flight-manual.atom.io/hacking-atom/sections/package-word-count/) for
+// See [package docs](https://pulsar-edit.dev/docs/launch-manual/sections/core-hacking/#package-word-count) for
 // more info.
 //
 // ## Config Schemas
@@ -329,7 +329,7 @@ const schemaEnforcers = {};
 //
 // * **bold** - `**bold**`
 // * *italics* - `*italics*`
-// * [links](https://atom.io) - `[links](https://atom.io)`
+// * [links](https://pulsar-edit.dev) - `[links](https://pulsar-edit.dev)`
 // * `code spans` - `` `code spans` ``
 // * line breaks - `line breaks<br/>`
 // * ~~strikethrough~~ - `~~strikethrough~~`
@@ -487,7 +487,7 @@ class Config {
   //   * `scope` (optional) {ScopeDescriptor} describing a path from
   //     the root of the syntax tree to a token. Get one by calling
   //     {editor.getLastCursor().getScopeDescriptor()}. See {::get} for examples.
-  //     See [the scopes docs](http://flight-manual.atom.io/behind-atom/sections/scoped-settings-scopes-and-scope-descriptors/)
+  //     See [the scopes docs](https://pulsar-edit.dev/docs/launch-manual/sections/behind-pulsar#scoped-settings-scopes-and-scope-descriptors)
   //     for more information.
   // * `callback` {Function} to call when the value of the key changes.
   //   * `value` the new value of the key
@@ -531,7 +531,7 @@ class Config {
   //   * `scope` (optional) {ScopeDescriptor} describing a path from
   //     the root of the syntax tree to a token. Get one by calling
   //     {editor.getLastCursor().getScopeDescriptor()}. See {::get} for examples.
-  //     See [the scopes docs](http://flight-manual.atom.io/behind-atom/sections/scoped-settings-scopes-and-scope-descriptors/)
+  //     See [the scopes docs](https://pulsar-edit.dev/docs/launch-manual/sections/behind-pulsar#scoped-settings-scopes-and-scope-descriptors)
   //     for more information.
   // * `callback` {Function} to call when the value of the key changes.
   //   * `event` {Object}
@@ -613,7 +613,7 @@ class Config {
   //   * `scope` (optional) {ScopeDescriptor} describing a path from
   //     the root of the syntax tree to a token. Get one by calling
   //     {editor.getLastCursor().getScopeDescriptor()}
-  //     See [the scopes docs](http://flight-manual.atom.io/behind-atom/sections/scoped-settings-scopes-and-scope-descriptors/)
+  //     See [the scopes docs](https://pulsar-edit.dev/docs/launch-manual/sections/behind-pulsar#scoped-settings-scopes-and-scope-descriptors)
   //     for more information.
   //
   // Returns the value from Pulsar's default settings, the user's configuration
@@ -720,7 +720,7 @@ class Config {
   //   setting to the default value.
   // * `options` (optional) {Object}
   //   * `scopeSelector` (optional) {String}. eg. '.source.ruby'
-  //     See [the scopes docs](http://flight-manual.atom.io/behind-atom/sections/scoped-settings-scopes-and-scope-descriptors/)
+  //     See [the scopes docs](https://pulsar-edit.dev/docs/launch-manual/sections/behind-pulsar#scoped-settings-scopes-and-scope-descriptors)
   //     for more information.
   //   * `source` (optional) {String} The name of a file with which the setting
   //     is associated. Defaults to the user's config file.

--- a/src/keymap-extensions.js
+++ b/src/keymap-extensions.js
@@ -61,7 +61,7 @@ KeymapManager.prototype.loadUserKeymap = function() {
 
         On linux there are currently problems with watch sizes. See \
         [this document][watches] for more info. \
-        [watches]:https://github.com/atom/atom/blob/master/docs/build-instructions/linux.md#typeerror-unable-to-watch-path`;
+        [watches]:https://pulsar-edit.dev/docs/atom-archive/hacking-atom/#typeerror-unable-to-watch-path`; //TODO: Update the above to Pulsar docs if we choose to add this
       this.notificationManager.addError(message, {dismissable: true});
     }
     else {

--- a/src/main-process/atom-application.js
+++ b/src/main-process/atom-application.js
@@ -599,7 +599,7 @@ module.exports = class AtomApplication extends EventEmitter {
       shell.openExternal('https://pulsar-edit.dev/docs/launch-manual/sections/faq/')
     );
     this.on('application:open-terms-of-use', () =>
-      shell.openExternal('https://atom.io/terms')
+      shell.openExternal('https://atom.io/terms') //TODO: This needs to be updated for when we have our own published on the site
     );
     this.on('application:report-issue', () =>
       shell.openExternal(

--- a/src/main-process/atom-window.js
+++ b/src/main-process/atom-window.js
@@ -256,7 +256,7 @@ module.exports = class AtomWindow extends EventEmitter {
         buttons: ['Close Window', 'Reload', 'Keep It Open'],
         cancelId: 2, // Canceling should be the least destructive action
         message: 'The editor has crashed',
-        detail: 'Please report this issue to https://github.com/atom/atom'
+        detail: 'Please report this issue to https://github.com/pulsar-edit/pulsar'
       });
 
       switch (result.response) {

--- a/src/scope-descriptor.js
+++ b/src/scope-descriptor.js
@@ -15,7 +15,7 @@
 //   specific position in the buffer.
 // * {Cursor::getScopeDescriptor} to get a cursor's descriptor based on position.
 //
-// See the [scopes and scope descriptor guide](http://flight-manual.atom.io/behind-atom/sections/scoped-settings-scopes-and-scope-descriptors/)
+// See the [scopes and scope descriptor guide](https://pulsar-edit.dev/docs/launch-manual/sections/behind-pulsar#scoped-settings-scopes-and-scope-descriptors)
 // for more information.
 module.exports = class ScopeDescriptor {
   static fromObject(scopes) {

--- a/src/theme-manager.js
+++ b/src/theme-manager.js
@@ -244,8 +244,8 @@ you have permissions to \`${userStylesheetPath}\`.
 
 On linux there are currently problems with watch sizes. See
 [this document][watches] for more info.
-[watches]:https://github.com/atom/atom/blob/master/docs/build-instructions/linux.md#typeerror-unable-to-watch-path\
-`;
+[watches]:https://pulsar-edit.dev/docs/atom-archive/hacking-atom/#typeerror-unable-to-watch-path
+`; //TODO: Update the above to Pulsar docs if we choose to add this
       this.notificationManager.addError(message, { dismissable: true });
     }
 


### PR DESCRIPTION
This is mostly just a bunch of Atom -> Pulsar rebranding as well as fixing some atom.io links to the new site.

There are a few other tweaks in here too (some might be pointless and not worth even adding).