### PR TITLE
deps: Update github to v0.36.14-pretranspiled-take-2

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "fuzzy-finder": "https://codeload.github.com/atom/fuzzy-finder/legacy.tar.gz/refs/tags/v1.14.3",
     "git-diff": "file:packages/git-diff",
     "git-utils": "5.7.1",
-    "github": "https://codeload.github.com/pulsar-edit/github/tar.gz/refs/tags/v0.36.14-pretranspiled",
+    "github": "https://codeload.github.com/pulsar-edit/github/tar.gz/refs/tags/v0.36.14-pretranspiled-take-2",
     "glob": "^7.1.1",
     "go-to-line": "file:packages/go-to-line",
     "grammar-selector": "file:packages/grammar-selector",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4957,9 +4957,9 @@ github-from-package@0.0.0:
   resolved "https://registry.yarnpkg.com/github-from-package/-/github-from-package-0.0.0.tgz#97fb5d96bfde8973313f20e8288ef9a167fa64ce"
   integrity sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==
 
-"github@https://codeload.github.com/pulsar-edit/github/tar.gz/refs/tags/v0.36.14-pretranspiled":
+"github@https://codeload.github.com/pulsar-edit/github/tar.gz/refs/tags/v0.36.14-pretranspiled-take-2":
   version "0.36.14"
-  resolved "https://codeload.github.com/pulsar-edit/github/tar.gz/refs/tags/v0.36.14-pretranspiled#1888aad132a9dfbfed265d07ac87fcbd9f42a2ce"
+  resolved "https://codeload.github.com/pulsar-edit/github/tar.gz/refs/tags/v0.36.14-pretranspiled-take-2#22158525f8801ecbb084e23ea45ee92ba3d3f9e1"
   dependencies:
     "@atom/babel-plugin-chai-assert-async" "1.0.0"
     "@atom/babel7-transpiler" "1.0.0-1"


### PR DESCRIPTION
A quick follow-up to #373...

Fixes an error message spawned when the editor tries to load the github package, attempts to transpile its JS files, but a needed `devDependencies` dependency of the `github` package is missing. _(This error unfortunately broke (loading of) the github package!)_

(As can be seen in [this video from CI](https://api.cirrus-ci.com/v1/artifact/task/6269393324212224/videos/tests/videos/opening-first-time/89339799dfc340e66af2f9e44a3af3a7.webm) -- taken from this CI run over at Cirrus: https://cirrus-ci.com/task/6269393324212224.)

<details><summary>The video embedded here for posterity (<1MB) (click to expand):</summary>

[CI visual test recording showing the github package failed to activate due to missing dependency.webm](https://user-images.githubusercontent.com/20157115/217680502-f96b2a0e-7645-4a57-9735-11c9a88c1922.webm)

</details>

---

<details><summary>Technical details of the issue + <b>details of the fix</b> (click to expand):</summary>

This change (done over at the github package's `v0.36.14-pretranspiled-take-2` tag itself) stops the package from implicitly instructing the editor to transpile github -- since this tagged version of the package is pretranspiled, we don't need the editor to attempt to transpile it a second time over, or anything.

(This change prevents this redundant [re]-transpilation by deleting the `atomTranspilers` field of github package's package.json. (Just as [Atom's old build scripts used to do right after they custom transpiled the github package source](https://github.com/atom/atom/blob/1c3bd35ce238dc0491def9e1780d04748d8e18af/script/lib/transpile-packages-with-custom-transpiler-paths.js#L67-L74) in preparation for inclusion in the app bundle.  See "`delete metadata.atomTranspilers;`" in that snippet I linked to.))

Transpiling again would be redundant, presumably would waste CPU cycles, and **will show errors if devDependencies are missing.** (And they *would* be missing, due to the way this package is currently specified in package.json, as a *tarball*, not a git ref URL where the devDependencies *would* be included.)

See the comparison of the two tags for confirmation to review, and to see that this is all that is changed:
https://github.com/pulsar-edit/github/compare/v0.36.14-pretranspiled...pulsar-edit:github:v0.36.14-pretranspiled-take-2

</details>

**CI/validation note:** If the visual tests don't display an error and the github package properly loads (see macOS job in Cirrus) then this PR worked as intended.

\[ EDIT/UPDATE: It's working! \]