### PR TITLE
Add LICENSE.md to extra resources (resourcesPath)

### DIFF
--- a/script/electron-builder.js
+++ b/script/electron-builder.js
@@ -138,6 +138,9 @@ let options = {
     }, {
       "from": pngIcon,
       "to": "pulsar.png"
+    }, {
+      "from": "LICENSE.md",
+      "to": "LICENSE.md"
     },
   ],
   compression: "normal",
@@ -168,7 +171,7 @@ let options = {
         // Extra SVG icon included in the resources folder to give a chance to
         // Linux packagers to add a scalable desktop icon under
         // /usr/share/icons/hicolor/scalable
-        // (used only by desktops to show it on bar/switcher and app menus).  
+        // (used only by desktops to show it on bar/switcher and app menus).
         "from": svgIcon,
         "to": "pulsar.svg"
       },


### PR DESCRIPTION
Fixes https://github.com/pulsar-edit/pulsar/issues/339 (well, it does on Windows anyway, would be useful if other people could check on other OSs, I'll update this PR with ones I can get it to work on).

Just adds the LICENSE.md to the resources which wasn't working before as the file didn't exist where Pulsar was looking `process.resourcesPath`.

Cirrus run - https://cirrus-ci.com/build/5990596528046080

- [x] Windows portable
- [x] Windows setup
- [x] Linux Appimage
- [x] Linux rpm
- [x] Linux Deb
- [x] Linux tarball
- [x] macOS dmg
- [x] macOS zip