### PR TITLE
Restore `right-clicked` class on a right-clicked tab

### DIFF
--- a/packages/tabs/lib/tab-bar-view.js
+++ b/packages/tabs/lib/tab-bar-view.js
@@ -575,7 +575,11 @@ class TabBarView {
     if (!tab) { return; }
 
     if ((event.button === 2) || ((event.button === 0) && (event.ctrlKey === true))) {
+      if (this.rightClickedTab) {
+        this.rightClickedTab.element.classList.remove('right-clicked');
+      }
       this.rightClickedTab = tab;
+      this.rightClickedTab.element.classList.add('right-clicked');
       return event.preventDefault();
     } else if (event.button === 1) {
       // This prevents Chromium from activating "scroll mode" when

--- a/packages/tabs/spec/tabs-spec.js
+++ b/packages/tabs/spec/tabs-spec.js
@@ -1274,6 +1274,16 @@ describe("TabBarView", () => {
     expect(newFileHandler.callCount).toBe(1);
   }));
 
+  describe("when the tab bar is right-clicked", () => {
+    it("adds the right-clicked class when right-clicked", () => {
+      triggerClickEvent(tabBar.tabAtIndex(0).element, {button: 2});
+      expect(tabBar.tabAtIndex(0).element.classList.contains('right-clicked')).toBe(true);
+      triggerClickEvent(tabBar.tabAtIndex(2).element, {button: 2});
+      expect(tabBar.tabAtIndex(2).element.classList.contains('right-clicked')).toBe(true);
+      expect(tabBar.tabAtIndex(0).element.classList.contains('right-clicked')).toBe(false);
+    });
+  });
+
   describe("when the mouse wheel is used on the tab bar", () => {
     describe("when tabScrolling is true in package settings", () => {
       beforeEach(() => {


### PR DESCRIPTION
Fixes #349.

### Identify the Bug

Until recently, when a tab was right-clicked, the `tabs` package marked it with a `right-clicked` class. As described in #349, [this PR](https://github.com/atom/tabs/pull/531) removed that functionality because of a belief that it was unused.

At least one popular package, [Zentabs](https://github.com/ArnaudRinquin/atom-zentabs), was broken by this change — when a user right-clicked a tab and selected **Pin Tab**, Zentabs used the `right-clicked` class to determine which tab the command was invoked against.


### Description of the Change

The code being restored is exactly equivalent to what was removed in the aforementioned PR.

### Alternate Designs

Because this was restoring code that used to be present, I didn’t think much about alternate approaches, but they can be explored once the regression is fixed.

### Possible Drawbacks

It occurs to me that, if you right-click on a tab and then exit the context menu, that tab will continue to bear the `right-clicked` class name until you right-click on a _different_ tab, but I think that’s OK.

### Verification Process

All existing tab specs pass. The new spec I wrote fails on `master` and passes on this PR branch.

By pinning this package in dev mode, I have ascertained that this fixes the Zentabs issue. I am once again able to pin a tab by right-clicking on it and selecting the **Pin Tab** option.

### Release Notes

Restores the ability of a package to know when a given tab was right-clicked on.
