### PR TITLE
Fix URl to correct address

### DIFF
--- a/packages/settings-view/lib/install-panel.js
+++ b/packages/settings-view/lib/install-panel.js
@@ -139,7 +139,7 @@ export default class InstallPanel {
       this.refs.searchThemesButton.classList.remove('selected')
       this.refs.searchEditor.setPlaceholderText('Search packages')
       this.refs.publishedToText.textContent = 'Packages are published to '
-      this.atomIoURL = 'https://pulsar-edit.dev/packages'
+      this.atomIoURL = 'https://web.pulsar-edit.dev/packages'
       this.loadFeaturedPackages()
     }
   }


### PR DESCRIPTION
### What happened?

![Bildschirm­foto 2023-01-19 um 12 47 09](https://user-images.githubusercontent.com/77158987/213434637-e5c3bc22-1174-4e48-b0db-728b562d70cc.png)

Clicking on the link marked "Packages are published to" opens the web address https://pulsar-edit.dev/packages, causing a 404 error.

The correct link should be to the web address **https://web.pulsar-edit.dev/packages**.

### The solution

The pull request changes line 142 in the file "pachages/settings-view/lib/install-panel.js" and sets the correct web address there.

Note: At times, line 134 would also have to be adjusted at the same place. Otherwise a 404 error may occur here as well.

### Pulsar version

1.101.2023011902

### OS

macOS Ventura 13.1