### PR TITLE
update copyright year (2023)

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022 Pulsar-Edit
+Copyright (c) 2022-2023 Pulsar-Edit
 Original work copyright (c) 2011-2022 GitHub Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy


### PR DESCRIPTION
my current heuristic is
`substantial changes --> update copyright year`
which definitely applies now