### PR TITLE
Resolve all Tests within `language-javascript` (Resolves 24 Failing Tests)

### DIFF
--- a/packages/language-javascript/spec/javascript-spec.coffee
+++ b/packages/language-javascript/spec/javascript-spec.coffee
@@ -838,14 +838,9 @@ describe "JavaScript grammar", ->
       expect(tokens[14]).toEqual value: '`', scopes: ['source.js', 'string.quoted.template.js', 'punctuation.definition.string.end.js']
 
   describe "HTML template strings", ->
-    # TODO: Remove after Atom 1.21 is released
     [tagScope, entityScope] = []
-    if parseFloat(atom.getVersion()) <= 1.21
-      tagScope = 'meta.tag.inline.any.html'
-      entityScope = 'entity.name.tag.inline.any.html'
-    else
-      tagScope = 'meta.tag.inline.b.html'
-      entityScope = 'entity.name.tag.inline.b.html'
+    tagScope = 'meta.tag.inline.b.html'
+    entityScope = 'entity.name.tag.inline.b.html'
 
     beforeEach ->
       waitsForPromise ->


### PR DESCRIPTION
Looks like we had 24 failing tests within `language-javascript` because of our Pulsar version.

Essentially there was a check here that if the version of the editor was below `1.21` it would revert to an old style of `scopeSelector` but above that version would use the newer style.

Since we have now moved to Pulsar `1.100.0` when `1.100.0-dev <= 1.21` was evaluated it would return `true` and use the old style.

So this PR simply removes the if else block handling this (As we shouldn't be worried about supporting versions of Pulsar lower than this because they don't exist.) and statically assigns these `scopeSelectors` with the newer style. Which still using them will at least let us change them more easily in the future if we ever need to.

Additionally this PR removes the comment saying to remove the if else block after Atom `1.21` was released.

And in local testing this now resolves all failing `language-javascript` tests, which account for 24 of the failing test on this package test bundle. The bundle likely won't be totally passing yet, as I believe there are still a handful more that fail in that bundle.
