### PR TITLE
Getting Started with JSDocs

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -4,7 +4,11 @@ module.exports = {
     commonjs: true,
     es2021: true,
   },
-  extends: ["eslint:recommended", "plugin:node/recommended"],
+  extends: [
+    "eslint:recommended",
+    "plugin:node/recommended",
+    "plugin:jsdoc/recommended"
+  ],
   overrides: [],
   parserOptions: {
     ecmaVersion: "latest"
@@ -17,6 +21,9 @@ module.exports = {
       }
     ]
   },
+  plugins: [
+    "jsdoc"
+  ],
   globals: {
     atom: "writeable"
   }

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -1,0 +1,38 @@
+name: Documentation
+
+on:
+  push:
+    branches: [ "master" ]
+
+jobs:
+  documentation:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    strategy:
+      matrix:
+        node-version: [16.x]
+
+    steps:
+    - name: Checkout the Latest Code
+      uses: actions/checkout@v3
+
+    - name: Setup NodeJS - ${{ matrix.node-version }}
+      uses: actions/setup-node@v3
+      with:
+        node-version: #{{ matrix.node-version }}
+
+    - name: Install Dependencies
+      run: yarn install
+
+    - name: Generate Public JSDocs
+      run: yarn run js-docs
+
+    - name: Generate Private JSDocs
+      run: yarn run private-js-docs
+
+    - name: Commit All Changes
+      uses: stefanzweifel/git-auto-commit-action@v4
+      with:
+        commit_message: GH Action Documentation

--- a/docs/Pulsar-API-Documentation.md
+++ b/docs/Pulsar-API-Documentation.md
@@ -1,0 +1,150 @@
+## Classes
+
+<dl>
+<dt><a href="#AtomEnvironment">AtomEnvironment</a></dt>
+<dd><p>Pulsar global for dealing with packages, themes, menus, and the window.</p>
+<p>An instance of this class is always available as the <code>atom</code> global.</p>
+</dd>
+<dt><a href="#Clipboard">Clipboard</a></dt>
+<dd></dd>
+</dl>
+
+<a name="AtomEnvironment"></a>
+
+## AtomEnvironment
+Pulsar global for dealing with packages, themes, menus, and the window.An instance of this class is always available as the `atom` global.
+
+**Kind**: global class  
+
+* [AtomEnvironment](#AtomEnvironment)
+    * _instance_
+        * [.clipboard](#AtomEnvironment+clipboard) : [<code>Clipboard</code>](#Clipboard)
+        * [.deserializers](#AtomEnvironment+deserializers) : <code>DeserializerManager</code>
+        * [.views](#AtomEnvironment+views) : <code>ViewRegistry</code>
+        * [.notifications](#AtomEnvironment+notifications) : <code>NotificationManager</code>
+        * [.config](#AtomEnvironment+config) : <code>Config</code>
+        * [.keymaps](#AtomEnvironment+keymaps) : <code>KeymapManager</code>
+        * [.tooltips](#AtomEnvironment+tooltips) : <code>TooltipManager</code>
+        * [.commands](#AtomEnvironment+commands) : <code>CommandRegistry</code>
+        * [.grammars](#AtomEnvironment+grammars) : <code>GrammarRegistry</code>
+        * [.styles](#AtomEnvironment+styles) : <code>StyleManager</code>
+        * [.packages](#AtomEnvironment+packages) : <code>PackageManager</code>
+        * [.themes](#AtomEnvironment+themes) : <code>ThemeManager</code>
+        * [.menu](#AtomEnvironment+menu) : <code>MenuManager</code>
+        * [.contextMenu](#AtomEnvironment+contextMenu) : <code>ContextMenuManager</code>
+        * [.project](#AtomEnvironment+project) : <code>Project</code>
+        * [.textEditors](#AtomEnvironment+textEditors) : <code>TextEditorRegistry</code>
+        * [.workspace](#AtomEnvironment+workspace) : <code>Workspace</code>
+        * [.history](#AtomEnvironment+history) : <code>HistoryManager</code>
+        * _Messaging the User_
+            * [.beep()](#AtomEnvironment+beep)
+    * _static_
+        * _Event Subscription_
+            * [.onDidBeep(callback)](#AtomEnvironment.onDidBeep) ⇒ <code>Disposable</code>
+
+<a name="AtomEnvironment+clipboard"></a>
+
+### atomEnvironment.clipboard : [<code>Clipboard</code>](#Clipboard)
+**Kind**: instance property of [<code>AtomEnvironment</code>](#AtomEnvironment)  
+<a name="AtomEnvironment+deserializers"></a>
+
+### atomEnvironment.deserializers : <code>DeserializerManager</code>
+**Kind**: instance property of [<code>AtomEnvironment</code>](#AtomEnvironment)  
+<a name="AtomEnvironment+views"></a>
+
+### atomEnvironment.views : <code>ViewRegistry</code>
+**Kind**: instance property of [<code>AtomEnvironment</code>](#AtomEnvironment)  
+<a name="AtomEnvironment+notifications"></a>
+
+### atomEnvironment.notifications : <code>NotificationManager</code>
+**Kind**: instance property of [<code>AtomEnvironment</code>](#AtomEnvironment)  
+<a name="AtomEnvironment+config"></a>
+
+### atomEnvironment.config : <code>Config</code>
+**Kind**: instance property of [<code>AtomEnvironment</code>](#AtomEnvironment)  
+<a name="AtomEnvironment+keymaps"></a>
+
+### atomEnvironment.keymaps : <code>KeymapManager</code>
+**Kind**: instance property of [<code>AtomEnvironment</code>](#AtomEnvironment)  
+<a name="AtomEnvironment+tooltips"></a>
+
+### atomEnvironment.tooltips : <code>TooltipManager</code>
+**Kind**: instance property of [<code>AtomEnvironment</code>](#AtomEnvironment)  
+<a name="AtomEnvironment+commands"></a>
+
+### atomEnvironment.commands : <code>CommandRegistry</code>
+**Kind**: instance property of [<code>AtomEnvironment</code>](#AtomEnvironment)  
+<a name="AtomEnvironment+grammars"></a>
+
+### atomEnvironment.grammars : <code>GrammarRegistry</code>
+**Kind**: instance property of [<code>AtomEnvironment</code>](#AtomEnvironment)  
+<a name="AtomEnvironment+styles"></a>
+
+### atomEnvironment.styles : <code>StyleManager</code>
+**Kind**: instance property of [<code>AtomEnvironment</code>](#AtomEnvironment)  
+<a name="AtomEnvironment+packages"></a>
+
+### atomEnvironment.packages : <code>PackageManager</code>
+**Kind**: instance property of [<code>AtomEnvironment</code>](#AtomEnvironment)  
+<a name="AtomEnvironment+themes"></a>
+
+### atomEnvironment.themes : <code>ThemeManager</code>
+**Kind**: instance property of [<code>AtomEnvironment</code>](#AtomEnvironment)  
+<a name="AtomEnvironment+menu"></a>
+
+### atomEnvironment.menu : <code>MenuManager</code>
+**Kind**: instance property of [<code>AtomEnvironment</code>](#AtomEnvironment)  
+<a name="AtomEnvironment+contextMenu"></a>
+
+### atomEnvironment.contextMenu : <code>ContextMenuManager</code>
+**Kind**: instance property of [<code>AtomEnvironment</code>](#AtomEnvironment)  
+<a name="AtomEnvironment+project"></a>
+
+### atomEnvironment.project : <code>Project</code>
+**Kind**: instance property of [<code>AtomEnvironment</code>](#AtomEnvironment)  
+<a name="AtomEnvironment+textEditors"></a>
+
+### atomEnvironment.textEditors : <code>TextEditorRegistry</code>
+**Kind**: instance property of [<code>AtomEnvironment</code>](#AtomEnvironment)  
+<a name="AtomEnvironment+workspace"></a>
+
+### atomEnvironment.workspace : <code>Workspace</code>
+**Kind**: instance property of [<code>AtomEnvironment</code>](#AtomEnvironment)  
+<a name="AtomEnvironment+history"></a>
+
+### atomEnvironment.history : <code>HistoryManager</code>
+**Kind**: instance property of [<code>AtomEnvironment</code>](#AtomEnvironment)  
+<a name="AtomEnvironment+beep"></a>
+
+### atomEnvironment.beep()
+Visually and audibly trigger a beep.
+
+**Kind**: instance method of [<code>AtomEnvironment</code>](#AtomEnvironment)  
+**Category**: Messaging the User  
+**Emits**: <code>event:beep</code>  
+<a name="AtomEnvironment.onDidBeep"></a>
+
+### AtomEnvironment.onDidBeep(callback) ⇒ <code>Disposable</code>
+Invoke the given callback whenever [::beep](::beep) is called.
+
+**Kind**: static method of [<code>AtomEnvironment</code>](#AtomEnvironment)  
+**Returns**: <code>Disposable</code> - on which `.dispose()` can be called to unsubscribe.  
+**Category**: Event Subscription  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| callback | <code>function</code> | Function to be called whenever [::beep](::beep) is called. |
+
+<a name="Clipboard"></a>
+
+## Clipboard
+**Kind**: global class  
+<a name="new_Clipboard_new"></a>
+
+### new Clipboard()
+Represents the clipboard used for copying and pasting in Pulsar.An instance of this class is always available as the `atom.clipboard` global.
+
+**Example**  
+```js
+// returns 'hello'atom.clipboard.write('hello');console.log(atom.clipboard.read());
+```

--- a/docs/Source-Code-Documentation.md
+++ b/docs/Source-Code-Documentation.md
@@ -1,0 +1,158 @@
+## Classes
+
+<dl>
+<dt><a href="#AtomEnvironment">AtomEnvironment</a></dt>
+<dd><p>Pulsar global for dealing with packages, themes, menus, and the window.</p>
+<p>An instance of this class is always available as the <code>atom</code> global.</p>
+</dd>
+<dt><a href="#Clipboard">Clipboard</a></dt>
+<dd></dd>
+</dl>
+
+<a name="AtomEnvironment"></a>
+
+## AtomEnvironment
+Pulsar global for dealing with packages, themes, menus, and the window.An instance of this class is always available as the `atom` global.
+
+**Kind**: global class  
+
+* [AtomEnvironment](#AtomEnvironment)
+    * _instance_
+        * [.clipboard](#AtomEnvironment+clipboard) : [<code>Clipboard</code>](#Clipboard)
+        * [.deserializers](#AtomEnvironment+deserializers) : <code>DeserializerManager</code>
+        * [.views](#AtomEnvironment+views) : <code>ViewRegistry</code>
+        * [.notifications](#AtomEnvironment+notifications) : <code>NotificationManager</code>
+        * [.config](#AtomEnvironment+config) : <code>Config</code>
+        * [.keymaps](#AtomEnvironment+keymaps) : <code>KeymapManager</code>
+        * [.tooltips](#AtomEnvironment+tooltips) : <code>TooltipManager</code>
+        * [.commands](#AtomEnvironment+commands) : <code>CommandRegistry</code>
+        * [.grammars](#AtomEnvironment+grammars) : <code>GrammarRegistry</code>
+        * [.styles](#AtomEnvironment+styles) : <code>StyleManager</code>
+        * [.packages](#AtomEnvironment+packages) : <code>PackageManager</code>
+        * [.themes](#AtomEnvironment+themes) : <code>ThemeManager</code>
+        * [.menu](#AtomEnvironment+menu) : <code>MenuManager</code>
+        * [.contextMenu](#AtomEnvironment+contextMenu) : <code>ContextMenuManager</code>
+        * [.project](#AtomEnvironment+project) : <code>Project</code>
+        * [.textEditors](#AtomEnvironment+textEditors) : <code>TextEditorRegistry</code>
+        * [.workspace](#AtomEnvironment+workspace) : <code>Workspace</code>
+        * [.history](#AtomEnvironment+history) : <code>HistoryManager</code>
+        * _Messaging the User_
+            * [.beep()](#AtomEnvironment+beep)
+    * _static_
+        * [.preloadPackages](#AtomEnvironment.preloadPackages) ℗
+        * _Event Subscription_
+            * [.onDidBeep(callback)](#AtomEnvironment.onDidBeep) ⇒ <code>Disposable</code>
+
+<a name="AtomEnvironment+clipboard"></a>
+
+### atomEnvironment.clipboard : [<code>Clipboard</code>](#Clipboard)
+**Kind**: instance property of [<code>AtomEnvironment</code>](#AtomEnvironment)  
+<a name="AtomEnvironment+deserializers"></a>
+
+### atomEnvironment.deserializers : <code>DeserializerManager</code>
+**Kind**: instance property of [<code>AtomEnvironment</code>](#AtomEnvironment)  
+<a name="AtomEnvironment+views"></a>
+
+### atomEnvironment.views : <code>ViewRegistry</code>
+**Kind**: instance property of [<code>AtomEnvironment</code>](#AtomEnvironment)  
+<a name="AtomEnvironment+notifications"></a>
+
+### atomEnvironment.notifications : <code>NotificationManager</code>
+**Kind**: instance property of [<code>AtomEnvironment</code>](#AtomEnvironment)  
+<a name="AtomEnvironment+config"></a>
+
+### atomEnvironment.config : <code>Config</code>
+**Kind**: instance property of [<code>AtomEnvironment</code>](#AtomEnvironment)  
+<a name="AtomEnvironment+keymaps"></a>
+
+### atomEnvironment.keymaps : <code>KeymapManager</code>
+**Kind**: instance property of [<code>AtomEnvironment</code>](#AtomEnvironment)  
+<a name="AtomEnvironment+tooltips"></a>
+
+### atomEnvironment.tooltips : <code>TooltipManager</code>
+**Kind**: instance property of [<code>AtomEnvironment</code>](#AtomEnvironment)  
+<a name="AtomEnvironment+commands"></a>
+
+### atomEnvironment.commands : <code>CommandRegistry</code>
+**Kind**: instance property of [<code>AtomEnvironment</code>](#AtomEnvironment)  
+<a name="AtomEnvironment+grammars"></a>
+
+### atomEnvironment.grammars : <code>GrammarRegistry</code>
+**Kind**: instance property of [<code>AtomEnvironment</code>](#AtomEnvironment)  
+<a name="AtomEnvironment+styles"></a>
+
+### atomEnvironment.styles : <code>StyleManager</code>
+**Kind**: instance property of [<code>AtomEnvironment</code>](#AtomEnvironment)  
+<a name="AtomEnvironment+packages"></a>
+
+### atomEnvironment.packages : <code>PackageManager</code>
+**Kind**: instance property of [<code>AtomEnvironment</code>](#AtomEnvironment)  
+<a name="AtomEnvironment+themes"></a>
+
+### atomEnvironment.themes : <code>ThemeManager</code>
+**Kind**: instance property of [<code>AtomEnvironment</code>](#AtomEnvironment)  
+<a name="AtomEnvironment+menu"></a>
+
+### atomEnvironment.menu : <code>MenuManager</code>
+**Kind**: instance property of [<code>AtomEnvironment</code>](#AtomEnvironment)  
+<a name="AtomEnvironment+contextMenu"></a>
+
+### atomEnvironment.contextMenu : <code>ContextMenuManager</code>
+**Kind**: instance property of [<code>AtomEnvironment</code>](#AtomEnvironment)  
+<a name="AtomEnvironment+project"></a>
+
+### atomEnvironment.project : <code>Project</code>
+**Kind**: instance property of [<code>AtomEnvironment</code>](#AtomEnvironment)  
+<a name="AtomEnvironment+textEditors"></a>
+
+### atomEnvironment.textEditors : <code>TextEditorRegistry</code>
+**Kind**: instance property of [<code>AtomEnvironment</code>](#AtomEnvironment)  
+<a name="AtomEnvironment+workspace"></a>
+
+### atomEnvironment.workspace : <code>Workspace</code>
+**Kind**: instance property of [<code>AtomEnvironment</code>](#AtomEnvironment)  
+<a name="AtomEnvironment+history"></a>
+
+### atomEnvironment.history : <code>HistoryManager</code>
+**Kind**: instance property of [<code>AtomEnvironment</code>](#AtomEnvironment)  
+<a name="AtomEnvironment+beep"></a>
+
+### atomEnvironment.beep()
+Visually and audibly trigger a beep.
+
+**Kind**: instance method of [<code>AtomEnvironment</code>](#AtomEnvironment)  
+**Category**: Messaging the User  
+**Emits**: <code>event:beep</code>  
+<a name="AtomEnvironment.preloadPackages"></a>
+
+### AtomEnvironment.preloadPackages ℗
+Returns output of `preloadPackages()` for this Classes Instance of `Packages`.
+
+**Kind**: static property of [<code>AtomEnvironment</code>](#AtomEnvironment)  
+**Access**: private  
+<a name="AtomEnvironment.onDidBeep"></a>
+
+### AtomEnvironment.onDidBeep(callback) ⇒ <code>Disposable</code>
+Invoke the given callback whenever [::beep](::beep) is called.
+
+**Kind**: static method of [<code>AtomEnvironment</code>](#AtomEnvironment)  
+**Returns**: <code>Disposable</code> - on which `.dispose()` can be called to unsubscribe.  
+**Category**: Event Subscription  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| callback | <code>function</code> | Function to be called whenever [::beep](::beep) is called. |
+
+<a name="Clipboard"></a>
+
+## Clipboard
+**Kind**: global class  
+<a name="new_Clipboard_new"></a>
+
+### new Clipboard()
+Represents the clipboard used for copying and pasting in Pulsar.An instance of this class is always available as the `atom.clipboard` global.
+
+**Example**  
+```js
+// returns 'hello'atom.clipboard.write('hello');console.log(atom.clipboard.read());
+```

--- a/package.json
+++ b/package.json
@@ -282,6 +282,7 @@
     "electron-builder": "23.3.1",
     "electron-rebuild": "3.2.7",
     "eslint": "^8.27.0",
+    "eslint-plugin-jsdoc": "^39.6.4",
     "eslint-plugin-node": "^11.1.0",
     "jsdoc-to-markdown": "^8.0.0",
     "playwright": "1.22.2",

--- a/package.json
+++ b/package.json
@@ -273,8 +273,8 @@
     "build:apm": "cd ppm && yarn install",
     "start": "electron --no-sandbox --enable-logging . -f",
     "dist": "node script/electron-builder.js",
-    "js-docs": "jsdoc2md ./src/*.js ./src/main-process/*.js ./packages/*/*.js > ./docs/Pulsar-API-Documentation.md",
-    "private-js-docs": "jsdoc2md --private ./src/*.js ./src/main-process/*.js ./packages/*/*.js > ./docs/Source-Code-Documentation.md"
+    "js-docs": "jsdoc2md ./src/**/*.js ./packages/**/*.js > ./docs/Pulsar-API-Documentation.md",
+    "private-js-docs": "jsdoc2md --private ./src/**/*.js ./packages/**/*.js > ./docs/Source-Code-Documentation.md"
   },
   "devDependencies": {
     "@playwright/test": "1.22.2",

--- a/package.json
+++ b/package.json
@@ -272,7 +272,9 @@
     "build": "electron-rebuild",
     "build:apm": "cd ppm && yarn install",
     "start": "electron --no-sandbox --enable-logging . -f",
-    "dist": "node script/electron-builder.js"
+    "dist": "node script/electron-builder.js",
+    "js-docs": "jsdoc2md ./src/*.js ./src/main-process/*.js ./packages/*/*.js > ./docs/Pulsar-API-Documentation.md",
+    "private-js-docs": "jsdoc2md --private ./src/*.js ./src/main-process/*.js ./packages/*/*.js > ./docs/Source-Code-Documentation.md"
   },
   "devDependencies": {
     "@playwright/test": "1.22.2",
@@ -281,6 +283,7 @@
     "electron-rebuild": "3.2.7",
     "eslint": "^8.27.0",
     "eslint-plugin-node": "^11.1.0",
+    "jsdoc-to-markdown": "^8.0.0",
     "playwright": "1.22.2",
     "playwright-core": "1.22.2",
     "random-seed": "0.3.0",

--- a/src/atom-environment.js
+++ b/src/atom-environment.js
@@ -52,18 +52,18 @@ const stat = util.promisify(fs.stat);
 
 let nextId = 0;
 
-// Essential: Pulsar global for dealing with packages, themes, menus, and the window.
-//
-// An instance of this class is always available as the `atom` global.
+/**
+ * @class AtomEnvironment
+ * @classdesc Pulsar global for dealing with packages, themes, menus, and the window.
+ *
+ * An instance of this class is always available as the `atom` global.
+ */
 class AtomEnvironment {
-  /*
-  Section: Properties
-  */
 
   constructor(params = {}) {
     this.id = params.id != null ? params.id : nextId++;
 
-    // Public: A {Clipboard} instance
+    /** @type {Clipboard} */
     this.clipboard = params.clipboard;
     this.updateProcessEnv = params.updateProcessEnv || updateProcessEnv;
     this.enablePersistence = params.enablePersistence;
@@ -76,19 +76,19 @@ class AtomEnvironment {
     this.disposables = new CompositeDisposable();
     this.pathsWithWaitSessions = new Set();
 
-    // Public: A {DeserializerManager} instance
+    /** @type {DeserializerManager} */
     this.deserializers = new DeserializerManager(this);
     this.deserializeTimings = {};
 
-    // Public: A {ViewRegistry} instance
+    /** @type {ViewRegistry} */
     this.views = new ViewRegistry(this);
 
-    // Public: A {NotificationManager} instance
+    /** @type {NotificationManager} */
     this.notifications = new NotificationManager();
 
     this.stateStore = new StateStore('AtomEnvironments', 1);
 
-    // Public: A {Config} instance
+    /** @type {Config} */
     this.config = new Config({
       saveCallback: settings => {
         if (this.enablePersistence) {
@@ -104,28 +104,28 @@ class AtomEnvironment {
       properties: _.clone(ConfigSchema)
     });
 
-    // Public: A {KeymapManager} instance
+    /** @type {KeymapManager} */
     this.keymaps = new KeymapManager({
       notificationManager: this.notifications
     });
 
-    // Public: A {TooltipManager} instance
+    /** @type {TooltipManager} */
     this.tooltips = new TooltipManager({
       keymapManager: this.keymaps,
       viewRegistry: this.views
     });
 
-    // Public: A {CommandRegistry} instance
+    /** @type {CommandRegistry} */
     this.commands = new CommandRegistry();
     this.uriHandlerRegistry = new URIHandlerRegistry();
 
-    // Public: A {GrammarRegistry} instance
+    /** @type {GrammarRegistry} */
     this.grammars = new GrammarRegistry({ config: this.config });
 
-    // Public: A {StyleManager} instance
+    /** @type {StyleManager} */
     this.styles = new StyleManager();
 
-    // Public: A {PackageManager} instance
+    /** @type {PackageManager} */
     this.packages = new PackageManager({
       config: this.config,
       styleManager: this.styles,
@@ -138,7 +138,7 @@ class AtomEnvironment {
       uriHandlerRegistry: this.uriHandlerRegistry
     });
 
-    // Public: A {ThemeManager} instance
+    /** @type {ThemeManager} */
     this.themes = new ThemeManager({
       packageManager: this.packages,
       config: this.config,
@@ -147,20 +147,20 @@ class AtomEnvironment {
       viewRegistry: this.views
     });
 
-    // Public: A {MenuManager} instance
+    /** @type {MenuManager} */
     this.menu = new MenuManager({
       keymapManager: this.keymaps,
       packageManager: this.packages
     });
 
-    // Public: A {ContextMenuManager} instance
+    /** @type {ContextMenuManager} */
     this.contextMenu = new ContextMenuManager({ keymapManager: this.keymaps });
 
     this.packages.setMenuManager(this.menu);
     this.packages.setContextMenuManager(this.contextMenu);
     this.packages.setThemeManager(this.themes);
 
-    // Public: A {Project} instance
+    /** @type {Project} */
     this.project = new Project({
       notificationManager: this.notifications,
       packageManager: this.packages,
@@ -171,7 +171,7 @@ class AtomEnvironment {
     this.commandInstaller = new CommandInstaller(this.applicationDelegate);
     this.protocolHandlerInstaller = new ProtocolHandlerInstaller();
 
-    // Public: A {TextEditorRegistry} instance
+    /** @type {TextEditorRegistry} */
     this.textEditors = new TextEditorRegistry({
       config: this.config,
       grammarRegistry: this.grammars,
@@ -179,7 +179,7 @@ class AtomEnvironment {
       packageManager: this.packages
     });
 
-    // Public: A {Workspace} instance
+    /** @type {Workspace} */
     this.workspace = new Workspace({
       config: this.config,
       project: this.project,
@@ -214,7 +214,7 @@ class AtomEnvironment {
       applicationDelegate: this.applicationDelegate
     });
 
-    // Public: A {HistoryManager} instance
+    /** @type {HistoryManager} */
     this.history = new HistoryManager({
       project: this.project,
       commands: this.commands,
@@ -339,6 +339,12 @@ class AtomEnvironment {
     );
   }
 
+  /**
+   * @name preloadPackages
+   * @private
+   * @memberof AtomEnvironment
+   * @desc Returns output of `preloadPackages()` for this Classes Instance of `Packages`.
+   */
   preloadPackages() {
     return this.packages.preloadPackages();
   }
@@ -469,15 +475,15 @@ class AtomEnvironment {
     this.uninstallWindowEventHandler();
   }
 
-  /*
-  Section: Event Subscription
-  */
-
-  // Extended: Invoke the given callback whenever {::beep} is called.
-  //
-  // * `callback` {Function} to be called whenever {::beep} is called.
-  //
-  // Returns a {Disposable} on which `.dispose()` can be called to unsubscribe.
+  /**
+   * @memberof AtomEnvironment
+   * @function onDidBeep
+   * @desc Invoke the given callback whenever {@link ::beep} is called.
+   * @listens ::beep
+   * @param {function} callback - Function to be called whenever {@link ::beep} is called.
+   * @returns {Disposable} on which `.dispose()` can be called to unsubscribe.
+   * @category Event Subscription
+   */
   onDidBeep(callback) {
     return this.emitter.on('did-beep', callback);
   }
@@ -1186,11 +1192,11 @@ class AtomEnvironment {
     this.packages.triggerActivationHook('core:loaded-shell-environment');
   }
 
-  /*
-  Section: Messaging the User
-  */
-
-  // Essential: Visually and audibly trigger a beep.
+  /**
+   * Visually and audibly trigger a beep.
+   * @fires beep
+   * @category Messaging the User
+   */
   beep() {
     if (this.config.get('core.audioBeep'))
       this.applicationDelegate.playBeepSound();

--- a/src/clipboard.js
+++ b/src/clipboard.js
@@ -12,6 +12,17 @@ const { clipboard } = require('electron');
 //
 // console.log(atom.clipboard.read()) // 'hello'
 // ```
+/**
+ * @class Clipboard
+ * @desc Represents the clipboard used for copying and pasting in Pulsar.
+ *
+ * An instance of this class is always available as the `atom.clipboard` global.
+ * @example
+ * // returns 'hello'
+ * atom.clipboard.write('hello');
+ *
+ * console.log(atom.clipboard.read());
+ */
 module.exports = class Clipboard {
   constructor() {
     this.reset();

--- a/yarn.lock
+++ b/yarn.lock
@@ -1406,6 +1406,15 @@
     minimatch "^3.0.4"
     plist "^3.0.4"
 
+"@es-joy/jsdoccomment@~0.36.1":
+  version "0.36.1"
+  resolved "https://registry.yarnpkg.com/@es-joy/jsdoccomment/-/jsdoccomment-0.36.1.tgz#c37db40da36e4b848da5fd427a74bae3b004a30f"
+  integrity sha512-922xqFsTpHs6D0BUiG4toiyPOMc8/jafnWKxz1KWgS4XzKPy2qXf1Pe6UFuNSCQqt6tOuhAWXBNuuyUhJmw9Vg==
+  dependencies:
+    comment-parser "1.3.1"
+    esquery "^1.4.0"
+    jsdoc-type-pratt-parser "~3.1.0"
+
 "@eslint/eslintrc@^1.3.3":
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-1.3.3.tgz#2b044ab39fdfa75b4688184f9e573ce3c5b0ff95"
@@ -3247,6 +3256,11 @@ commander@^6.2.0:
   resolved "https://registry.yarnpkg.com/commander/-/commander-6.2.1.tgz#0792eb682dfbc325999bb2b84fddddba110ac73c"
   integrity sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==
 
+comment-parser@1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/comment-parser/-/comment-parser-1.3.1.tgz#3d7ea3adaf9345594aedee6563f422348f165c1b"
+  integrity sha512-B52sN2VNghyq5ofvUsqZjmk6YkihBX5vMSChmSK9v4ShjKf3Vk5Xcmgpw4o+iIgtrnM/u5FiMpz9VKb8lpBveA==
+
 common-sequence@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/common-sequence/-/common-sequence-2.0.2.tgz#accc76bdc5876a1fcd92b73484d4285fff99d838"
@@ -4202,6 +4216,19 @@ eslint-plugin-es@^3.0.0:
   dependencies:
     eslint-utils "^2.0.0"
     regexpp "^3.0.0"
+
+eslint-plugin-jsdoc@^39.6.4:
+  version "39.6.4"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-39.6.4.tgz#b940aebd3eea26884a0d341785d2dc3aba6a38a7"
+  integrity sha512-fskvdLCfwmPjHb6e+xNGDtGgbF8X7cDwMtVLAP2WwSf9Htrx68OAx31BESBM1FAwsN2HTQyYQq7m4aW4Q4Nlag==
+  dependencies:
+    "@es-joy/jsdoccomment" "~0.36.1"
+    comment-parser "1.3.1"
+    debug "^4.3.4"
+    escape-string-regexp "^4.0.0"
+    esquery "^1.4.0"
+    semver "^7.3.8"
+    spdx-expression-parse "^3.0.1"
 
 eslint-plugin-node@^11.1.0:
   version "11.1.0"
@@ -5977,6 +6004,11 @@ jsdoc-to-markdown@^8.0.0:
     jsdoc-api "^8.0.0"
     jsdoc-parse "^6.2.0"
     walk-back "^5.1.0"
+
+jsdoc-type-pratt-parser@~3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-3.1.0.tgz#a4a56bdc6e82e5865ffd9febc5b1a227ff28e67e"
+  integrity sha512-MgtD0ZiCDk9B+eI73BextfRrVQl0oyzRG8B2BjORts6jbunj4ScKPcyXGTbB6eXL4y9TzxCm6hyeLq/2ASzNdw==
 
 jsdoc@^4.0.0:
   version "4.0.0"
@@ -8509,7 +8541,7 @@ semver@^6.0.0, semver@^6.1.0, semver@^6.1.1, semver@^6.1.2, semver@^6.2.0, semve
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
 
-semver@^7.3.2, semver@^7.3.4, semver@^7.3.5, semver@^7.3.7:
+semver@^7.3.2, semver@^7.3.4, semver@^7.3.5, semver@^7.3.7, semver@^7.3.8:
   version "7.3.8"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.8.tgz#07a78feafb3f7b32347d725e33de7e2a2df67798"
   integrity sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==
@@ -8763,7 +8795,7 @@ spdx-exceptions@^2.1.0:
   resolved "https://registry.yarnpkg.com/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz#3f28ce1a77a00372683eade4a433183527a2163d"
   integrity sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A==
 
-spdx-expression-parse@^3.0.0:
+spdx-expression-parse@^3.0.0, spdx-expression-parse@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz#cf70f50482eefdc98e3ce0a6833e4a53ceeba679"
   integrity sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==

--- a/yarn.lock
+++ b/yarn.lock
@@ -376,6 +376,11 @@
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.20.3.tgz#5358cf62e380cf69efcb87a7bb922ff88bfac6e2"
   integrity sha512-OP/s5a94frIPXwjzEcv5S/tpQfc6XhxYUnmWpgdqMWGgYCuErA3SzozaRAMQgSZWKeTJxht9aWAkUY+0UzvOFg==
 
+"@babel/parser@^7.9.4":
+  version "7.20.7"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.20.7.tgz#66fe23b3c8569220817d5feb8b9dcdc95bb4f71b"
+  integrity sha512-T3Z9oHybU+0vZlY9CiDSJQTD5ZapcW18ZctFMi0MOAl/4BjFF4ul7NVSARLdbGO5vDqy9eQiGTV0LtKfvCYvcg==
+
 "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@^7.18.6":
   version "7.18.6"
   resolved "https://registry.yarnpkg.com/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression/-/plugin-bugfix-safari-id-destructuring-collision-in-function-expression-7.18.6.tgz#da5b8f9a580acdfbe53494dba45ea389fb09a4d2"
@@ -1480,6 +1485,13 @@
     "@jridgewell/resolve-uri" "3.1.0"
     "@jridgewell/sourcemap-codec" "1.4.14"
 
+"@jsdoc/salty@^0.2.1":
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/@jsdoc/salty/-/salty-0.2.2.tgz#567017ddda2048c5ff921aeffd38564a0578fdca"
+  integrity sha512-A1FrVnc7L9qI2gUGsfN0trTiJNK72Y0CL/VAyrmYEmeKI3pnHDawP64CEev31XLyAAOx2xmDo3tbadPxC0CSbw==
+  dependencies:
+    lodash "^4.17.21"
+
 "@malept/cross-spawn-promise@^1.1.0":
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@malept/cross-spawn-promise/-/cross-spawn-promise-1.1.1.tgz#504af200af6b98e198bce768bc1730c6936ae01d"
@@ -1711,6 +1723,24 @@
   dependencies:
     "@types/node" "*"
 
+"@types/linkify-it@*":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@types/linkify-it/-/linkify-it-3.0.2.tgz#fd2cd2edbaa7eaac7e7f3c1748b52a19143846c9"
+  integrity sha512-HZQYqbiFVWufzCwexrvh694SOim8z2d+xJl5UNamcvQFejLY/2YUtzXHYi3cHdI7PMlS8ejH2slRAOJQ32aNbA==
+
+"@types/markdown-it@^12.2.3":
+  version "12.2.3"
+  resolved "https://registry.yarnpkg.com/@types/markdown-it/-/markdown-it-12.2.3.tgz#0d6f6e5e413f8daaa26522904597be3d6cd93b51"
+  integrity sha512-GKMHFfv3458yYy+v/N8gjufHO6MSZKCOXpZc5GXIWWy8uldwfmPn98vp81gZ5f9SVw8YYBctgfJ22a2d7AOMeQ==
+  dependencies:
+    "@types/linkify-it" "*"
+    "@types/mdurl" "*"
+
+"@types/mdurl@*":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@types/mdurl/-/mdurl-1.0.2.tgz#e2ce9d83a613bacf284c7be7d491945e39e1f8e9"
+  integrity sha512-eC4U9MlIcu2q0KQmXszyn5Akca/0jrQmwDRgpAMJai7qBWq4amIQhZyNau4VYGtCeALvW1/NtjzJJ567aZxfKA==
+
 "@types/minimatch@*":
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-5.1.2.tgz#07508b45797cb81ec3f273011b054cd0755eddca"
@@ -1935,6 +1965,13 @@ ansi-colors@3.2.3:
   resolved "https://registry.yarnpkg.com/ansi-colors/-/ansi-colors-3.2.3.tgz#57d35b8686e851e2cc04c403f1c00203976a1813"
   integrity sha512-LEHHyuhlPY3TmuUYMh2oz89lTShfvgbmzaBcxve9t/9Wuy7Dwf4yoAKcND7KFT1HAQfqZ12qtc+DUrBMeKF9nw==
 
+ansi-escape-sequences@^4.0.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/ansi-escape-sequences/-/ansi-escape-sequences-4.1.0.tgz#2483c8773f50dd9174dd9557e92b1718f1816097"
+  integrity sha512-dzW9kHxH011uBsidTXd14JXgzye/YLb2LzeKZ4bsgl/Knwx8AtbSFkkGxagdNOoh0DlqHCmfiEjWKBaqjOanVw==
+  dependencies:
+    array-back "^3.0.1"
+
 ansi-regex@^2.0.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-2.1.1.tgz#c3b33ab5ee360d86e0e628f0468ae7ef27d654df"
@@ -2107,6 +2144,40 @@ aria-query@^5.0.0:
   integrity sha512-R5iJ5lkuHybztUfuOAznmboyjWq8O6sqNqtK7CLOqdydi54VNbORp49mb14KbWgG1QD3JFO9hJdZ+y4KutfdOQ==
   dependencies:
     deep-equal "^2.0.5"
+
+array-back@^1.0.2, array-back@^1.0.3:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/array-back/-/array-back-1.0.4.tgz#644ba7f095f7ffcf7c43b5f0dc39d3c1f03c063b"
+  integrity sha512-1WxbZvrmyhkNoeYcizokbmh5oiOCIfyvGtcqbK3Ls1v1fKcquzxnQSceOx6tzq7jmai2kFLWIpGND2cLhH6TPw==
+  dependencies:
+    typical "^2.6.0"
+
+array-back@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/array-back/-/array-back-2.0.0.tgz#6877471d51ecc9c9bfa6136fb6c7d5fe69748022"
+  integrity sha512-eJv4pLLufP3g5kcZry0j6WXpIbzYw9GUB4mVJZno9wfwiBxbizTnHCw3VJb07cBihbFX48Y7oSrW9y+gt4glyw==
+  dependencies:
+    typical "^2.6.1"
+
+array-back@^3.0.1, array-back@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/array-back/-/array-back-3.1.0.tgz#b8859d7a508871c9a7b2cf42f99428f65e96bfb0"
+  integrity sha512-TkuxA4UCOvxuDK6NZYXCalszEzj+TLszyASooky+i742l9TqsOdYCMJJupxRic61hwquNtppB3hgcuq9SVSH1Q==
+
+array-back@^4.0.1:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/array-back/-/array-back-4.0.2.tgz#8004e999a6274586beeb27342168652fdb89fa1e"
+  integrity sha512-NbdMezxqf94cnNfWLL7V/im0Ub+Anbb0IoZhvzie8+4HJ4nMQuzHuy49FkGYCJK2yAloZ3meiB6AVMClbrI1vg==
+
+array-back@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/array-back/-/array-back-5.0.0.tgz#e196609edcec48376236d163958df76e659a0d36"
+  integrity sha512-kgVWwJReZWmVuWOQKEOohXKJX+nD02JAZ54D1RRWlv8L0NebauKAaFxACKzB74RTclt1+WNz5KHaLRDAPZbDEw==
+
+array-back@^6.2.2:
+  version "6.2.2"
+  resolved "https://registry.yarnpkg.com/array-back/-/array-back-6.2.2.tgz#f567d99e9af88a6d3d2f9dfcc21db6f9ba9fd157"
+  integrity sha512-gUAZ7HPyb4SJczXAMUXMGAvI976JoK3qEx9v1FTmeYuJj0IBiaKttG1ydtGKdkfqWkIkouke7nG8ufGy77+Cvw==
 
 array.prototype.reduce@^1.0.5:
   version "1.0.5"
@@ -2509,7 +2580,7 @@ bluebird-lst@^1.0.9:
   dependencies:
     bluebird "^3.5.5"
 
-bluebird@^3.5.0, bluebird@^3.5.5:
+bluebird@^3.5.0, bluebird@^3.5.5, bluebird@^3.7.2:
   version "3.7.2"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.7.2.tgz#9f229c15be272454ffa973ace0dbee79a1b0c36f"
   integrity sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==
@@ -2700,6 +2771,15 @@ cacache@^15.2.0:
     tar "^6.0.2"
     unique-filename "^1.1.1"
 
+cache-point@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/cache-point/-/cache-point-2.0.0.tgz#91e03c38da9cfba9d95ac6a34d24cfe6eff8920f"
+  integrity sha512-4gkeHlFpSKgm3vm2gJN5sPqfmijYRFYCQ6tv5cLw0xVmT6r1z1vd4FNnpuOREco3cBs1G709sZ72LdgddKvL5w==
+  dependencies:
+    array-back "^4.0.1"
+    fs-then-native "^2.0.0"
+    mkdirp2 "^1.0.4"
+
 cacheable-lookup@^5.0.3:
   version "5.0.4"
   resolved "https://registry.yarnpkg.com/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz#5a6b865b2c44357be3d5ebc2a467b032719a7005"
@@ -2768,6 +2848,13 @@ caseless@~0.12.0:
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
   integrity sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==
+
+catharsis@^0.9.0:
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/catharsis/-/catharsis-0.9.0.tgz#40382a168be0e6da308c277d3a2b3eb40c7d2121"
+  integrity sha512-prMTQVpcns/tzFgFVkVp6ak6RykZyWb3gu8ckUpd6YkTlacOd3DXGJjIpD4Q6zJirizvaiAjSSHlOsA+6sNh2A==
+  dependencies:
+    lodash "^4.17.15"
 
 chai@4.3.4:
   version "4.3.4"
@@ -3024,6 +3111,14 @@ coffee-script@~1.8.0:
     fs-plus "^3.1.1"
     source-map "~0.1.43"
 
+collect-all@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/collect-all/-/collect-all-1.0.4.tgz#50cd7119ac24b8e12a661f0f8c3aa0ea7222ddfc"
+  integrity sha512-RKZhRwJtJEP5FWul+gkSMEnaK6H3AGPTTWOiRimCcs+rc/OmQE3Yhy1Q7A7KsdkG3ZXVdZq68Y6ONSdvkeEcKA==
+  dependencies:
+    stream-connect "^1.0.2"
+    stream-via "^1.0.4"
+
 color-convert@^1.9.0, color-convert@^1.9.1:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.3.tgz#bb71850690e1f136567de629d2d5471deda4c1e8"
@@ -3091,6 +3186,37 @@ combined-stream@^1.0.5, combined-stream@^1.0.6, combined-stream@^1.0.8, combined
   dependencies:
     delayed-stream "~1.0.0"
 
+command-line-args@^5.0.0:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/command-line-args/-/command-line-args-5.2.1.tgz#c44c32e437a57d7c51157696893c5909e9cec42e"
+  integrity sha512-H4UfQhZyakIjC74I9d34fGYDwk3XpSr17QhEd0Q3I9Xq1CETHo4Hcuo87WyWHpAF1aSLjLRf5lD9ZGX2qStUvg==
+  dependencies:
+    array-back "^3.1.0"
+    find-replace "^3.0.0"
+    lodash.camelcase "^4.3.0"
+    typical "^4.0.0"
+
+command-line-tool@^0.8.0:
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/command-line-tool/-/command-line-tool-0.8.0.tgz#b00290ef1dfc11cc731dd1f43a92cfa5f21e715b"
+  integrity sha512-Xw18HVx/QzQV3Sc5k1vy3kgtOeGmsKIqwtFFoyjI4bbcpSgnw2CWVULvtakyw4s6fhyAdI6soQQhXc2OzJy62g==
+  dependencies:
+    ansi-escape-sequences "^4.0.0"
+    array-back "^2.0.0"
+    command-line-args "^5.0.0"
+    command-line-usage "^4.1.0"
+    typical "^2.6.1"
+
+command-line-usage@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/command-line-usage/-/command-line-usage-4.1.0.tgz#a6b3b2e2703b4dcf8bd46ae19e118a9a52972882"
+  integrity sha512-MxS8Ad995KpdAC0Jopo/ovGIroV/m0KHwzKfXxKag6FHOkGsH8/lv5yjgablcRxCJJC0oJeUMuO/gmaq+Wq46g==
+  dependencies:
+    ansi-escape-sequences "^4.0.0"
+    array-back "^2.0.0"
+    table-layout "^0.4.2"
+    typical "^2.6.1"
+
 "command-palette@file:packages/command-palette":
   version "0.43.5"
   dependencies:
@@ -3120,6 +3246,11 @@ commander@^6.2.0:
   version "6.2.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-6.2.1.tgz#0792eb682dfbc325999bb2b84fddddba110ac73c"
   integrity sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==
+
+common-sequence@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/common-sequence/-/common-sequence-2.0.2.tgz#accc76bdc5876a1fcd92b73484d4285fff99d838"
+  integrity sha512-jAg09gkdkrDO9EWTdXfv80WWH3yeZl5oT69fGfedBNS9pXUKYInVJ1bJ+/ht2+Moeei48TmSbQDYMc8EOx9G0g==
 
 compare-sets@1.0.1:
   version "1.0.1"
@@ -3163,6 +3294,13 @@ config-chain@^1.1.11:
   dependencies:
     ini "^1.3.4"
     proto-list "~1.2.1"
+
+config-master@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/config-master/-/config-master-3.1.0.tgz#667663590505a283bf26a484d68489d74c5485da"
+  integrity sha512-n7LBL1zBzYdTpF1mx5DNcZnZn05CWIdsdvtPL4MosvqbBUK3Rq6VWEtGUuF3Y0s9/CIhMejezqlSkP6TnCJ/9g==
+  dependencies:
+    walk-back "^2.0.1"
 
 configstore@^5.0.1:
   version "5.0.1"
@@ -3441,7 +3579,7 @@ deep-equal@^2.0.5:
     which-collection "^1.0.1"
     which-typed-array "^1.1.8"
 
-deep-extend@^0.6.0:
+deep-extend@^0.6.0, deep-extend@~0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.6.0.tgz#c4fa7c95404a17a9c3e8ca7e1537312b736330ac"
   integrity sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==
@@ -3580,6 +3718,24 @@ dir-compare@^2.4.0:
     colors "1.0.3"
     commander "2.9.0"
     minimatch "3.0.4"
+
+dmd@^6.2.0:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/dmd/-/dmd-6.2.0.tgz#d267a9fb1ce62b74edca8bf5bcbd3b8e08574fe7"
+  integrity sha512-uXWxLF1H7TkUAuoHK59/h/ts5cKavm2LnhrIgJWisip4BVzPoXavlwyoprFFn2CzcahKYgvkfaebS6oxzgflkg==
+  dependencies:
+    array-back "^6.2.2"
+    cache-point "^2.0.0"
+    common-sequence "^2.0.2"
+    file-set "^4.0.2"
+    handlebars "^4.7.7"
+    marked "^4.2.3"
+    object-get "^2.1.1"
+    reduce-flatten "^3.0.1"
+    reduce-unique "^2.0.1"
+    reduce-without "^1.0.1"
+    test-value "^3.0.0"
+    walk-back "^5.1.0"
 
 dmg-builder@23.3.1:
   version "23.3.1"
@@ -3869,6 +4025,11 @@ entities@^4.2.0, entities@^4.3.0, entities@^4.4.0:
   resolved "https://registry.yarnpkg.com/entities/-/entities-4.4.0.tgz#97bdaba170339446495e653cfd2db78962900174"
   integrity sha512-oYp7156SP8LkeGD0GF85ad1X9Ai79WtRsZ2gxJqtBuzH+98YUV6jkHEKlZkMbcrjJjIVJNIDP/3WL9wQkoPbWA==
 
+entities@~2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/entities/-/entities-2.1.0.tgz#992d3129cf7df6870b96c57858c249a120f8b8b5"
+  integrity sha512-hCx1oky9PFrJ611mf0ifBLBRW8lUUVRlFolb5gWRfIELabBlbp9xZvrqZLZAs+NxFnbfQoeGd8wDkygjg7U85w==
+
 env-paths@^2.2.0:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/env-paths/-/env-paths-2.2.1.tgz#420399d416ce1fbe9bc0a07c62fa68d67fd0f8f2"
@@ -4023,6 +4184,11 @@ escape-string-regexp@1.0.5, escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
   integrity sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==
+
+escape-string-regexp@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz#a30304e99daa32e23b2fd20f51babd07cffca344"
+  integrity sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==
 
 escape-string-regexp@^4.0.0:
   version "4.0.0"
@@ -4329,6 +4495,14 @@ file-entry-cache@^6.0.1:
   dependencies:
     flat-cache "^3.0.4"
 
+file-set@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/file-set/-/file-set-4.0.2.tgz#8d67c92a864202c2085ac9f03f1c9909c7e27030"
+  integrity sha512-fuxEgzk4L8waGXaAkd8cMr73Pm0FxOVkn8hztzUW7BAHhOGH90viQNXbiOsnecCWmfInqU6YmAMwxRMdKETceQ==
+  dependencies:
+    array-back "^5.0.0"
+    glob "^7.1.6"
+
 filelist@^1.0.1:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/filelist/-/filelist-1.0.4.tgz#f78978a1e944775ff9e62e744424f215e58352b5"
@@ -4365,6 +4539,13 @@ find-parent-dir@^0.3.0:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/find-parent-dir/-/find-parent-dir-0.3.1.tgz#c5c385b96858c3351f95d446cab866cbf9f11125"
   integrity sha512-o4UcykWV/XN9wm+jMEtWLPlV8RXCZnMhQI6F6OdHeSez7iiJWePw8ijOlskJZMsaQoGR/b7dH6lO02HhaTN7+A==
+
+find-replace@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/find-replace/-/find-replace-3.0.0.tgz#3e7e23d3b05167a76f770c9fbd5258b0def68c38"
+  integrity sha512-6Tb2myMioCAgv5kfvP5/PkZZ/ntTpVK39fHY7WkWBgvbeE+VHd/tZuZ4mrC+bxh4cfOZeYKVPaJIZtZXV7GNCQ==
+  dependencies:
+    array-back "^3.0.1"
 
 find-up@3.0.0, find-up@^3.0.0:
   version "3.0.0"
@@ -4551,6 +4732,11 @@ fs-readdir-recursive@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/fs-readdir-recursive/-/fs-readdir-recursive-1.1.0.tgz#e32fc030a2ccee44a6b5371308da54be0b397d27"
   integrity sha512-GNanXlVr2pf02+sPN40XN8HG+ePaNcvM0q5mZBd668Obwb0yD5GiUbZOFgwn8kGMY6I3mdyDJzieUy3PTYyTRA==
+
+fs-then-native@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/fs-then-native/-/fs-then-native-2.0.0.tgz#19a124d94d90c22c8e045f2e8dd6ebea36d48c67"
+  integrity sha512-X712jAOaWXkemQCAmWeg5rOT2i+KOpWz1Z/txk/cW0qlOu2oQ9H61vc5w3X/iyuUEfq/OyaFJ78/cZAQD1/bgA==
 
 fs.realpath@^1.0.0:
   version "1.0.0"
@@ -4946,7 +5132,7 @@ got@^9.6.0:
     to-readable-stream "^1.0.0"
     url-parse-lax "^3.0.0"
 
-graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.6:
+graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.1.9, graceful-fs@^4.2.0, graceful-fs@^4.2.6:
   version "4.2.10"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.10.tgz#147d3a006da4ca3ce14728c7aefc287c367d7a6c"
   integrity sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==
@@ -4991,6 +5177,18 @@ growl@1.10.5:
   version "1.10.5"
   resolved "https://registry.yarnpkg.com/growl/-/growl-1.10.5.tgz#f2735dc2283674fa67478b10181059355c369e5e"
   integrity sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==
+
+handlebars@^4.7.7:
+  version "4.7.7"
+  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.7.7.tgz#9ce33416aad02dbd6c8fafa8240d5d98004945a1"
+  integrity sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==
+  dependencies:
+    minimist "^1.2.5"
+    neo-async "^2.6.0"
+    source-map "^0.6.1"
+    wordwrap "^1.0.0"
+  optionalDependencies:
+    uglify-js "^3.1.4"
 
 har-schema@^1.0.5:
   version "1.0.5"
@@ -5723,6 +5921,13 @@ js-yaml@^4.1.0:
   dependencies:
     argparse "^2.0.1"
 
+js2xmlparser@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/js2xmlparser/-/js2xmlparser-4.0.2.tgz#2a1fdf01e90585ef2ae872a01bc169c6a8d5e60a"
+  integrity sha512-6n4D8gLlLf1n5mNLQPRfViYzu9RATblzPEtm1SthMX1Pjao0r9YI9nw7ZIfRxQMERS87mcswrg+r/OYrPRX6jA==
+  dependencies:
+    xmlcreate "^2.0.4"
+
 jsbn@~0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.1.tgz#a5e654c2e5a2deb5f201d96cefbca80c0ef2f513"
@@ -5732,6 +5937,67 @@ jschardet@^1.1.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/jschardet/-/jschardet-1.6.0.tgz#c7d1a71edcff2839db2f9ec30fc5d5ebd3c1a678"
   integrity sha512-xYuhvQ7I9PDJIGBWev9xm0+SMSed3ZDBAmvVjbFR1ZRLAF+vlXcQu6cRI9uAlj81rzikElRVteehwV7DuX2ZmQ==
+
+jsdoc-api@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/jsdoc-api/-/jsdoc-api-8.0.0.tgz#4b2c25ff60f91b80da51b6cd33943acc7b2cab74"
+  integrity sha512-Rnhor0suB1Ds1abjmFkFfKeD+kSMRN9oHMTMZoJVUrmtCGDwXty+sWMA9sa4xbe4UyxuPjhC7tavZ40mDKK6QQ==
+  dependencies:
+    array-back "^6.2.2"
+    cache-point "^2.0.0"
+    collect-all "^1.0.4"
+    file-set "^4.0.2"
+    fs-then-native "^2.0.0"
+    jsdoc "^4.0.0"
+    object-to-spawn-args "^2.0.1"
+    temp-path "^1.0.0"
+    walk-back "^5.1.0"
+
+jsdoc-parse@^6.2.0:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/jsdoc-parse/-/jsdoc-parse-6.2.0.tgz#2b71d3925acfc4badc72526f2470766e0561f6b5"
+  integrity sha512-Afu1fQBEb7QHt6QWX/6eUWvYHJofB90Fjx7FuJYF7mnG9z5BkAIpms1wsnvYLytfmqpEENHs/fax9p8gvMj7dw==
+  dependencies:
+    array-back "^6.2.2"
+    lodash.omit "^4.5.0"
+    lodash.pick "^4.4.0"
+    reduce-extract "^1.0.0"
+    sort-array "^4.1.5"
+    test-value "^3.0.0"
+
+jsdoc-to-markdown@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/jsdoc-to-markdown/-/jsdoc-to-markdown-8.0.0.tgz#27f32ed200d3b84dbf22a49beed485790f93b3ce"
+  integrity sha512-2FQvYkg491+FP6s15eFlgSSWs69CvQrpbABGYBtvAvGWy/lWo8IKKToarT283w59rQFrpcjHl3YdhHCa3l7gXg==
+  dependencies:
+    array-back "^6.2.2"
+    command-line-tool "^0.8.0"
+    config-master "^3.1.0"
+    dmd "^6.2.0"
+    jsdoc-api "^8.0.0"
+    jsdoc-parse "^6.2.0"
+    walk-back "^5.1.0"
+
+jsdoc@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/jsdoc/-/jsdoc-4.0.0.tgz#9569f79ea5b14ba4bc726da1a48fe6a241ad7893"
+  integrity sha512-tzTgkklbWKrlaQL2+e3NNgLcZu3NaK2vsHRx7tyHQ+H5jcB9Gx0txSd2eJWlMC/xU1+7LQu4s58Ry0RkuaEQVg==
+  dependencies:
+    "@babel/parser" "^7.9.4"
+    "@jsdoc/salty" "^0.2.1"
+    "@types/markdown-it" "^12.2.3"
+    bluebird "^3.7.2"
+    catharsis "^0.9.0"
+    escape-string-regexp "^2.0.0"
+    js2xmlparser "^4.0.2"
+    klaw "^3.0.0"
+    markdown-it "^12.3.2"
+    markdown-it-anchor "^8.4.1"
+    marked "^4.0.10"
+    mkdirp "^1.0.4"
+    requizzle "^0.2.3"
+    strip-json-comments "^3.1.0"
+    underscore "~1.13.2"
 
 jsesc@^2.5.1:
   version "2.5.2"
@@ -5873,6 +6139,13 @@ keyv@^4.0.0:
   integrity sha512-5MHbFaKn8cNSmVW7BYnijeAVlE4cYA/SVkifVgrh7yotnfhKmjuXpDKjrABLnT0SfHWV21P8ow07OGfRrNDg8g==
   dependencies:
     json-buffer "3.0.1"
+
+klaw@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/klaw/-/klaw-3.0.0.tgz#b11bec9cf2492f06756d6e809ab73a2910259146"
+  integrity sha512-0Fo5oir+O9jnXu5EefYbVK+mHMBeEVEy2cmctR1O1NECcCkPRreJKrS6Qt/j3KC2C148Dfo9i3pCmCMsdqGr0g==
+  dependencies:
+    graceful-fs "^4.1.9"
 
 ky@0.30.0:
   version "0.30.0"
@@ -6100,6 +6373,13 @@ lines-and-columns@^1.1.6:
   dependencies:
     underscore-plus "^1.7.0"
 
+linkify-it@^3.0.1:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/linkify-it/-/linkify-it-3.0.3.tgz#a98baf44ce45a550efb4d49c769d07524cc2fa2e"
+  integrity sha512-ynTsyrFSdE5oZ/O9GEf00kPngmOfVwazR5GKDq6EYfhlpFug3J2zybX56a2PRRpc9P+FuSoGNAwjlbDs9jJBPQ==
+  dependencies:
+    uc.micro "^1.0.1"
+
 locate-path@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-3.0.0.tgz#dbec3b3ab759758071b58fe59fc41871af21400e"
@@ -6121,6 +6401,11 @@ locate-path@^6.0.0:
   integrity sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==
   dependencies:
     p-locate "^5.0.0"
+
+lodash.camelcase@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz#b28aa6288a2b9fc651035c7711f65ab6190331a6"
+  integrity sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==
 
 lodash.clonedeep@^4.5.0:
   version "4.5.0"
@@ -6172,6 +6457,21 @@ lodash.merge@^4.6.1, lodash.merge@^4.6.2:
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
 
+lodash.omit@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.omit/-/lodash.omit-4.5.0.tgz#6eb19ae5a1ee1dd9df0b969e66ce0b7fa30b5e60"
+  integrity sha512-XeqSp49hNGmlkj2EJlfrQFIzQ6lXdNro9sddtQzcJY8QaoC2GO0DT7xaIokHeyM+mIT0mPMlPvkYzg2xCuHdZg==
+
+lodash.padend@^4.6.1:
+  version "4.6.1"
+  resolved "https://registry.yarnpkg.com/lodash.padend/-/lodash.padend-4.6.1.tgz#53ccba047d06e158d311f45da625f4e49e6f166e"
+  integrity sha512-sOQs2aqGpbl27tmCS1QNZA09Uqp01ZzWfDUoD+xzTii0E7dSQfRKcRetFwa+uXaxaqL+TKm7CgD2JdKP7aZBSw==
+
+lodash.pick@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/lodash.pick/-/lodash.pick-4.4.0.tgz#52f05610fff9ded422611441ed1fc123a03001b3"
+  integrity sha512-hXt6Ul/5yWjfklSGvLQl8vM//l3FtyHZeuelpzK6mm99pNvN9yTDruNZPEJZD1oWrqo+izBmB7oUfWgcCX7s4Q==
+
 lodash.toarray@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.toarray/-/lodash.toarray-4.4.0.tgz#24c4bfcd6b2fba38bfd0594db1179d8e9b656561"
@@ -6187,7 +6487,7 @@ lodash.zip@^4.2.0:
   resolved "https://registry.yarnpkg.com/lodash.zip/-/lodash.zip-4.2.0.tgz#ec6662e4896408ed4ab6c542a3990b72cc080020"
   integrity sha512-C7IOaBBK/0gMORRBd8OETNx3kmOkgIWIPvyDpZSCTwUrpYmgZwJkjZeOD8ww4xbOUOs4/attY+pciKvadNfFbg==
 
-lodash@^4.17.10, lodash@^4.17.13, lodash@^4.17.15, lodash@^4.17.19:
+lodash@^4.17.10, lodash@^4.17.13, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.21:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
@@ -6325,6 +6625,22 @@ map-stream@~0.1.0:
   resolved "https://registry.yarnpkg.com/map-stream/-/map-stream-0.1.0.tgz#e56aa94c4c8055a16404a0674b78f215f7c8e194"
   integrity sha512-CkYQrPYZfWnu/DAmVCpTSX/xHpKZ80eKh2lAkyA6AJTef6bW+6JpbQZN5rofum7da+SyN1bi5ctTm+lTfcCW3g==
 
+markdown-it-anchor@^8.4.1:
+  version "8.6.6"
+  resolved "https://registry.yarnpkg.com/markdown-it-anchor/-/markdown-it-anchor-8.6.6.tgz#4a12e358c9c2167ee28cb7a5f10e29d6f1ffd7ca"
+  integrity sha512-jRW30YGywD2ESXDc+l17AiritL0uVaSnWsb26f+68qaW9zgbIIr1f4v2Nsvc0+s0Z2N3uX6t/yAw7BwCQ1wMsA==
+
+markdown-it@^12.3.2:
+  version "12.3.2"
+  resolved "https://registry.yarnpkg.com/markdown-it/-/markdown-it-12.3.2.tgz#bf92ac92283fe983fe4de8ff8abfb5ad72cd0c90"
+  integrity sha512-TchMembfxfNVpHkbtriWltGWc+m3xszaRD0CZup7GFFhzIgQqxIfn3eGj1yZpfuflzPvfkt611B2Q/Bsk1YnGg==
+  dependencies:
+    argparse "^2.0.1"
+    entities "~2.1.0"
+    linkify-it "^3.0.1"
+    mdurl "^1.0.1"
+    uc.micro "^1.0.5"
+
 "markdown-preview@https://codeload.github.com/atom/markdown-preview/legacy.tar.gz/refs/tags/v0.160.2":
   version "0.160.2"
   resolved "https://codeload.github.com/atom/markdown-preview/legacy.tar.gz/refs/tags/v0.160.2#6d6f4075ea5b5ec5a683104b12f2e91ad33fa392"
@@ -6362,6 +6678,11 @@ marked@^4.0.10:
   resolved "https://registry.yarnpkg.com/marked/-/marked-4.2.2.tgz#1d2075ad6cdfe42e651ac221c32d949a26c0672a"
   integrity sha512-JjBTFTAvuTgANXx82a5vzK9JLSMoV6V3LBVn4Uhdso6t7vXrGx7g1Cd2r6NYSsxrYbQGFCMqBDhFHyK5q2UvcQ==
 
+marked@^4.2.3:
+  version "4.2.5"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-4.2.5.tgz#979813dfc1252cc123a79b71b095759a32f42a5d"
+  integrity sha512-jPueVhumq7idETHkb203WDD4fMA3yV9emQ5vLwop58lu8bTclMghBWcYAavlDqIEMaisADinV1TooIFCfqOsYQ==
+
 marky@^1.2.2:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/marky/-/marky-1.2.5.tgz#55796b688cbd72390d2d399eaaf1832c9413e3c0"
@@ -6382,6 +6703,11 @@ md5@^2.1.0:
     charenc "0.0.2"
     crypt "0.0.2"
     is-buffer "~1.1.6"
+
+mdurl@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/mdurl/-/mdurl-1.0.1.tgz#fe85b2ec75a59037f2adfec100fd6c601761152e"
+  integrity sha512-/sKlQJCBYVY9Ers9hqzKou4H6V5UWc/M59TH2dvkt+84itfnq7uFOMLpOiOS4ujvHP4etln18fmIxA5R5fll0g==
 
 mime-db@1.52.0:
   version "1.52.0"
@@ -6568,6 +6894,11 @@ mkdirp-classic@^0.5.2, mkdirp-classic@^0.5.3:
   resolved "https://registry.yarnpkg.com/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz#fa10c9115cc6d8865be221ba47ee9bed78601113"
   integrity sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==
 
+mkdirp2@^1.0.4:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/mkdirp2/-/mkdirp2-1.0.5.tgz#68bbe61defefafce4b48948608ec0bac942512c2"
+  integrity sha512-xOE9xbICroUDmG1ye2h4bZ8WBie9EGmACaco8K8cx6RlkJJrxGIqjGqztAI+NMhexXBcdGbSEzI6N3EJPevxZw==
+
 mkdirp@0.5.4:
   version "0.5.4"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.4.tgz#fd01504a6797ec5c9be81ff43d204961ed64a512"
@@ -6732,6 +7063,11 @@ negotiator@^0.6.2:
   version "0.6.3"
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.3.tgz#58e323a72fedc0d6f9cd4d31fe49f51479590ccd"
   integrity sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==
+
+neo-async@^2.6.0:
+  version "2.6.2"
+  resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.2.tgz#b4aafb93e3aeb2d8174ca53cf163ab7d7308305f"
+  integrity sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==
 
 next-tick@^1.1.0:
   version "1.1.0"
@@ -6969,6 +7305,11 @@ object-assign@^4.1.0, object-assign@^4.1.1:
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
   integrity sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==
 
+object-get@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/object-get/-/object-get-2.1.1.tgz#1dad63baf6d94df184d1c58756cc9be55b174dac"
+  integrity sha512-7n4IpLMzGGcLEMiQKsNR7vCe+N5E9LORFrtNUVy4sO3dj9a3HedZCxEL2T7QuLhcHN1NBuBsMOKaOsAYI9IIvg==
+
 object-inspect@^1.12.2, object-inspect@^1.9.0:
   version "1.12.2"
   resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.12.2.tgz#c0641f26394532f28ab8d796ab954e43c009a8ea"
@@ -6986,6 +7327,11 @@ object-keys@^1.0.11, object-keys@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.1.1.tgz#1c47f272df277f3b1daf061677d9c82e2322c60e"
   integrity sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==
+
+object-to-spawn-args@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/object-to-spawn-args/-/object-to-spawn-args-2.0.1.tgz#cf8b8e3c9b3589137a469cac90391f44870144a5"
+  integrity sha512-6FuKFQ39cOID+BMZ3QaphcC8Y4cw6LXBLyIgPU+OhIYwviJamPAn+4mITapnSBQrejB+NNp+FMskhD8Cq+Ys3w==
 
 object.assign@4.1.0:
   version "4.1.0"
@@ -7725,6 +8071,35 @@ readdirp@~3.6.0:
   dependencies:
     picomatch "^2.2.1"
 
+reduce-extract@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/reduce-extract/-/reduce-extract-1.0.0.tgz#67f2385beda65061b5f5f4312662e8b080ca1525"
+  integrity sha512-QF8vjWx3wnRSL5uFMyCjDeDc5EBMiryoT9tz94VvgjKfzecHAVnqmXAwQDcr7X4JmLc2cjkjFGCVzhMqDjgR9g==
+  dependencies:
+    test-value "^1.0.1"
+
+reduce-flatten@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/reduce-flatten/-/reduce-flatten-1.0.1.tgz#258c78efd153ddf93cb561237f61184f3696e327"
+  integrity sha512-j5WfFJfc9CoXv/WbwVLHq74i/hdTUpy+iNC534LxczMRP67vJeK3V9JOdnL0N1cIRbn9mYhE2yVjvvKXDxvNXQ==
+
+reduce-flatten@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/reduce-flatten/-/reduce-flatten-3.0.1.tgz#3db6b48ced1f4dbe4f4f5e31e422aa9ff0cd21ba"
+  integrity sha512-bYo+97BmUUOzg09XwfkwALt4PQH1M5L0wzKerBt6WLm3Fhdd43mMS89HiT1B9pJIqko/6lWx3OnV4J9f2Kqp5Q==
+
+reduce-unique@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/reduce-unique/-/reduce-unique-2.0.1.tgz#fb34b90e89297c1e08d75dcf17e9a6443ea71081"
+  integrity sha512-x4jH/8L1eyZGR785WY+ePtyMNhycl1N2XOLxhCbzZFaqF4AXjLzqSxa2UHgJ2ZVR/HHyPOvl1L7xRnW8ye5MdA==
+
+reduce-without@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/reduce-without/-/reduce-without-1.0.1.tgz#68ad0ead11855c9a37d4e8256c15bbf87972fc8c"
+  integrity sha512-zQv5y/cf85sxvdrKPlfcRzlDn/OqKFThNimYmsS3flmkioKvkUGn2Qg9cJVoQiEvdxFGLE0MQER/9fZ9sUqdxg==
+  dependencies:
+    test-value "^2.0.0"
+
 regenerate-unicode-properties@^10.1.0:
   version "10.1.0"
   resolved "https://registry.yarnpkg.com/regenerate-unicode-properties/-/regenerate-unicode-properties-10.1.0.tgz#7c3192cab6dd24e21cb4461e5ddd7dd24fa8374c"
@@ -7882,6 +8257,13 @@ requirejs@>=0.27.1:
   version "2.3.6"
   resolved "https://registry.yarnpkg.com/requirejs/-/requirejs-2.3.6.tgz#e5093d9601c2829251258c0b9445d4d19fa9e7c9"
   integrity sha512-ipEzlWQe6RK3jkzikgCupiTbTvm4S0/CAU5GlgptkN5SO6F3u0UD0K18wy6ErDqiCyP4J4YYe1HuAShvsxePLg==
+
+requizzle@^0.2.3:
+  version "0.2.4"
+  resolved "https://registry.yarnpkg.com/requizzle/-/requizzle-0.2.4.tgz#319eb658b28c370f0c20f968fa8ceab98c13d27c"
+  integrity sha512-JRrFk1D4OQ4SqovXOgdav+K8EAhSB/LJZqCz8tbX0KObcdeM15Ss59ozWMBWmmINMagCwmqn4ZNryUGpBsl6Jw==
+  dependencies:
+    lodash "^4.17.21"
 
 resolve-alpn@^1.0.0:
   version "1.2.1"
@@ -8328,6 +8710,14 @@ socks@^2.6.2:
 "solarized-light-syntax@file:packages/solarized-light-syntax":
   version "1.3.0"
 
+sort-array@^4.1.5:
+  version "4.1.5"
+  resolved "https://registry.yarnpkg.com/sort-array/-/sort-array-4.1.5.tgz#64b92aaba222aec606786f4df28ae4e3e3e68313"
+  integrity sha512-Ya4peoS1fgFN42RN1REk2FgdNOeLIEMKFGJvs7VTP3OklF8+kl2SkpVliZ4tk/PurWsrWRsdNdU+tgyOBkB9sA==
+  dependencies:
+    array-back "^5.0.0"
+    typical "^6.0.1"
+
 source-map-support@^0.5.19:
   version "0.5.21"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.21.tgz#04fe7c7f9e1ed2d662233c28cb2b35b9f63f6e4f"
@@ -8496,6 +8886,18 @@ stream-combiner@~0.0.4:
   integrity sha512-rT00SPnTVyRsaSz5zgSPma/aHSOic5U1prhYdRy5HS2kTZviFpmDgzilbtsJsxiroqACmayynDN/9VzIbX5DOw==
   dependencies:
     duplexer "~0.1.1"
+
+stream-connect@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/stream-connect/-/stream-connect-1.0.2.tgz#18bc81f2edb35b8b5d9a8009200a985314428a97"
+  integrity sha512-68Kl+79cE0RGKemKkhxTSg8+6AGrqBt+cbZAXevg2iJ6Y3zX4JhA/sZeGzLpxW9cXhmqAcE7KnJCisUmIUfnFQ==
+  dependencies:
+    array-back "^1.0.2"
+
+stream-via@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/stream-via/-/stream-via-1.0.4.tgz#8dccbb0ac909328eb8bc8e2a4bd3934afdaf606c"
+  integrity sha512-DBp0lSvX5G9KGRDTkR/R+a29H+Wk2xItOF+MpZLLNDWbEV9tGPnqLPxHEYjmiz8xGtJHRIqmI+hCjmNzqoA4nQ==
 
 streamroller@^3.1.3:
   version "3.1.3"
@@ -8692,6 +9094,17 @@ tabbable@^5.1.5:
   resolved "https://registry.yarnpkg.com/tabbable/-/tabbable-5.3.3.tgz#aac0ff88c73b22d6c3c5a50b1586310006b47fbf"
   integrity sha512-QD9qKY3StfbZqWOPLp0++pOrAVb/HbUi5xCc8cUo4XjP19808oaMiDzn0leBY5mCespIBM0CIZePzZjgzR83kA==
 
+table-layout@^0.4.2:
+  version "0.4.5"
+  resolved "https://registry.yarnpkg.com/table-layout/-/table-layout-0.4.5.tgz#d906de6a25fa09c0c90d1d08ecd833ecedcb7378"
+  integrity sha512-zTvf0mcggrGeTe/2jJ6ECkJHAQPIYEwDoqsiqBjI24mvRmQbInK5jq33fyypaCBxX08hMkfmdOqj6haT33EqWw==
+  dependencies:
+    array-back "^2.0.0"
+    deep-extend "~0.6.0"
+    lodash.padend "^4.6.1"
+    typical "^2.6.1"
+    wordwrapjs "^3.0.0"
+
 "tabs@file:packages/tabs":
   version "0.110.2"
   dependencies:
@@ -8785,6 +9198,11 @@ temp-file@^3.4.0:
     async-exit-hook "^2.0.1"
     fs-extra "^10.0.0"
 
+temp-path@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/temp-path/-/temp-path-1.0.0.tgz#24b1543973ab442896d9ad367dd9cbdbfafe918b"
+  integrity sha512-TvmyH7kC6ZVTYkqCODjJIbgvu0FKiwQpZ4D1aknE7xpcDf/qEOB8KZEK5ef2pfbVoiBhNWs3yx4y+ESMtNYmlg==
+
 temp@0.9.1:
   version "0.9.1"
   resolved "https://registry.yarnpkg.com/temp/-/temp-0.9.1.tgz#2d666114fafa26966cd4065996d7ceedd4dd4697"
@@ -8814,6 +9232,30 @@ temp@^0.9.0, temp@~0.9.0:
   dependencies:
     mkdirp "^0.5.1"
     rimraf "~2.6.2"
+
+test-value@^1.0.1:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/test-value/-/test-value-1.1.0.tgz#a09136f72ec043d27c893707c2b159bfad7de93f"
+  integrity sha512-wrsbRo7qP+2Je8x8DsK8ovCGyxe3sYfQwOraIY/09A2gFXU9DYKiTF14W4ki/01AEh56kMzAmlj9CaHGDDUBJA==
+  dependencies:
+    array-back "^1.0.2"
+    typical "^2.4.2"
+
+test-value@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/test-value/-/test-value-2.1.0.tgz#11da6ff670f3471a73b625ca4f3fdcf7bb748291"
+  integrity sha512-+1epbAxtKeXttkGFMTX9H42oqzOTufR1ceCF+GYA5aOmvaPq9wd4PUS8329fn2RRLGNeUkgRLnVpycjx8DsO2w==
+  dependencies:
+    array-back "^1.0.3"
+    typical "^2.6.0"
+
+test-value@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/test-value/-/test-value-3.0.0.tgz#9168c062fab11a86b8d444dd968bb4b73851ce92"
+  integrity sha512-sVACdAWcZkSU9x7AOmJo5TqE+GyNJknHaHsMrR6ZnhjVlVN9Yx6FjHrsKZ3BjIpPCT68zYesPWkakrNupwfOTQ==
+  dependencies:
+    array-back "^2.0.0"
+    typical "^2.6.1"
 
 text-buffer@^13.18.6:
   version "13.18.6"
@@ -9135,6 +9577,21 @@ typescript@^2.2.1:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.9.2.tgz#1cbf61d05d6b96269244eb6a3bce4bd914e0f00c"
   integrity sha512-Gr4p6nFNaoufRIY4NMdpQRNmgxVIGMs4Fcu/ujdYk3nAZqk7supzBE9idmvfZIlH/Cuj//dvi+019qEue9lV0w==
 
+typical@^2.4.2, typical@^2.6.0, typical@^2.6.1:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/typical/-/typical-2.6.1.tgz#5c080e5d661cbbe38259d2e70a3c7253e873881d"
+  integrity sha512-ofhi8kjIje6npGozTip9Fr8iecmYfEbS06i0JnIg+rh51KakryWF4+jX8lLKZVhy6N+ID45WYSFCxPOdTWCzNg==
+
+typical@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/typical/-/typical-4.0.0.tgz#cbeaff3b9d7ae1e2bbfaf5a4e6f11eccfde94fc4"
+  integrity sha512-VAH4IvQ7BDFYglMd7BPRDfLgxZZX4O4TFcRDA6EN5X7erNJJq+McIEp8np9aVtxrCJ6qx4GTYVfOWNjcqwZgRw==
+
+typical@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/typical/-/typical-6.0.1.tgz#89bd1a6aa5e5e96fa907fb6b7579223bff558a06"
+  integrity sha512-+g3NEp7fJLe9DPa1TArHm9QAA7YciZmWnfAqEaFrBihQ7epOv9i99rjtgb6Iz0wh3WuQDjsCTDfgRoGnmHN81A==
+
 ua-parser-js@^0.7.18:
   version "0.7.32"
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.32.tgz#cd8c639cdca949e30fa68c44b7813ef13e36d211"
@@ -9144,6 +9601,16 @@ ua-parser-js@^1.0.1:
   version "1.0.32"
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-1.0.32.tgz#786bf17df97de159d5b1c9d5e8e9e89806f8a030"
   integrity sha512-dXVsz3M4j+5tTiovFVyVqssXBu5HM47//YSOeZ9fQkdDKkfzv2v3PP1jmH6FUyPW+yCSn7aBVK1fGGKNhowdDA==
+
+uc.micro@^1.0.1, uc.micro@^1.0.5:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/uc.micro/-/uc.micro-1.0.6.tgz#9c411a802a409a91fc6cf74081baba34b24499ac"
+  integrity sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==
+
+uglify-js@^3.1.4:
+  version "3.17.4"
+  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.17.4.tgz#61678cf5fa3f5b7eb789bb345df29afb8257c22c"
+  integrity sha512-T9q82TJI9e/C1TAxYvfb16xO120tMVFZrGA3f9/P4424DNu6ypK103y0GPFVa17yotwSyZW5iYXgjYHkGrJW/g==
 
 unbox-primitive@^1.0.2:
   version "1.0.2"
@@ -9170,7 +9637,7 @@ underscore-plus@1.7.0, underscore-plus@1.x, underscore-plus@^1, underscore-plus@
   dependencies:
     underscore "^1.9.1"
 
-"underscore@>= 1.3.1", underscore@>=1.3.1, underscore@^1.3.1, underscore@^1.9.1:
+"underscore@>= 1.3.1", underscore@>=1.3.1, underscore@^1.3.1, underscore@^1.9.1, underscore@~1.13.2:
   version "1.13.6"
   resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.13.6.tgz#04786a1f589dc6c09f761fc5f45b89e935136441"
   integrity sha512-+A5Sja4HP1M08MaXya7p5LvjuM7K6q/2EaC0+iovj/wOcMsTzMvDFbasi/oSapiwOlt252IqsKqPjCl7huKS0A==
@@ -9340,6 +9807,16 @@ vscode-ripgrep@^1.2.5:
   dependencies:
     https-proxy-agent "^4.0.0"
     proxy-from-env "^1.1.0"
+
+walk-back@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/walk-back/-/walk-back-2.0.1.tgz#554e2a9d874fac47a8cb006bf44c2f0c4998a0a4"
+  integrity sha512-Nb6GvBR8UWX1D+Le+xUq0+Q1kFmRBIWVrfLnQAOmcpEzA9oAxwJ9gIr36t9TWYfzvWRvuMtjHiVsJYEkXWaTAQ==
+
+walk-back@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/walk-back/-/walk-back-5.1.0.tgz#486d6f29e67f56ab89b952d987028bbb1a4e956c"
+  integrity sha512-Uhxps5yZcVNbLEAnb+xaEEMdgTXl9qAQDzKYejG2AZ7qPwRQ81lozY9ECDbjLPNWm7YsO1IK5rsP1KoQzXAcGA==
 
 walkdir@0.0.11:
   version "0.0.11"
@@ -9559,10 +10036,23 @@ word-wrap@^1.2.3:
   resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.3.tgz#610636f6b1f703891bd34771ccb17fb93b47079c"
   integrity sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==
 
+wordwrap@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
+  integrity sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==
+
 wordwrap@~0.0.2:
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-0.0.3.tgz#a3d5da6cd5c0bc0008d37234bbaf1bed63059107"
   integrity sha512-1tMA907+V4QmxV7dbRvb4/8MaRALK6q9Abid3ndMYnbyo8piisCmeONVqVSXqQA3KaP4SLt5b7ud6E2sqP8TFw==
+
+wordwrapjs@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/wordwrapjs/-/wordwrapjs-3.0.0.tgz#c94c372894cadc6feb1a66bff64e1d9af92c5d1e"
+  integrity sha512-mO8XtqyPvykVCsrwj5MlOVWvSnCdT+C+QVbm6blradR7JExAhbkZ7hZ9A+9NUtwzSqrlUo9a67ws0EiILrvRpw==
+  dependencies:
+    reduce-flatten "^1.0.1"
+    typical "^2.6.1"
 
 wrap-ansi@^2.0.0:
   version "2.1.0"
@@ -9633,6 +10123,11 @@ xmlbuilder@>=11.0.1, xmlbuilder@^15.1.1:
   version "15.1.1"
   resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-15.1.1.tgz#9dcdce49eea66d8d10b42cae94a79c3c8d0c2ec5"
   integrity sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg==
+
+xmlcreate@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/xmlcreate/-/xmlcreate-2.0.4.tgz#0c5ab0f99cdd02a81065fa9cd8f8ae87624889be"
+  integrity sha512-nquOebG4sngPmGPICTS5EnxqhKbCmz5Ox5hsszI2T6U5qdrJizBc+0ilYSEjTSzU0yZcmvppztXe/5Al5fUwdg==
 
 xregexp@^3.2.0:
   version "3.2.0"


### PR DESCRIPTION
Alright, so it was a while ago, but we held a [poll](https://discord.com/channels/992103415163396136/1052121046263795745/1053607801508872272) to determine what was the best plan for our Pulsar API Documentation, and JSDocs was the winner here.

So I've taken a look and setup what I believe to be our best combination of keeping with Atom's old documentation style, while staying within JSDoc's, requiring zero extra libraries for us.

An overview of what was done here:

We use basic JSDoc setup on some key parts of the documentation, I've attempted to cover all the different types of documentation Atom had, to ensure we are able to translate everything to our satisfaction, that's why these docs are very incomplete and jump around significantly.

Additionally I've added another GitHub action, that will only run on a push to the `master` branch here that will automatically generate our documentation for us, so we don't ever have to.

Then you'll notice I've added two separate scripts to the `package.json`. The reason I've done this, is because one of those scripts generates the documentation that we can declare as the Public Pulsar API.
The other script then generates what's being called within as Private documentation. Not that it's really private, but if we wanted to be able to use JSDoc to document the entire actual codebase we have, then we can label the documentation of internal functions/classes/methods as `@private` and that will keep them out of the Public Pulsar API, but then we can still generate Markdown for them for contributors to reference. Which could become extremely helpful to letting everyone understand what's going on within the code.

---

The not so birds eye view of it.

Within Atoms documentation they had several categories of docs:

* Properties
* Event Subscription
* Atom Details
* Managing The Atom Window

For example, these categories vary based on what the parent class is, but they used them frequently.

To accomplish somewhat the same thing, we could use the custom tag of `jsdoc-to-markdown` of `@category` to do this.

Obviously we will lose the visual style that Atom's documentation had, but I'm not sure that this is much of a downside for us, since we wanted to change things anyway.

Additionally Atom in their docs have lots of things linking to each other, now some of the time we will be able to link to other parts of the docs with just as much ease, whereas other times we will have to manually do something like `{@link JSDOC_NAMEPATH}` instead.

Additionally you'll notice the style of JSDocs we are using is slightly verbose, now at times it is needed when declaring some of the properties we are, other times we could instead use JSDoc shorthand, the drawbacks I saw of this, is to me personally it's not nearly as clear when reading the source code, and additionally often times it results in the MarkDown documentation being much more smooshed together. An example is when you look at the `AtomEnvironment` markdown generated under the `instance` section you'll see a long list of properties, without the extra verbosity in most places everything would be listed there, and can be hard to read through.

Now if the outputted Markdown looks good to everyone, and the syntax used to create it looks doable, I'd be happy to continue doing this wherever we can, and can additionally make a PR to our Contributing Guidelines with instructions on how to handle the conversation from Atom's docs to ours, as I've already written up a document detailing how to do so, while doing it.

So please feel free to provide any feedback, as I'd want to wait on any pointers before investing the time to cover the rest of our documentation.