### PR TITLE
c++ fixes

### DIFF
--- a/packages/language-c/grammars/c++.cson
+++ b/packages/language-c/grammars/c++.cson
@@ -69,8 +69,16 @@
     'name': 'punctuation.separator.namespace.access.cpp'
   }
   {
-    'match': '\\b(and|and_eq|bitand|bitor|compl|not|not_eq|or|or_eq|typeid|xor|xor_eq|alignof|alignas)\\b'
+    'match': '\\b(typeid|alignof|alignas)\\b'
     'name': 'keyword.operator.cpp'
+  }
+  {
+    'match': '\\b(and|and_eq|bitand|bitor|compl|not|not_eq|or|or_eq|xor|xor_eq)\\b'
+    'name': 'keyword.operator.alias.cpp'
+  }
+  {
+    'match': '\\bstatic_assert\\b'
+    'name': 'keyword.static-assert.cpp'
   }
   {
     'match': '\\b(class|decltype|wchar_t|char16_t|char32_t)\\b'
@@ -242,7 +250,7 @@
         "name": "meta.using-namespace-declaration.cpp"
       },
       {
-        'begin': '\\b(namespace)\\b\\s*([_A-Za-z][_A-Za-z0-9]*\\b)?+'
+        'begin': '\\b(namespace)\\b\\s*((?:[_A-Za-z][_A-Za-z0-9]*\\b(::)?)*)?+'
         'beginCaptures':
           '1':
             'name': 'storage.type.cpp'
@@ -281,32 +289,35 @@
         ]
       }
       {
-        'begin': '\\b(class|struct)\\b\\s*([_A-Za-z][_A-Za-z0-9]*\\b)?+(\\s*:\\s*(public|protected|private)\\s*([_A-Za-z][_A-Za-z0-9]*\\b)((\\s*,\\s*(public|protected|private)\\s*[_A-Za-z][_A-Za-z0-9]*\\b)*))?'
+        'begin': '\\b(class|struct)\\b\\s*([_A-Za-z][_A-Za-z0-9]*\\b)?+(\\s*:\\s)?'
         'beginCaptures':
           '1':
             'name': 'storage.type.cpp'
           '2':
             'name': 'entity.name.type.cpp'
-          '4':
-            'name': 'storage.type.modifier.cpp'
-          '5':
-            'name': 'entity.name.type.inherited.cpp'
-          '6':
-            'patterns': [
-              {
-                'match': '(public|protected|private)'
-                'name': 'storage.type.modifier.cpp'
-              }
-              {
-                'match': '[_A-Za-z][_A-Za-z0-9]*'
-                'name': 'entity.name.type.inherited.cpp'
-              }
-            ]
         'end': '(?<=\\})|(?=(;|\\(|\\)|>|\\[|\\]|=))'
         'name': 'meta.class-struct-block.cpp'
         'patterns': [
           {
             'include': '#angle_brackets'
+          }
+          {
+            'begin': '(virtual\\s*)?(public|protected|private)\\s*(virtual\\s*)?([_A-Za-z][_A-Za-z0-9]*)\\b'
+            'beginCaptures':
+              '1':
+                'name': 'storage.type.modifier.cpp'
+              '2':
+                'name': 'storage.type.modifier.cpp'
+              '3':
+                'name': 'storage.type.modifier.cpp'
+              '4':
+                'name': 'entity.name.type.inherited.cpp'
+            'end': '(\\{)|(\\s*\\n)|(,)?'
+            'patterns': [
+              {
+                'include': '#angle_brackets'
+              }
+            ]
           }
           {
             'begin': '\\{'

--- a/packages/language-c/grammars/tree-sitter-cpp.cson
+++ b/packages/language-c/grammars/tree-sitter-cpp.cson
@@ -90,6 +90,7 @@ scopes:
   '"#define"': 'keyword.control.directive'
   '"#include"': 'keyword.control.directive'
   'preproc_directive': 'keyword.control.directive'
+  '"static_assert"': 'keyword.control.directive'
 
   '"if"': 'keyword.control'
   '"else"': 'keyword.control'
@@ -133,12 +134,14 @@ scopes:
   call_expression > identifier,
   call_expression > field_expression > field_identifier,
   call_expression > scoped_identifier > identifier,
+  call_expression > qualified_identifier > identifier,
   template_function > identifier,
   template_function > scoped_identifier > identifier,
   template_method > field_identifier,
   function_declarator > identifier,
   function_declarator > field_identifier,
   function_declarator > scoped_identifier > identifier,
+  function_declarator > qualified_identifier > identifier,
   destructor_name > identifier
   ''': 'entity.name.function'
 
@@ -224,8 +227,8 @@ scopes:
   '"=="': 'keyword.operator'
   '"!"': 'keyword.operator'
   '"!="': 'keyword.operator'
-  'relational_expression > "<"': 'keyword.operator'
-  'relational_expression > ">"': 'keyword.operator'
+  'binary_expression > "<"': 'keyword.operator'
+  'binary_expression > ">"': 'keyword.operator'
   '">="': 'keyword.operator'
   '"<="': 'keyword.operator'
   '"&&"': 'keyword.operator'


### PR DESCRIPTION
### Description of change:

incorporates:

+ https://github.com/atom/language-c/pull/252
    > **Drawback**:
    > `class public virtual : public virtual Example` is invalid I think, but I don't see a good way to prevent that because the 
detection must be moved into `patterns > include` because textmate is not multiline regex.
    > See also https://github.com/jeff-hykin/better-cpp-syntax/issues/14 (In fact that whole repository probably has some improvements)
    >
    > Another drawback: Looks like a newline ends the include, i.e. individual classes cannot be multiline

    I changed it to include the angle brackets because classes can have those (generics).
+ https://github.com/atom/language-c/pull/263
+ https://github.com/atom/language-c/pull/311
+ https://github.com/atom/language-c/pull/368

### Alternate Designs

Note for the first incorporation, I only syntax color the last function name and not the namespace or `::`. But that could easily be changed.

For future me, the relevant tree-sitter namespace identifier scopes are:
`call_expression > qualified_identifier > identifier` and
`function_declarator > qualified_identifier > identifier`

I don't know anything about template functions so I left that untouched. So this is probably an incomplete fix.

Finally, add the `static_assert` operator. It's technically a directive so it'll appear purple, not blue. Again this could easily be changed so don't hesitate about feedback, idk anything about c++

### Verification Process

Will download and check to make sure it works

### Applicable issues

Relevant to https://github.com/atom/language-c/issues/246, https://github.com/atom/language-c/issues/245 (pretty much a fix except drawback),

(I split these out bc github doesn't detect that "fixes" applies to multiple issues)
Fixes https://github.com/atom/language-c/issues/169
Fixes https://github.com/atom/language-c/issues/170
Fixes https://github.com/atom/language-c/issues/260
Fixes https://github.com/microsoft/vscode-cpptools/issues/1477

For tree-sitter, kinda fix the Discord reported issue (In #support M1 Mac C++ Syntax highlighting)