### PR TITLE
meta: Bump version to `1.101.0-beta`

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "pulsar",
   "author": "Pulsar Community <noreply@pulsar-edit.com>",
   "productName": "Pulsar",
-  "version": "1.101.0-beta",
+  "version": "1.101.0-dev",
   "description": "A Community-led Hyper-Hackable Text Editor",
   "branding": {
     "id": "pulsar",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "pulsar",
   "author": "Pulsar Community <noreply@pulsar-edit.com>",
   "productName": "Pulsar",
-  "version": "1.100.0-dev",
+  "version": "1.101.0-beta",
   "description": "A Community-led Hyper-Hackable Text Editor",
   "branding": {
     "id": "pulsar",


### PR DESCRIPTION
Following in the steps of #237 I've done the same steps with a slight advantage from @DeeDeeG 

Just changing the version name, will allow our binaries to build under the right name since the `sed` usage in Cirrus CI will fail to find the the version using `-dev`.

Once done we can change the naming on the version back to `-dev` and merge into master.
