### PR TITLE
bump version to 1.102.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "pulsar",
   "author": "Pulsar Community <noreply@pulsar-edit.com>",
   "productName": "Pulsar",
-  "version": "1.102.0",
+  "version": "1.102.0-dev",
   "description": "A Community-led Hyper-Hackable Text Editor",
   "branding": {
     "id": "pulsar",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "pulsar",
   "author": "Pulsar Community <noreply@pulsar-edit.com>",
   "productName": "Pulsar",
-  "version": "1.101.0-dev",
+  "version": "1.102.0",
   "description": "A Community-led Hyper-Hackable Text Editor",
   "branding": {
     "id": "pulsar",


### PR DESCRIPTION
This PR bumps the version, then reverts it, so we can build a release and continue our rolling releases from master afterwards.