### PR TITLE
meta: Delete preinstall script from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -269,7 +269,6 @@
   },
   "private": true,
   "scripts": {
-    "preinstall": "node -e 'process.exit(0)'",
     "build": "electron-rebuild",
     "build:apm": "cd ppm && yarn install",
     "start": "electron --no-sandbox --enable-logging . -f",


### PR DESCRIPTION
This script launches Node to run a script that has it immediately exit ... It is from way back in 2012, when Atom still had a binding.gyp at the root dir of the project.

See commit 2697b5e402e59143501297eb883e3e1d4e1f9b8d's commit message for details of why this was added, then see commit 010905db0b39e3e0c8bf8e9a4fcc5faee574f477, and see also npm's "scripts" documentation page:

> If there is a binding.gyp file in the root of your package and you haven't defined your own install or preinstall scripts, npm will default the install command to compile using node-gyp via node-gyp rebuild
- Source: https://docs.npmjs.com/cli/v9/using-npm/scripts#npm-install

...
But there's no binding.gyp in the project root anymore, hasn't been for a while, and keeping this script all these years has been fairly silly, and wastes a few seconds of time and some tiny amount of RAM/ disk access, I suppose.

It [does not spark joy](https://knowyourmeme.com/memes/does-it-spark-joy), so I am saying goodbye to this script.

"Goodbye, preinstall script."