### PR TITLE
update apm message to pulsar -p

### DIFF
--- a/src/package.js
+++ b/src/package.js
@@ -897,7 +897,7 @@ module.exports = class Package {
         Failed to require the main module of '${
           this.name
         }' because it requires one or more incompatible native modules (${nativeModuleNames}).
-        Run \`apm rebuild\` in the package directory and restart Pulsar to resolve.\
+        Run \`pulsar -p rebuild\` in the package directory and restart Pulsar to resolve.\
       `);
     } else {
       const mainModulePath = this.getMainModulePath();
@@ -1252,7 +1252,7 @@ module.exports = class Package {
   //
   // Returns a {Promise} that resolves with an object containing `code`,
   // `stdout`, and `stderr` properties based on the results of running
-  // `apm rebuild` on the package.
+  // `pulsar -p rebuild` on the package.
   rebuild() {
     return new Promise(resolve =>
       this.runRebuildProcess(result => {


### PR DESCRIPTION
This simply updates a message presented to a user to use `pulsar -p` instead of `apm` (and updates a comment line whilst it is at it).

See: https://discord.com/channels/992103415163396136/992103415163396139/1066139005852332072

Example:

> /opt/Pulsar/resources/app.asar/src/package.js:896 Failed to require the main module of 'Hydrogen' because it requires one or more incompatible native modules (zeromq).
Run `apm rebuild` in the package directory and restart Pulsar to resolve.