### PR TITLE
Set Max Concurrent Package Tests

### DIFF
--- a/.github/workflows/package-tests-linux.yml
+++ b/.github/workflows/package-tests-linux.yml
@@ -45,7 +45,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
-      max-parallel: 2
+      max-parallel: 10
       matrix:
         include:
           - package: "atom-dark-syntax"

--- a/.github/workflows/package-tests-linux.yml
+++ b/.github/workflows/package-tests-linux.yml
@@ -45,7 +45,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
-      max-parallel: 10
+      max-parallel: 8
       matrix:
         include:
           - package: "atom-dark-syntax"

--- a/.github/workflows/package-tests-linux.yml
+++ b/.github/workflows/package-tests-linux.yml
@@ -45,6 +45,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
+      max-parallel: 2
       matrix:
         include:
           - package: "atom-dark-syntax"


### PR DESCRIPTION
As we have been seeing across the whole Org, we are getting instances of GitHub Actions in some repos taking hours to pick up a runner.

In short, this is because we are limited to 20 concurrent GitHub Actions runners across the org. And when each PR on `pulsar` spawns 100 GitHub Actions we can quickly see how this will very quickly absorb every available runner for some time, causing other repos to wait hours.

This PR doesn't totally fix the issue, rather than provide a trade off.

It sets the max concurrent package test GitHub Actions at `2`. This way only 2 of these Package Tests will ever run at any given time. Freeing up the queue for other repos within the org to run their tests in a more timely manner.

This of course will mean that PR's on `pulsar` will take longer to execute. But this seems to be a fair trade off to causing no other actions across the org for hours.

If the limit of 2 seems to low and causes actions here to take far to long we can increase this. Anything below 20 would still provide an advantage to the rest of the Org, but this seems a safe limit that we can monitor for changes in the future.