### PR TITLE
Uncomment and fix a settings-view package test

### DIFF
--- a/packages/settings-view/spec/fixtures/package-internal/package.json
+++ b/packages/settings-view/spec/fixtures/package-internal/package.json
@@ -1,4 +1,4 @@
 {
   "name": "package-internal",
-  "repository": "https://github.com/atom/atom"
+  "repository": "https://github.com/pulsar-edit/pulsar"
 }

--- a/packages/settings-view/spec/package-detail-view-spec.coffee
+++ b/packages/settings-view/spec/package-detail-view-spec.coffee
@@ -152,4 +152,4 @@ describe "PackageDetailView", ->
     loadPackageFromRemote('package-internal')
     spyOn(shell, 'openExternal')
     view.refs.packageRepo.click()
-    expect(shell.openExternal).toHaveBeenCalledWith('https://github.com/atom/atom/tree/master/packages/package-internal')
+    expect(shell.openExternal).toHaveBeenCalledWith('https://github.com/pulsar-edit/pulsar/tree/master/packages/package-internal')

--- a/packages/settings-view/spec/package-detail-view-spec.coffee
+++ b/packages/settings-view/spec/package-detail-view-spec.coffee
@@ -148,8 +148,8 @@ describe "PackageDetailView", ->
     view.refs.packageRepo.click()
     expect(shell.openExternal).toHaveBeenCalledWith('https://github.com/example/package-with-readme')
 
-  # it "should open internal package repository url", ->
-  #   loadPackageFromRemote('package-internal')
-  #   spyOn(shell, 'openExternal')
-  #   view.refs.packageRepo.click()
-  #   expect(shell.openExternal).toHaveBeenCalledWith('https://github.com/atom/atom/tree/master/packages/package-internal')
+  it "should open internal package repository url", ->
+    loadPackageFromRemote('package-internal')
+    spyOn(shell, 'openExternal')
+    view.refs.packageRepo.click()
+    expect(shell.openExternal).toHaveBeenCalledWith('https://github.com/atom/atom/tree/master/packages/package-internal')


### PR DESCRIPTION
A quick follow-up to https://github.com/pulsar-edit/pulsar/pull/307.

<details><summary>What this fix is all about (click to expand):</summary>

There is a special handling of internal/bundled packages which specify their `repository` field of `package.json` as the exact GitHub repo URL of the main editor...

The editor (specifically some logic in the `settings-view` package, I guess) understands that _bundled packages_ with `"repository": "https://github.com/pulsar-edit/pulsar"` should link to this repo's `packages/[package name here]` subdir, _not_ just to the root repo URL as specified verbatim in the package's package.json, i.e. `https://github.com/pulsar-edit/pulsar`

This updates the dummy spec package used for this spec to have its `repository` URL be `https://github.com/pulsar-edit/pulsar` instead of the old `https://github.com/atom/atom`. Which, after this change, then matches with the editor's own `repository` URL in its own package.json. So the test, which assumes the special handling described above is in play, works as intended again and passes.

---

</details>

So this fixes a test that been failing and which got commented out during https://github.com/pulsar-edit/pulsar/pull/307. (The fix is essentially a tiny re-branding task.)

This gives us one more test running, one more test passing. Not a huge deal, but feels better than just commenting this one out, and I got the fix sorted relatively quickly, so here we are. Figured I may as well submit this as a PR.