### PR TITLE
typo $ as #

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Setup NodeJS - ${{ matrix.node-version }}
       uses: actions/setup-node@v3
       with:
-        node-version: #{{ matrix.node-version }}
+        node-version: ${{ matrix.node-version }}
 
     - name: Install Dependencies
       run: yarn install


### PR DESCRIPTION
I found a small typo in the documentation workflow, where `${{ matrix.node-version }}` was typoed with a `#` instead of a `$`. It errored in my editor, and when I checked into the workflow run logs, it appears that the step to set up node just does a no-op. It was fine, because the default node version was v16 for the workflow image.