### PR TITLE
Remove handlers for opening things on Mac

### DIFF
--- a/src/main-process/atom-application.js
+++ b/src/main-process/atom-application.js
@@ -1059,7 +1059,6 @@ module.exports = class AtomApplication extends EventEmitter {
   // command - The string representing the command.
   // args - The optional arguments to pass along.
   sendCommand(command, ...args) {
-    console.log("WILL SEND COMMAND", command)
     if (!this.emit(command, ...args)) {
       const focusedWindow = this.focusedWindow();
       if (focusedWindow) {

--- a/src/main-process/atom-application.js
+++ b/src/main-process/atom-application.js
@@ -39,17 +39,6 @@ const LocationSuffixRegExp = /(:\d+)(:\d+)?$/;
 // incompatible way.
 const APPLICATION_STATE_VERSION = '1';
 
-const getDefaultPath = () => {
-  const editor = atom.workspace.getActiveTextEditor();
-  if (!editor || !editor.getPath()) {
-    return;
-  }
-  const paths = atom.project.getPaths();
-  if (paths) {
-    return paths[0];
-  }
-};
-
 const getSocketSecretPath = applicationVersion => {
   const { username } = os.userInfo();
   const atomHome = path.resolve(process.env.ATOM_HOME);
@@ -631,28 +620,6 @@ module.exports = class AtomApplication extends EventEmitter {
         this.openPaths({ pathsToOpen: paths });
       });
 
-      this.on('application:open', () => {
-        this.promptForPathToOpen(
-          'all',
-          createOpenSettings({ sameWindow: true }),
-          getDefaultPath()
-        );
-      });
-      this.on('application:open-file', () => {
-        this.promptForPathToOpen(
-          'file',
-          createOpenSettings({ sameWindow: true }),
-          getDefaultPath()
-        );
-      });
-      this.on('application:open-folder', () => {
-        this.promptForPathToOpen(
-          'folder',
-          createOpenSettings({ sameWindow: true }),
-          getDefaultPath()
-        );
-      });
-
       this.on('application:bring-all-windows-to-front', () =>
         Menu.sendActionToFirstResponder('arrangeInFront:')
       );
@@ -1092,6 +1059,7 @@ module.exports = class AtomApplication extends EventEmitter {
   // command - The string representing the command.
   // args - The optional arguments to pass along.
   sendCommand(command, ...args) {
+    console.log("WILL SEND COMMAND", command)
     if (!this.emit(command, ...args)) {
       const focusedWindow = this.focusedWindow();
       if (focusedWindow) {


### PR DESCRIPTION
I have to be completely honest here: I actually have NO IDEA what this does. It basically tries to access the global `atom` object which is not present here. I removed these lines, and opening files now work on Mac...
