### PR TITLE
autocomplete-snippets: Fix repo URL

### DIFF
--- a/packages/autocomplete-snippets/package.json
+++ b/packages/autocomplete-snippets/package.json
@@ -3,7 +3,7 @@
   "main": "./lib/autocomplete-snippets",
   "version": "1.12.1",
   "description": "Adds snippets to autocomplete+ suggestions",
-  "repository": "https://github.com/pulsa-edit/pulsar",
+  "repository": "https://github.com/pulsar-edit/pulsar",
   "license": "MIT",
   "engines": {
     "atom": ">=0.174.0 <2.0.0"


### PR DESCRIPTION
Just a tiny fix...

In the `repository` field of autocomplete-snippets' package.json, updated the URL from `pulsa-edit` --> `pulsar-edit` (added a missing 'r'`).

Noticed this when browsing my locally installed packages in the latest Beta:

![autocomplete-snippets package info page in settings-view, showing incorrect repo URL 'pulsa-edit:pulsar'](https://user-images.githubusercontent.com/20157115/214225650-8765da86-6209-4aa1-bbc2-43ca5c74b993.png)