### PR TITLE
Fix `archive-view`

### DIFF
--- a/packages/archive-view/package-lock.json
+++ b/packages/archive-view/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "etch": "0.9.0",
         "humanize-plus": "~1.8.2",
-        "ls-archive": "https://github.com/pulsar-edit/node-ls-archive/archive/refs/tags/v1.3.1.tar.gz",
+        "ls-archive": "1.3.4",
         "temp": "~0.8.1"
       },
       "engines": {
@@ -148,9 +148,9 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "node_modules/ls-archive": {
-      "version": "1.3.1",
-      "resolved": "https://github.com/pulsar-edit/node-ls-archive/archive/refs/tags/v1.3.1.tar.gz",
-      "integrity": "sha512-E73OPpAbApoY0qViDs+Rre57yq5IdysEXI+MfD4CnBfTlx+xxxKSeD29os/kQEDu6LdKZoNi24M1/76mBWzeYw==",
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/ls-archive/-/ls-archive-1.3.4.tgz",
+      "integrity": "sha512-7GmjZOckV+gzm4PM1/LcWIsZIRsSkAVmIchoEf5xjquNKU0Ti5KUvGQ3dl/7VsbZIduMOPwRDXrvpo3LVJ0Pmg==",
       "dependencies": {
         "async": "~0.2.9",
         "colors": "~0.6.2",
@@ -396,8 +396,9 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "ls-archive": {
-      "version": "https://github.com/pulsar-edit/node-ls-archive/archive/refs/tags/v1.3.1.tar.gz",
-      "integrity": "sha512-E73OPpAbApoY0qViDs+Rre57yq5IdysEXI+MfD4CnBfTlx+xxxKSeD29os/kQEDu6LdKZoNi24M1/76mBWzeYw==",
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/ls-archive/-/ls-archive-1.3.4.tgz",
+      "integrity": "sha512-7GmjZOckV+gzm4PM1/LcWIsZIRsSkAVmIchoEf5xjquNKU0Ti5KUvGQ3dl/7VsbZIduMOPwRDXrvpo3LVJ0Pmg==",
       "requires": {
         "async": "~0.2.9",
         "colors": "~0.6.2",

--- a/packages/archive-view/package.json
+++ b/packages/archive-view/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "etch": "0.9.0",
     "humanize-plus": "~1.8.2",
-    "ls-archive": "https://github.com/pulsar-edit/node-ls-archive/archive/refs/tags/v1.3.1.tar.gz",
+    "ls-archive": "1.3.4",
     "temp": "~0.8.1"
   },
   "repository": "https://github.com/pulsar-edit/pulsar",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2041,7 +2041,7 @@ aproba@^1.0.3:
   dependencies:
     etch "0.9.0"
     humanize-plus "~1.8.2"
-    ls-archive "https://github.com/pulsar-edit/node-ls-archive/archive/refs/tags/v1.3.1.tar.gz"
+    ls-archive "1.3.4"
     temp "~0.8.1"
 
 archiver-utils@^2.1.0:
@@ -6265,9 +6265,10 @@ lru-cache@^6.0.0:
   dependencies:
     yallist "^4.0.0"
 
-"ls-archive@https://github.com/pulsar-edit/node-ls-archive/archive/refs/tags/v1.3.1.tar.gz":
-  version "1.3.1"
-  resolved "https://github.com/pulsar-edit/node-ls-archive/archive/refs/tags/v1.3.1.tar.gz#43baa626a66f9c904548741b5bdf2f8095fbc7d9"
+ls-archive@1.3.4:
+  version "1.3.4"
+  resolved "https://registry.yarnpkg.com/ls-archive/-/ls-archive-1.3.4.tgz#52150919dab1acb094cdcef9dde9c66934a4650f"
+  integrity sha512-7GmjZOckV+gzm4PM1/LcWIsZIRsSkAVmIchoEf5xjquNKU0Ti5KUvGQ3dl/7VsbZIduMOPwRDXrvpo3LVJ0Pmg==
   dependencies:
     async "~0.2.9"
     colors "~0.6.2"


### PR DESCRIPTION
A previous PR I authored had moved our installation of `ls-archive` a dependency of `archive-view` to use the module directly from our repo.

But that repo doesn't actually provide a usable installation by default. It relies on a `prepublish` script to build the module, and as such fails currently in the latest alpha release of Pulsar.

Not sure how I didn't catch this initially, but this PR fixes the issue by reverting to using the `ls-archive` available on NPM published by Atom.

So we can still switch over, but only after we make the raw repo usable as a module, or move the script into a `build` script rather than `prepublish`
