### PR TITLE
Get Windows `pulsar` Working

### DIFF
--- a/resources/win/pulsar.cmd
+++ b/resources/win/pulsar.cmd
@@ -41,11 +41,11 @@ IF "%ATOM_ADD%"=="YES" (
 
 IF "%EXPECT_OUTPUT%"=="YES" (
   IF "%WAIT%"=="YES" (
-    powershell -noexit "Start-Process -FilePath \"%~dp0\..\..\<%= atomExeName %>\" -ArgumentList \"--pid=$pid $env:PSARGS\" ; wait-event"
+    powershell -noexit "Start-Process -FilePath \"%~dp0\..\Pulsar.exe\" -ArgumentList \"--pid=$pid $env:PSARGS\" ; wait-event"
     exit 0
   ) ELSE (
-    "%~dp0\..\..\<%= atomExeName %>" %*
+    "%~dp0\..\Pulsar.exe" %*
   )
 ) ELSE (
-  "%~dp0\..\app\apm\bin\node.exe" "%~dp0\pulsar.js" "<%= atomExeName %>" %*
+  "%~dp0\app\ppm\bin\node.exe" "%~dp0\pulsar.js" "Pulsar.exe" %*
 )

--- a/resources/win/pulsar.cmd
+++ b/resources/win/pulsar.cmd
@@ -16,6 +16,8 @@ FOR %%a IN (%*) DO (
   IF /I "%%a"=="--test"                     SET EXPECT_OUTPUT=YES
   IF /I "%%a"=="--benchmark"                SET EXPECT_OUTPUT=YES
   IF /I "%%a"=="--benchmark-test"           SET EXPECT_OUTPUT=YES
+  IF /I "%%a"=="-p"                         SET EXPECT_OUTPUT=YES
+  IF /I "%%a"=="--package"                  SET EXPECT_OUTPUT=YES
   IF /I "%%a"=="-v"                         SET EXPECT_OUTPUT=YES
   IF /I "%%a"=="--version"                  SET EXPECT_OUTPUT=YES
   IF /I "%%a"=="--enable-electron-logging"  SET ELECTRON_ENABLE_LOGGING=YES

--- a/resources/win/pulsar.js
+++ b/resources/win/pulsar.js
@@ -1,7 +1,7 @@
 var path = require('path');
 var spawn = require('child_process').spawn;
 
-var atomCommandPath = path.resolve(__dirname, '..', '..', process.argv[2]);
+var atomCommandPath = path.resolve(__dirname, '..', process.argv[2]);
 var args = process.argv.slice(3);
 args.unshift('--executed-from', process.cwd());
 var options = { detached: true, stdio: 'ignore' };

--- a/script/electron-builder.js
+++ b/script/electron-builder.js
@@ -168,7 +168,7 @@ let options = {
         // Extra SVG icon included in the resources folder to give a chance to
         // Linux packagers to add a scalable desktop icon under
         // /usr/share/icons/hicolor/scalable
-        // (used only by desktops to show it on bar/switcher and app menus).  
+        // (used only by desktops to show it on bar/switcher and app menus).
         "from": svgIcon,
         "to": "pulsar.svg"
       },
@@ -197,6 +197,14 @@ let options = {
       {
         "from": icoIcon,
         "to": "pulsar.ico"
+      },
+      {
+        "from": "resources/win/pulsar.cmd",
+        "to": "pulsar.cmd"
+      },
+      {
+        "from": "resources/win/pulsar.js",
+        "to": "pulsar.js"
       },
     ],
     "target": [


### PR DESCRIPTION
Currently when a Windows user installs Pulsar, there are none of the tools needed to run `pulsar` on the CLI available at all.

This PR gets us partly there. 

That is this PR moves both `/resources/win/pulsar.cmd` && `/resources/win/pulsar.js` and puts them into the build output for Pulsar on Windows only.

Additionally once done the scripts have also been modified to find Pulsar correctly due to our changed build path. There also was some logic here that seems like during binary build time these scripts would be updated injecting the `AtomExeName` into the scripts, likely because the Atom.exe would change depending on the version. But now since all Pulsar builds use `Pulsar.exe` the value has been hardcoded to `Pulsar.exe` with the proper path being added.

So now this does allow Windows Users to run `pulsar` on the CLI or even many commands like `pulsar -v` it unfortunately does not get `pulsar -p` working just yet.

As I'm not sure exactly where the code that handles this is, we can go with the minor improvement for now and build off of it later when possible.