### PR TITLE
Resolve all Tests within `language-html` (Resolves 2 Failing Tests)

### DIFF
--- a/packages/language-html/spec/html-spec.coffee
+++ b/packages/language-html/spec/html-spec.coffee
@@ -181,11 +181,8 @@ describe 'TextMate HTML grammar', ->
 
       expect(lines[0][0]).toEqual value: '<', scopes: ['text.html.basic', 'meta.tag.script.html', 'punctuation.definition.tag.html']
       expect(lines[1][0]).toEqual value: '  ', scopes: ['text.html.basic', 'meta.tag.script.html', 'source.coffee.embedded.html']
-      # TODO: Remove when Atom 1.21 reaches stable
-      if parseFloat(atom.getVersion()) <= 1.20
-        expect(lines[1][1]).toEqual value: '->', scopes: ['text.html.basic', 'meta.tag.script.html', 'source.coffee.embedded.html', 'storage.type.function.coffee']
-      else
-        expect(lines[1][1]).toEqual value: '->', scopes: ['text.html.basic', 'meta.tag.script.html', 'source.coffee.embedded.html', 'meta.function.inline.coffee', 'storage.type.function.coffee']
+
+      expect(lines[1][1]).toEqual value: '->', scopes: ['text.html.basic', 'meta.tag.script.html', 'source.coffee.embedded.html', 'meta.function.inline.coffee', 'storage.type.function.coffee']
       expect(lines[2][0]).toEqual value: '</', scopes: ['text.html.basic', 'meta.tag.script.html', 'punctuation.definition.tag.html']
 
     it 'tokenizes multiline tags', ->
@@ -197,11 +194,8 @@ describe 'TextMate HTML grammar', ->
       '''
 
       expect(lines[0][0]).toEqual value: '<', scopes: ['text.html.basic', 'meta.tag.script.html', 'punctuation.definition.tag.html']
-      # TODO: Remove when Atom 1.21 reaches stable
-      if parseFloat(atom.getVersion()) <= 1.20
-        expect(lines[2][1]).toEqual value: '->', scopes: ['text.html.basic', 'meta.tag.script.html', 'source.coffee.embedded.html', 'storage.type.function.coffee']
-      else
-        expect(lines[2][1]).toEqual value: '->', scopes: ['text.html.basic', 'meta.tag.script.html', 'source.coffee.embedded.html', 'meta.function.inline.coffee', 'storage.type.function.coffee']
+
+      expect(lines[2][1]).toEqual value: '->', scopes: ['text.html.basic', 'meta.tag.script.html', 'source.coffee.embedded.html', 'meta.function.inline.coffee', 'storage.type.function.coffee']
       expect(lines[3][0]).toEqual value: '</', scopes: ['text.html.basic', 'meta.tag.script.html', 'punctuation.definition.tag.html']
 
     it 'recognizes closing script tags in comments', ->


### PR DESCRIPTION
Very similar to PR #299 `language-html` had some `scopeSelectors` that would manually check what version of Pulsar was being run.

And if prior to `1.21` would use an old style of `scopeSelectors`. Which now that we are on version `1.100.0` was being reported as true, causing the tests to use the old style of `scopeSelector` which would cause the test to fail.

Much more detail is on the linked PR, but this resolves these tests in the same exact way. Remove the older `scopeSelector` style support, sticking with the newer style. Which can still be updated if/when needed. But otherwise gets two more passing tests into the language testing bundle.
