### PR TITLE
Rebrand AppUserModelID - Ensure Pulsar is separated as it's own App Icon on Windows

### DIFF
--- a/src/main-process/start.js
+++ b/src/main-process/start.js
@@ -79,7 +79,7 @@ module.exports = function start(resourcePath, devResourcePath, startTime) {
   }
 
   const releaseChannel = getReleaseChannel(app.getVersion());
-  let appUserModelId = 'com.squirrel.atom.' + process.arch;
+  let appUserModelId = 'dev.pulsaredit.pulsar.' + process.arch;
 
   // If the release channel is not stable, we append it to the app user model id.
   // This allows having the different release channels as separate items in the taskbar.

--- a/src/main-process/start.js
+++ b/src/main-process/start.js
@@ -79,7 +79,7 @@ module.exports = function start(resourcePath, devResourcePath, startTime) {
   }
 
   const releaseChannel = getReleaseChannel(app.getVersion());
-  let appUserModelId = 'dev.pulsaredit.pulsar.' + process.arch;
+  let appUserModelId = 'dev.pulsar-edit.pulsar.' + process.arch;
 
   // If the release channel is not stable, we append it to the app user model id.
   // This allows having the different release channels as separate items in the taskbar.


### PR DESCRIPTION
By rebranding this value, it ensures that if a User were to run both Atom and Pulsar at the same time, that they will remain separate items within the Task Bar.

Without this change running both items simultaneous (or if a user has Atom/Pulsar pinned) the programs would overlap each other within the Task Bar.

But with it rebranding ensures they stay as separate applications.