### PR TITLE
Replace incorrect spellings of 'macOS' with the correct one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,11 +41,11 @@ fewer errors on the settings-view regarding package info)
 - Fixed: Resolve 40 Failing `image-view` Tests [@confused-Techie](https://github.com/pulsar-edit/pulsar/pull/293)
 - Added: Added changelog entries that we missed [@mauricioszabo](https://github.com/pulsar-edit/pulsar/pull/292)
 - Removed: meta: Delete preinstall script from package.json [@DeeDeeG](https://github.com/pulsar-edit/pulsar/pull/296)
-- Added: Improve MacOS Builds [@confused-Techie](https://github.com/pulsar-edit/pulsar/pull/280)
+- Added: Improve macOS Builds [@confused-Techie](https://github.com/pulsar-edit/pulsar/pull/280)
 - Fixed: Fix `archive-view` [@confused-Techie](https://github.com/pulsar-edit/pulsar/pull/294)
 - Added: Improved Windows Builds [@confused-Techie](https://github.com/pulsar-edit/pulsar/pull/279)
 - Added: More Bundles [@confused-Techie](https://github.com/pulsar-edit/pulsar/pull/290)
-- Fixed: Fix macos open without window [@mauricioszabo](https://github.com/pulsar-edit/pulsar/pull/291)
+- Fixed: Fix macOS open without window [@mauricioszabo](https://github.com/pulsar-edit/pulsar/pull/291)
 - Removed: delete workflow from language-java [@Sertonix](https://github.com/pulsar-edit/pulsar/pull/285)
 - Removed: Remove handlers for opening things on Mac [@mauricioszabo](https://github.com/pulsar-edit/pulsar/pull/288)
 - Rebrand: Rebranding and relinking to new site [@Daeraxa](https://github.com/pulsar-edit/pulsar/pull/282)
@@ -219,7 +219,7 @@ fewer errors on the settings-view regarding package info)
   * [@DeeDeeG](https://github.com/pulsar-edit/ppm/pull/39)
 
 ### autocomplete-html
-- Fixed:    Finding the proper Node version [@mauricioszabo](https://github.com/pulsar-edit/autocomplete-html/pull/1)  
+- Fixed:    Finding the proper Node version [@mauricioszabo](https://github.com/pulsar-edit/autocomplete-html/pull/1)
 
 ### settings-view
 - Added:    Remember Scroll Position [@jonian](https://github.com/pulsar-edit/settings-view/pull/12)

--- a/hooks/README.md
+++ b/hooks/README.md
@@ -11,8 +11,8 @@ These hooks are not guaranteed. These were made out of convenience and presented
 ### Usage
 There are several ways to apply these hooks:
 - You can manually copy the files over to the `<pulsar-repo-root>/.git/hooks` folder and validate that they are executable - the effect should be immediate. This is the preferred option for Windows.
-- You can use manage_hooks.sh to copy/symlink the hooks you choose. This is the preferred option for Linux/MacOS.
-  - Your mileage may vary on MacOS as it has not been tested outright, but should work in theory.
+- You can use manage_hooks.sh to copy/symlink the hooks you choose. This is the preferred option for Linux/macOS.
+  - Your mileage may vary on macOS as it has not been tested outright, but should work in theory.
 
 ### Instructions
 - Open your favorite terminal

--- a/script/mac-bundle-document-types.js
+++ b/script/mac-bundle-document-types.js
@@ -1,5 +1,5 @@
 /**
-  The MacOS configuration MUST be passed this exact object structure in order to
+  The macOS configuration MUST be passed this exact object structure in order to
   build the plist file as expected and accepted.
   mac.extendInfo.CFBundleDocumentTypes is a plist entry that MUST receive an array.
 
@@ -11,7 +11,7 @@
   But I do not recommend changing the structure of the object without careful testing.
 
   The Extensions and Names of the files have all been taken from a Known working
-  configuration of Atom's plist that was included with the MacOS build.
+  configuration of Atom's plist that was included with the macOS build.
 
   But as we now build this for ourselves we will take advantage of our new methods
   and ensure we use the wins electron-builder provides by staying on platform.

--- a/src/config-schema.js
+++ b/src/config-schema.js
@@ -594,7 +594,7 @@ const configSchema = {
         type: 'boolean',
         default: true,
         description:
-          'Add multiple cursors when pressing the Ctrl key (Command key on MacOS) and clicking the editor.'
+          'Add multiple cursors when pressing the Ctrl key (Command key on macOS) and clicking the editor.'
       }
     }
   }

--- a/src/main-process/parse-command-line.js
+++ b/src/main-process/parse-command-line.js
@@ -195,7 +195,7 @@ module.exports = function parseCommandLine(processArgs) {
       `Only one of the --add and --new-window options may be specified at the same time.\n\n${options.help()}`
     );
 
-    // Exiting the main process with a nonzero exit code on MacOS causes the app open to fail with the mysterious
+    // Exiting the main process with a nonzero exit code on macOS causes the app open to fail with the mysterious
     // message "LSOpenURLsWithRole() failed for the application /Applications/Pulsar Dev.app with error -10810."
     process.exit(0);
   }


### PR DESCRIPTION
### What happened?

I have noticed that in several places an incorrect or outdated spelling of the Apple operating system is used (e.g. -> screenshot).

![Bildschirm­foto 2023-01-19 um 19 01 53 (2)](https://user-images.githubusercontent.com/77158987/213524399-a1495502-b0c2-4454-a506-c6d28509c256.png)


### The solution

The pull request changes the affected text passages so that the currently valid spelling is used.


### Pulsar version

1.101.2023011902

### OS

macOS Ventura 13.1