### PR TITLE
script: Clean up `pulsar` and `ppm` on uninstall

### DIFF
--- a/script/electron-builder.js
+++ b/script/electron-builder.js
@@ -140,9 +140,13 @@ let options = {
     },
   ],
   compression: "normal",
-  deb: { afterInstall: "script/post-install.sh" },
+  deb: {
+    afterInstall: "script/post-install.sh",
+    afterRemove: "script/post-uninstall.sh",
+  },
   rpm: {
     afterInstall: "script/post-install.sh",
+    afterRemove: "script/post-uninstall.sh",
     compression: 'xz'
   },
   "linux": {

--- a/script/post-install.sh
+++ b/script/post-install.sh
@@ -12,7 +12,7 @@ cp "$FILESOURCE" "$FILEDEST"
 SYMLINK_TARGET='/opt/Pulsar/resources/app/ppm/bin/apm'
 SYMLINK_PATH='/usr/bin/ppm'
 
-if [ -f "$SYMLINK_PATH" ]
+if [ -L "$SYMLINK_PATH" ]
 then
   rm "$SYMLINK_PATH"
 fi

--- a/script/post-uninstall.sh
+++ b/script/post-uninstall.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+PULSAR_SCRIPT_PATH='/usr/bin/pulsar'
+
+if [ -f "$PULSAR_SCRIPT_PATH" ]
+then
+  rm "$PULSAR_SCRIPT_PATH"
+fi
+
+PPM_SYMLINK_PATH='/usr/bin/ppm'
+
+if [ -L "$PPM_SYMLINK_PATH" ]
+then
+  rm "$PPM_SYMLINK_PATH"
+fi


### PR DESCRIPTION
For Linux .rpm and .deb targets only.

<details><summary><b>Requirements for Contributing a Bug Fix</b> (from template, click to expand):</summary>

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* The pull request must only fix an existing bug. To contribute other changes, you must use a different template. You can see all templates at <https://github.com/atom/.github/tree/master/.github/PULL_REQUEST_TEMPLATE>.
* The pull request must update the test suite to demonstrate the changed functionality. For guidance, please see <https://flight-manual.atom.io/hacking-atom/sections/writing-specs/>.
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution. For more details, please see <https://github.com/atom/.github/tree/master/CONTRIBUTING.md#pull-requests>.

</details>

### Identify the Bug

<!--

Link to the issue describing the bug that you're fixing.

If there is not yet an issue for your bug, please open a new issue and then link to that issue in your pull request.
Note: In some cases, one person's "bug" is another person's "feature." If the pull request does not address an existing issue with the "bug" label, the maintainers have the final say on whether the current behavior is a bug.

-->

Follow-up to:
- https://github.com/pulsar-edit/pulsar/pull/82
- https://github.com/pulsar-edit/pulsar/pull/228
- https://github.com/pulsar-edit/pulsar/pull/273

### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

When uninstalling the .`deb` and `.rpm` packages on Linux, clean up the `pulsar` (`pulsar.sh`) and `ppm` (symlink to `/opt/Pulsar/resources/app/ppm/bin/apm`) stuff from `/usr/bin`.

(Note: These are only automatically created for the `.deb` and `.rpm` Linux packages. So there is nothing to clean up on other OSes or targets, other than the tangentially related but off-topic for this PR macOS bins users have to manually request installation of.)

**Relevant docs:** https://www.electron.build/configuration/linux#linuxtargetspecificoptions-apk-freebsd-pacman-p5p-and-rpm-options

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

Not cleaning up is bad, so I didn't consider just not cleaning up. However:

_I do want_ to move these from **`/usr/bin`** (distro packages install here and there are obscure conflicts with a `ppm` bin from a Perl package manager package, and with a bin `pulsar` from an MRI science package called `odin`) to **`/usr/local/bin`**, which is coincidentally where Atom installed its `atom` and `apm` bins to, presumably for the same reason.

(See: https://pkgs.org/search/?q=%2Fusr%2Fbin%2Fpulsar and https://pkgs.org/search/?q=%2Fusr%2Fbin%2Fppm)

**BUT*:* IMO we need to have this cleanup code out in the wild for a while to clean up all the old bins people have installed, before making the move to `/usr/local/bin`.

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

I would say there is a risk of deleting the Perl package manager `ppm` or the MRI science `pulsar` bin from Odin... but hey, we have already been clobbering these with our own bins! So... It's already too late for that! Oops. No drawbacks that I can think of that would be new as of this PR.

So yeah, let's move these to `/usr/local/bin` instead of `/usr/bin`, after about a month or so, say?

### Verification Process

<!--

What process did you follow to verify that the change has not introduced any regressions? Describe the actions you performed (including buttons you clicked, text you typed, commands you ran, etc.), and describe the results you observed.

-->

**TODO:** Grab one of the built packages from Cirrus and test this out. I'll be testing the .deb package, personally.

### Release Notes

<!--

Please describe the changes in a single line that explains this improvement in
terms that a user can understand. This text will be used in Atom's release notes.

If this change is not user-facing or notable enough to be included in release notes
you may use the strings "Not applicable" or "N/A" here.

Examples:

- The GitHub package now allows you to add co-authors to commits.
- Fixed an issue where multiple cursors did not work in a file with a single line.
- Increased the performance of searching and replacing across a whole project.

-->

Clean up `pulsar` and `ppm` bins/scripts/symlinks upon uninstalling the `.rpm` or `.deb` packages.