### PR TITLE
Move to XDG base specification

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,51 +1,69 @@
-linux_task:
-  alias: linux
-  container:
-    image: node:16-slim
-    memory: 8G
-  test_script:
-    - apt-get update
-    - export DEBIAN_FRONTEND="noninteractive"
-    - apt-get install -y
-                rpm
-                build-essential
-                git
-                libsecret-1-dev
-                fakeroot
-                libx11-dev
-                libxkbfile-dev
-                libgdk-pixbuf2.0-dev
-                libgtk-3-dev
-                libxss-dev
-                libasound2-dev
-                libnss3
-                xvfb
-    - git submodule init
-    - git submodule update
-    - sed -i -e "s/[0-9]*-dev/`date -u +%Y%m%d%H`/g" package.json
-    - yarn install || yarn install
-    - yarn build
-    - yarn run build:apm
-    - Xvfb :99 & DISPLAY=:99 PLAYWRIGHT_JUNIT_OUTPUT_NAME=report.xml npx playwright test --reporter=junit,list
-  always:
-    videos_artifacts:
-      path: ./tests/videos/**
-    junit_artifacts:
-      path: report.xml
-      type: text/xml
-      format: junit
-  build_binary_script:
-    - yarn dist || yarn dist
-  binary_artifacts:
-    path: ./binaries/*
+env:
+  PYTHON_VERSION: 3.10
+  GITHUB_TOKEN: ENCRYPTED[!b0ff4671044672be50914a3a10b49af642bd8e0e681a6f4e5855ec5230a5cf9afbc53d9e90239b8d2c79455f014f383f!]
+  # The above token, is a GitHub API Token, that allows us to download RipGrep without concern of API limits
+
+# linux_task:
+#   alias: linux
+#   container:
+#     image: node:16-slim
+#     memory: 8G
+#   prepare_script:
+#     - apt-get update
+#     - export DEBIAN_FRONTEND="noninteractive"
+#     - apt-get install -y
+#                 ffmpeg
+#                 rpm
+#                 build-essential
+#                 git
+#                 libsecret-1-dev
+#                 fakeroot
+#                 libx11-dev
+#                 libxkbfile-dev
+#                 libgdk-pixbuf2.0-dev
+#                 libgtk-3-dev
+#                 libxss-dev
+#                 libasound2-dev
+#                 libnss3
+#                 xvfb
+#     - git submodule init
+#     - git submodule update
+#     - sed -i -e "s/[0-9]*-dev/`date -u +%Y%m%d%H`/g" package.json
+#   install_script:
+#     - yarn install --ignore-engines || yarn install --ignore-engines
+#   build_script:
+#     - yarn build
+#     - yarn run build:apm
+#   build_binary_script:
+#     - yarn dist || yarn dist
+#   rename_binary_script:
+#     - node script/rename.js "Linux"
+#   binary_artifacts:
+#     path: ./binaries/*
+#   test_script:
+#     - rm -R node_modules/electron; yarn install --check-files
+#     - ./binaries/*AppImage --appimage-extract
+#     - export BINARY_NAME='squashfs-root/pulsar'
+#     - mkdir -p ./tests/videos
+#     - Xvfb -screen 0 1024x768x24+32 :99 & nohup ffmpeg -video_size 1024x768 -f x11grab -i :99.0 ./tests/videos/out.mpg & DISPLAY=:99 PLAYWRIGHT_JUNIT_OUTPUT_NAME=report.xml npx playwright test --reporter=junit,list
+#   always:
+#     videos_artifacts:
+#       path: ./tests/videos/**
+#     junit_artifacts:
+#       path: report.xml
+#       type: text/xml
+#       format: junit
 
 arm_linux_task:
   alias: linux
+  only_if: $CIRRUS_CRON != "" || $CIRRUS_TAG != ""
+  skip: $CIRRUS_CHANGE_IN_REPO == $CIRRUS_LAST_GREEN_CHANGE
   arm_container:
     image: node:16-slim
     memory: 8G
   env:
     USE_SYSTEM_FPM: 'true'
+    ROLLING_UPLOAD_TOKEN: ENCRYPTED[690950798401ec3715e9d20ac29a0859d3c58097038081ff6afeaf4721e661672d34eb952d8a6442bc7410821ab8545a]
   prepare_script:
     - apt-get update
     - export DEBIAN_FRONTEND="noninteractive"
@@ -53,6 +71,7 @@ arm_linux_task:
                 gnupg2
                 procps
                 curl
+                ruby
                 rpm
                 build-essential
                 git
@@ -66,25 +85,30 @@ arm_linux_task:
                 libasound2-dev
                 libnss3
                 xvfb
-    - gpg2 --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
-    - \curl -sSL https://get.rvm.io | bash -s stable
-    - source /etc/profile.d/rvm.sh
-    - rvm install ruby
     - gem install fpm
     - git submodule init
     - git submodule update
     - sed -i -e "s/[0-9]*-dev/`date -u +%Y%m%d%H`/g" package.json
-    - yarn install || yarn install
+  install_script:
+    - yarn install --ignore-engines || yarn install --ignore-engines
+  build_script:
     - yarn build
     - yarn run build:apm
-    - rm -Rf node-modules/electron && yarn install --check-files
   build_binary_script:
-    - source /etc/profile.d/rvm.sh
     - yarn dist || yarn dist
+  rename_binary_script:
+    - node script/rename.js "ARM.Linux"
   binary_artifacts:
     path: ./binaries/*
   test_script:
+    - rm -R node_modules/electron; yarn install --check-files
+    - ./binaries/*AppImage --appimage-extract
+    - export BINARY_NAME='squashfs-root/pulsar'
     - Xvfb :99 & DISPLAY=:99 PLAYWRIGHT_JUNIT_OUTPUT_NAME=report.xml npx playwright test --reporter=junit,list
+  rolling_upload_script:
+    - cd ./script/rolling-release-scripts
+    - npm install
+    - node ./rolling-release-binary-upload.js cirrus
   always:
     videos_artifacts:
       path: ./tests/videos/**
@@ -95,59 +119,51 @@ arm_linux_task:
 
 silicon_mac_task:
   alias: mac
+  only_if: $CIRRUS_CRON != "" || $CIRRUS_TAG != ""
+  skip: $CIRRUS_CHANGE_IN_REPO == $CIRRUS_LAST_GREEN_CHANGE
   macos_instance:
-    image: ghcr.io/cirruslabs/macos-monterey-base:latest
+    image: ghcr.io/cirruslabs/macos-monterey-xcode:14
     memory: 8G
-  test_script:
-    - brew install node@16 yarn git python
+  env:
+    CSC_LINK: ENCRYPTED[0078015a03bb6cfdbd80113ae5bbb6f448fd4bbbc40efd81bf2cb1554373046b475a4d7c77e3e3e82ac1ce2f7e3d2da5]
+    CSC_KEY_PASSWORD: ENCRYPTED[82bb72653d39578035ed1860ab4978703d50bd326d925a146ff08782f987ceb37ac2d8dbace52dec2b0e2ef92debf097]
+    APPLEID: ENCRYPTED[549ce052bd5666dba5245f4180bf93b74ed206fe5e6e7c8f67a8596d3767c1f682b84e347b326ac318c62a07c8844a57]
+    APPLEID_PASSWORD: ENCRYPTED[774c3307fd3b62660ecf5beb8537a24498c76e8d90d7f28e5bc816742fd8954a34ffed13f9aa2d1faf66ce08b4496e6f]
+    TEAM_ID: ENCRYPTED[11f3fedfbaf4aff1859bf6c105f0437ace23d84f5420a2c1cea884fbfa43b115b7834a463516d50cb276d4c4d9128b49]
+    ROLLING_UPLOAD_TOKEN: ENCRYPTED[690950798401ec3715e9d20ac29a0859d3c58097038081ff6afeaf4721e661672d34eb952d8a6442bc7410821ab8545a]
+  prepare_script:
+    - brew install node@16 yarn git python@$PYTHON_VERSION
     - git submodule init
     - git submodule update
-    - ln -s /opt/homebrew/bin/python3 /opt/homebrew/bin/python
+    - ln -s /opt/homebrew/bin/python$PYTHON_VERSION /opt/homebrew/bin/python
     - export PATH="/opt/homebrew/bin:/opt/homebrew/opt/node@16/bin:$PATH"
     - sed -i -e "s/[0-9]*-dev/`date -u +%Y%m%d%H`/g" package.json
-    - yarn install || yarn install
+  install_script:
+    - export PATH="/opt/homebrew/bin:/opt/homebrew/opt/node@16/bin:$PATH"
+    - yarn install --ignore-engines || yarn install --ignore-engines
+  build_script:
+    - export PATH="/opt/homebrew/bin:/opt/homebrew/opt/node@16/bin:$PATH"
     - yarn build
     - yarn run build:apm
-    - PLAYWRIGHT_JUNIT_OUTPUT_NAME=report.xml npx playwright test --reporter=junit,list
-  always:
-    videos_artifacts:
-      path: ./tests/videos/**
-    junit_artifacts:
-      path: report.xml
-      type: text/xml
-      format: junit
-  build_arm_binary_script:
+  build_binary_script:
     - export PATH="/opt/homebrew/bin:/opt/homebrew/opt/node@16/bin:$PATH"
     - yarn dist || yarn dist
-  binary_artifacts:
-    path: ./binaries/*
-
-intel_mac_task:
-  alias: mac
-  macos_instance:
-    image: ghcr.io/cirruslabs/macos-monterey-base:latest
-    memory: 8G
-  dist_script:
-    - sudo rm -rf /Library/Developer/CommandLineTools
-    - echo A | softwareupdate --install-rosetta
-    - arch -x86_64 xcode-select --install
-    - arch -x86_64 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
-    - export PATH="/usr/local/opt/node@16/bin:/usr/local/bin:$PATH"
-    - arch -x86_64 brew install node@16 yarn git python
-    - ln -s /usr/local/bin/python3 /usr/local/bin/python
-    - git submodule init
-    - git submodule update
-    - sed -i -e "s/[0-9]*-dev/`date -u +%Y%m%d%H`/g" package.json
-    - arch -x86_64 npx yarn install || arch -x86_64 npx yarn install
-    - arch -x86_64 npx yarn build
-    - arch -x86_64 yarn run build:apm
-    - export PATH="/usr/local/opt/node@16/bin:/usr/local/bin:$PATH"
-    - arch -x86_64 npx yarn dist || arch -x86_64 npx yarn dist
+  rename_binary_script:
+    - export PATH="/opt/homebrew/bin:/opt/homebrew/opt/node@16/bin:$PATH"
+    - node script/rename.js "Silicon.Mac"
   binary_artifacts:
     path: ./binaries/*
   test_script:
-    - export PATH="/usr/local/opt/node@16/bin:/usr/local/bin:$PATH"
-    - PLAYWRIGHT_JUNIT_OUTPUT_NAME=report.xml arch -x86_64 npx playwright test --reporter=junit,list
+    - export PATH="/opt/homebrew/bin:/opt/homebrew/opt/node@16/bin:$PATH"
+    - rm -R node_modules/electron; yarn install --check-files
+    - hdiutil mount binaries/*Pulsar*dmg
+    - export BINARY_NAME=`ls /Volumes/Pulsar*/Pulsar.app/Contents/MacOS/Pulsar`
+    - PLAYWRIGHT_JUNIT_OUTPUT_NAME=report.xml npx playwright test --reporter=junit,list
+  rolling_upload_script:
+    - export PATH="/opt/homebrew/bin:/opt/homebrew/opt/node@16/bin:$PATH"
+    - cd ./script/rolling-release-scripts
+    - npm install
+    - node ./rolling-release-binary-upload.js cirrus
   always:
     videos_artifacts:
       path: ./tests/videos/**
@@ -156,36 +172,94 @@ intel_mac_task:
       type: text/xml
       format: junit
 
-windows_task:
-  alias: windows
-  windows_container:
-    image: cirrusci/windowsservercore:visualstudio2022-2022.06.23
-  env:
-    CIRRUS_SHELL: bash
-    PATH: C:\Python310\Scripts\;C:\Python310\;%PATH%;C:\Program Files\nodejs\;C:\Program Files\Git\cmd;C:\Users\User\AppData\Local\Microsoft\WindowsApps;C:\Users\User\AppData\Roaming\npm;C:\Program Files\Microsoft Visual Studio\2022\Community\Msbuild\Current\Bin\
-  install_deps_script:
-    - choco install nodejs --version=14.15.0 -y
-    - choco install python --version=3.10.3	-y
-    - choco install git visualstudio2019-workload-vctools -y
-    - git submodule init
-    - git submodule update
-    - npm config set python 'C:\Python310\python.exe'
-  build_apm_script:
-    - cd ppm; npm install
-  install_with_scripts_script:
-    - npx yarn install --ignore-engines || sleep 1 && npx yarn install --ignore-engines || echo "There is a reason for so many tries"
-  #install_without_scripts_script:
-  #  - npx yarn install --ignore-scripts --ignore-engines || sleep 1 && npx yarn install --ignore-engines --ignore-scripts || sleep 2 && npx yarn cache clean; npx yarn install --ignore-engines --ignore-scripts || sleep 2 && npx yarn install --ignore-engines --ignore-scripts || echo "Giving up"
-  rebuild_for_electron_script:
-    - npx yarn build || npx yarn build || npx yarn build
-  # install_only_electron_script:
-  #   - rm -R node_modules/electron
-  #   - npx yarn install --ignore-engines || npx yarn install --ignore-engines || npx yarn cache clean; npx yarn install --ignore-engines || npx yarn install --ignore-engines
-    # - npx playwright test --reporter=list
-  videos_artifacts:
-    path: tests\videos\**
-  build_binary_script:
-    - sed -i -e "s/[0-9]*-dev/`date -u +%Y%m%d%H`/g" package.json
-    - npx yarn dist || npx yarn dist || npx yarn dist
-  binary_artifacts:
-    path: .\binaries\*
+# intel_mac_task:
+#   alias: mac
+#   macos_instance:
+#     image: ghcr.io/cirruslabs/macos-monterey-xcode:14
+#     memory: 8G
+#   env:
+#     CSC_LINK: ENCRYPTED[0078015a03bb6cfdbd80113ae5bbb6f448fd4bbbc40efd81bf2cb1554373046b475a4d7c77e3e3e82ac1ce2f7e3d2da5]
+#     CSC_KEY_PASSWORD: ENCRYPTED[82bb72653d39578035ed1860ab4978703d50bd326d925a146ff08782f987ceb37ac2d8dbace52dec2b0e2ef92debf097]
+#     APPLEID: ENCRYPTED[549ce052bd5666dba5245f4180bf93b74ed206fe5e6e7c8f67a8596d3767c1f682b84e347b326ac318c62a07c8844a57]
+#     APPLEID_PASSWORD: ENCRYPTED[774c3307fd3b62660ecf5beb8537a24498c76e8d90d7f28e5bc816742fd8954a34ffed13f9aa2d1faf66ce08b4496e6f]
+#     TEAM_ID: ENCRYPTED[11f3fedfbaf4aff1859bf6c105f0437ace23d84f5420a2c1cea884fbfa43b115b7834a463516d50cb276d4c4d9128b49]
+#   prepare_script:
+#     - sudo rm -rf /Library/Developer/CommandLineTools
+#     - echo A | softwareupdate --install-rosetta
+#     - arch -x86_64 xcode-select --install
+#     - arch -x86_64 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
+#     - export PATH="/usr/local/opt/node@16/bin:/usr/local/bin:$PATH"
+#     - arch -x86_64 brew install node@16 yarn git python@$PYTHON_VERSION
+#     - ln -s /usr/local/bin/python$PYTHON_VERSION /usr/local/bin/python
+#     - git submodule init
+#     - git submodule update
+#     - sed -i -e "s/[0-9]*-dev/`date -u +%Y%m%d%H`/g" package.json
+#   install_script:
+#     - export PATH="/usr/local/opt/node@16/bin:/usr/local/bin:$PATH"
+#     - arch -x86_64 npx yarn install --ignore-engines || arch -x86_64 npx yarn install --ignore-engines
+#   build_script:
+#     - export PATH="/usr/local/opt/node@16/bin:/usr/local/bin:$PATH"
+#     - arch -x86_64 npx yarn build
+#     - arch -x86_64 yarn run build:apm
+#   build_binary_script:
+#     - export PATH="/usr/local/opt/node@16/bin:/usr/local/bin:$PATH"
+#     - arch -x86_64 npx yarn dist || arch -x86_64 npx yarn dist
+#   rename_binary_script:
+#     - export PATH="/usr/local/opt/node@16/bin:/usr/local/bin:$PATH"
+#     - node script/rename.js "Intel.Mac"
+#   binary_artifacts:
+#     path: ./binaries/*
+#   test_script:
+#     - export PATH="/usr/local/opt/node@16/bin:/usr/local/bin:$PATH"
+#     - rm -R node_modules/electron; yarn install --check-files
+#     - hdiutil mount binaries/*Pulsar*dmg
+#     - export BINARY_NAME=`ls /Volumes/Pulsar*/Pulsar.app/Contents/MacOS/Pulsar`
+#     - PLAYWRIGHT_JUNIT_OUTPUT_NAME=report.xml arch -x86_64 npx playwright test --reporter=junit,list
+#   always:
+#     videos_artifacts:
+#       path: ./tests/videos/**
+#     junit_artifacts:
+#       path: report.xml
+#       type: text/xml
+#       format: junit
+
+# windows_task:
+#   alias: windows
+#   timeout_in: 90m
+#   windows_container:
+#     image: cirrusci/windowsservercore:visualstudio2022-2022.06.23
+#   env:
+#     CIRRUS_SHELL: bash
+#     PATH: C:\Python310\Scripts\;C:\Python310\;%PATH%;C:\Program Files\nodejs\;C:\Program Files\Git\cmd;C:\Users\User\AppData\Local\Microsoft\WindowsApps;C:\Users\User\AppData\Roaming\npm;C:\Program Files\Microsoft Visual Studio\2022\Community\Msbuild\Current\Bin\
+#   prepare_script:
+#     - choco install nodejs --version=16.16.0 -y
+#     - choco install python --version=3.10.3	-y
+#     - choco install git visualstudio2019-workload-vctools -y
+#     - git submodule init
+#     - git submodule update
+#     - npm config set python 'C:\Python310\python.exe'
+#   install_script:
+#     - npx yarn install --ignore-engines
+#       || rm -R node_modules && npx yarn install --ignore-engines
+#       || rm -R node_modules && npx yarn install --ignore-engines
+#   build_script:
+#     - npx yarn build:apm
+#     - npx yarn build || npx yarn build || npx yarn build
+#   build_binary_script:
+#     - sed -i -e "s/[0-9]*-dev/`date -u +%Y%m%d%H`/g" package.json
+#     - npx yarn dist || npx yarn dist || npx yarn dist
+#   rename_binary_script:
+#     - node script/rename.js "Windows"
+#   binary_artifacts:
+#     path: .\binaries\*
+#   test_script:
+#     - mkdir extracted; tar -xf binaries/*zip -C ./extracted/
+#     - export BINARY_NAME=./extracted/Pulsar.exe
+#     - PLAYWRIGHT_JUNIT_OUTPUT_NAME=report.xml npx playwright test --reporter=junit,list || echo "Yeah, tests failed, Windows is like this"
+#   always:
+#     videos_artifacts:
+#       path: ./tests/videos/**
+#     junit_artifacts:
+#       path: report.xml
+#       type: text/xml
+#       format: junit

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,20 +1,178 @@
 {
-  "schedule": ["every weekend"],
+  "extends": [ "config:base", ":dependencyDashboardApproval"],
+  "constraints": {
+    "node": "< 16"
+  },
   "labels": ["dependencies"],
   "separateMajorMinor": "false",
+  "ignorePaths": [
+    "packages/autocomplete-atom-api/spec/fixtures/",
+    "packages/dev-live-reload/spec/fixtures/",
+    "packages/incompatible-packages/spec/fixtures/",
+    "packages/settings-view/spec/fixtures/",
+    "spec/fixtures/"
+  ],
   "packageRules": [
     {
+      "description": "Group all DevDependencies for the Core Editor",
       "matchDepTypes": ["devDependencies"],
-      "matchUpdateTypes": ["major", "minor", "patch", "pin", "digest", "lockFileMaintenance", "rollback", "bump"],
-      "groupName": "devDependencies",
-      "semanticCommitType": "chore",
-      "automerge": true
+      "groupName": "Core DevDependencies",
+      "matchPaths": ["package.json"]
     },
     {
+      "description": "Group all Dependencies for the Core Editor",
       "matchDepTypes": ["dependencies"],
-      "matchUpdateTypes": ["major", "minor", "patch", "pin", "digest", "lockFileMaintenance", "rollback", "bump"],
-      "groupName": "dependencies",
-      "semanticCommitType": "fix"
+      "groupName": "Core Dependencies",
+      "matchPaths": ["package.json"]
+    },
+    {
+      "description": "Group all of our Syntax Themes and UI Themes",
+      "groupName": "Core Syntax & UI Themes",
+      "matchPaths": [
+        "packages/*-syntax/**", "packages/*-ui/**", "packages/*-theme/**"
+      ]
+    },
+    {
+      "description": "Group all of our Languages",
+      "groupName": "Core Languages",
+      "matchPaths": [
+        "packages/language-*/**"
+      ]
+    },
+    {
+      "matchPaths": [ "packages/about/**" ], "groupName": "about package"
+    },
+    {
+      "matchPaths": [ "packages/archive-view/**" ], "groupName": "archive-view package"
+    },
+    {
+      "matchPaths": [ "packages/autocomplete-atom-api/**" ], "groupName": "autocomplete-atom-api"
+    },
+    {
+      "matchPaths": [ "packages/autocomplete-css/**" ], "groupName": "autocomplete-css package"
+    },
+    {
+      "matchPaths": [ "packages/autocomplete-html/**" ], "groupName": "autocomplete-html package"
+    },
+    {
+      "matchPaths": [ "packages/autocomplete-plus/**" ], "groupName": "autocomplete-plus package"
+    },
+    {
+      "matchPaths": [ "packages/autocomplete-snippets/**" ], "groupName": "autocomplete-snippets package"
+    },
+    {
+      "matchPaths": [ "packages/autoflow/**" ], "groupName": "autoflow package"
+    },
+    {
+      "matchPaths": [ "packages/autosave/**" ], "groupName": "autosave package"
+    },
+    {
+      "matchPaths": [ "packages/background-tips/**" ], "groupName": "background-tips package"
+    },
+    {
+      "matchPaths": [ "packages/bookmarks/**" ], "groupName": "bookmarks package"
+    },
+    {
+      "matchPaths": [ "packages/bracket-matcher/**" ], "groupName": "bracket-matcher package"
+    },
+    {
+      "matchPaths": [ "packages/command-palette/**" ], "groupName": "command-palette package"
+    },
+    {
+      "matchPaths": [ "packages/dalek/**" ], "groupName": "dalek package"
+    },
+    {
+      "matchPaths": [ "packages/deprecation-cop/**" ], "groupName": "deprecation-cop package"
+    },
+    {
+      "matchPaths": [ "packages/dev-live-reload/**" ], "groupName": "dev-live-reload package"
+    },
+    {
+      "matchPaths": [ "packages/encoding-selector/**" ], "groupName": "encoding-selector package"
+    },
+    {
+      "matchPaths": [ "packages/exception-reporting/**" ], "groupName": "exception-reporting package"
+    },
+    {
+      "matchPaths": [ "packages/find-and-replace/**" ], "groupName": "find-and-replace package"
+    },
+    {
+      "matchPaths": [ "packages/fuzzy-finder/**" ], "groupName": "fuzzy-finder package"
+    },
+    {
+      "matchPaths": [ "packages/git-diff/**" ], "groupName": "git-diff package"
+    },
+    {
+      "matchPaths": [ "packages/go-to-line/**" ], "groupName": "go-to-line package"
+    },
+    {
+      "matchPaths": [ "packages/grammar-selector/**" ], "groupName": "grammar-selector package"
+    },
+    {
+      "matchPaths": [ "packages/image-view/**" ], "groupName": "image-view package"
+    },
+    {
+      "matchPaths": [ "packages/incompatible-packages/**" ], "groupName": "incompatible-packages package"
+    },
+    {
+      "matchPaths": [ "packages/keybinding-resolver/**" ], "groupName": "keybinding-resolver package"
+    },
+    {
+      "matchPaths": [ "packages/line-ending-selector/**" ], "groupName": "line-ending-selector package"
+    },
+    {
+      "matchPaths": [ "packages/link/**" ], "groupName": "link package"
+    },
+    {
+      "matchPaths": [ "packages/markdown-preview/**" ], "groupName": "markdown-preview package"
+    },
+    {
+      "matchPaths": [ "packages/notifications/**" ], "groupName": "notifications package"
+    },
+    {
+      "matchPaths": [ "packages/open-on-github/**" ], "groupName": "open-on-github package"
+    },
+    {
+      "matchPaths": [ "packages/package-generator/**" ], "groupName": "package-generator package"
+    },
+    {
+      "matchPaths": [ "packages/pulsar-updater/**" ], "groupName": "pulsar-updater package"
+    },
+    {
+      "matchPaths": [ "packages/settings-view/**" ], "groupName": "settings-view package"
+    },
+    {
+      "matchPaths": [ "packages/spell-check/**" ], "groupName": "spell-check package"
+    },
+    {
+      "matchPaths": [ "packages/status-bar/**" ], "groupName": "status-bar package"
+    },
+    {
+      "matchPaths": [ "packages/styleguide/**" ], "groupName": "styleguide package"
+    },
+    {
+      "matchPaths": [ "packages/symbols-view/**" ], "groupName": "symbols-view package"
+    },
+    {
+      "matchPaths": [ "packages/tabs/**" ], "groupName": "tabs package"
+    },
+    {
+      "matchPaths": [ "packages/timecop/**" ], "groupName": "timecop package"
+    },
+    {
+      "matchPaths": [ "packages/tree-view/**" ], "groupName": "tree-view package"
+    },
+    {
+      "matchPaths": [ "packages/update-package-dependencies/**" ], "groupName": "update-package-dependencies package"
+    },
+    {
+      "matchPaths": [ "packages/welcome/**" ], "groupName": "welcome package"
+    },
+    {
+      "matchPaths": [ "packages/whitespace/**" ], "groupName": "whitespace package"
+    },
+    {
+      "matchPaths": [ "packages/wrap-guide/**" ], "groupName": "wrap-guide package"
     }
   ]
 }

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,168 @@
+name: Build Pulsar Binaries
+
+on:
+  push:
+    branches:
+      - 'master'
+  pull_request:
+  workflow_dispatch:
+
+env:
+  # Variables needed for build information
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  PYTHON_VERSION: '3.10'
+  NODE_VERSION: 16
+  ROLLING_UPLOAD_TOKEN: ${{ secrets.ROLLING_RELEASE_UPLOAD_TOKEN }}
+  # Below variables allow us to quickly control visual tests for each platform
+  RUN_WINDOWS_VT: false
+  RUN_LINUX_VT: true
+  RUN_MACOS_VT: true
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        os: [ ubuntu-latest, windows-latest, macos-latest ]
+      fail-fast: false
+    runs-on: ${{ matrix.os }}
+
+    steps:
+    - name: Checkout the latest code
+      uses: actions/checkout@v3
+
+    - name: Setup Node
+      uses: actions/setup-node@v3
+      with:
+        node-version: ${{ env.NODE_VERSION }}
+
+    - name: Setup Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ env.PYTHON_VERSION }}
+
+    - name: Setup Git Submodule
+      run: |
+        git submodule init
+        git submodule update
+
+    - name: Check Pulsar Version
+      if: ${{ runner.os != 'Windows' }}
+      run: sed -i -e "s/[0-9]*-dev/`date -u +%Y%m%d%H`/g" package.json
+
+    - name: Check Pulsar Version - Windows
+      if: ${{ runner.os == 'Windows' }}
+      run: (Get-Content package.json) -replace '[0-9]*-dev', (date -u +%Y%m%d%H) | Set-Content -Path package.json
+
+    - name: Install Pulsar Dependencies
+      uses: nick-fields/retry@943e742917ac94714d2f408a0e8320f2d1fcafcd
+      with:
+        timeout_minutes: 30
+        max_attempts: 3
+        retry_on: error
+        command: yarn install --ignore-engines
+        on_retry_command: rm -R node_modules
+
+    - name: Build Pulsar
+      uses: nick-fields/retry@943e742917ac94714d2f408a0e8320f2d1fcafcd
+      with:
+        timeout_minutes: 30
+        max_attempts: 3
+        retry_on: error
+        command: |
+          yarn build
+          yarn run build:apm
+
+    # macOS Signing Stuff
+    - name: Build Pulsar Binaries (macOS) (Signed)
+      if: ${{ runner.os == 'macOS' && github.event.pull_request.head.repo.full_name == 'pulsar-edit/pulsar' }}
+      # PRs generated from forks cannot access GitHub Secrets
+      # So if the PR is a fork, we will still build, but will not sign.
+      env:
+        CSC_LINK: ${{ secrets.CSC_LINK }}
+        CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
+        APPLEID: ${{ secrets.APPLEID }}
+        APPLEID_PASSWORD: ${{ secrets.APPLEID_PASSWORD }}
+        TEAM_ID: ${{ secrets.TEAM_ID }}
+      uses: nick-fields/retry@943e742917ac94714d2f408a0e8320f2d1fcafcd
+      with:
+        timeout_minutes: 30
+        max_attempts: 3
+        retry_on: error
+        command: yarn dist
+
+    - name: Build Pulsar Binaries (macOS) (Unsigned)
+      if: ${{ runner.os == 'macOS' && github.event.pull_request.head.repo.full_name != 'pulsar-edit/pulsar' }}
+      uses: nick-fields/retry@943e742917ac94714d2f408a0e8320f2d1fcafcd
+      with:
+        timeout_minutes: 30
+        max_attempts: 3
+        retry_on: error
+        command: yarn dist
+
+    - name: Build Pulsar Binaries
+      if: ${{ runner.os != 'macOS' }}
+      uses: nick-fields/retry@943e742917ac94714d2f408a0e8320f2d1fcafcd
+      with:
+        timeout_minutes: 30
+        max_attempts: 3
+        retry_on: error
+        command: yarn dist
+
+    - name: Rename Pulsar Binaries for Regular release (Linux)
+      if: ${{ runner.os == 'Linux' }}
+      run: node ./script/rename.js "Linux"
+
+    - name: Rename Pulsar Binaries for Regular release (macOS)
+      if: ${{ runner.os == 'macOS' }}
+      run: node ./script/rename.js "Intel.Mac"
+
+    - name: Rename Pulsar Binaries for Regular release (Windows)
+      if: ${{ runner.os == 'Windows' }}
+      run: node ./script/rename.js "Windows"
+
+    - name: Upload Binary Artifacts
+      uses: actions/upload-artifact@v3
+      with:
+        name: ${{ matrix.os }} Binaries
+        path: ./binaries/*
+
+    - name: Test Binary - Linux
+      if: ${{ (runner.os == 'Linux') && env.RUN_LINUX_VT }}
+      run: |
+        rm -R node_modules/electron; yarn install --check-files
+        ./binaries/*AppImage --appimage-extract
+        export BINARY_NAME='squashfs-root/pulsar'
+        mkdir -p ./tests/videos
+        Xvfb -screen 0 1024x768x24+32 :99 & nohup ffmpeg -video_size 1024x768 -f x11grab -i :99.0 ./tests/videos/out.mpg & DISPLAY=:99 PLAYWRIGHT_JUNIT_OUTPUT_NAME=report.xml npx playwright test --reporter=junit,list
+
+    - name: Test Binary - Windows
+      if: runner.os == 'Windows' && env.RUN_WINDOWS_VT == true
+      # TODO: Convert script to PowerShell
+      run: |
+        mkdir extracted; tar -xf binaries/*zip -C ./extracted/
+        export BINARY_NAME=./extracted/Pulsar.exe
+        PLAYWRIGHT_JUNIT_OUTPUT_NAME=report.xml npx playwright test --reporter=junit,list || echo "Yeah, tests failed, Windows is like this"
+
+    - name: Test Binary - macOS
+      if: runner.os == 'macOS' && env.RUN_MACOS_VT == true
+      run: |
+        export PATH="/usr/local/opt/node@16/bin:/usr/local/bin:$PATH"
+        rm -R node_modules/electron; yarn install --check-files
+        hdiutil mount binaries/*Pulsar*dmg
+        export BINARY_NAME=`ls /Volumes/Pulsar*/Pulsar.app/Contents/MacOS/Pulsar`
+        PLAYWRIGHT_JUNIT_OUTPUT_NAME=report.xml arch -x86_64 npx playwright test --reporter=junit,list
+
+    - name: Add binaries to Rolling Release Repo
+      if: ${{ github.event_name == 'push' }}
+      # We only want to upload rolling binaries if they are a commit to master
+      # Otherwise we want to not upload if it's a PR or manually triggered build
+      run: |
+        cd ./script/rolling-release-scripts
+        npm install
+        node ./rolling-release-binary-upload.js
+
+    - name: Upload Video Artifacts
+      uses: actions/upload-artifact@v3
+      with:
+        name: ${{ matrix.os }} Videos
+        path: ./tests/videos/**

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -3,6 +3,10 @@ name: Documentation
 on:
   push:
     branches: [ "master" ]
+  workflow_dispatch:
+
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 jobs:
   documentation:

--- a/.github/workflows/editor-tests.yml
+++ b/.github/workflows/editor-tests.yml
@@ -1,13 +1,15 @@
 name: Editor tests
 on:
-  - pull_request
+  pull_request:
+  push:
+    branches: ['master']
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   ATOM_JASMINE_REPORTER: list
 
 jobs:
   tests:
-    name: tests
+    name: Tests
     if: |
       !startsWith(github.event.pull_request.title, '[skip-ci]') &&
       !startsWith(github.event.pull_request.title, '[skip-editor-ci]')
@@ -19,20 +21,20 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - name: Checkout the latest code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Setup node
-      uses: actions/setup-node@v2-beta
+      uses: actions/setup-node@v3
       with:
         node-version: 16
 
-    - name: install dependencies
+    - name: Install Dependencies
       run: yarn install
 
-    - name: build dependencies
+    - name: Build Dependencies
       run: yarn build
 
-    - name: Run tests
-      uses: GabrielBB/xvfb-action@v1
+    - name: Run Tests
+      uses: coactions/setup-xvfb@v1.0.1
       with:
         run: node script/run-tests.js spec

--- a/.github/workflows/package-tests-linux.yml
+++ b/.github/workflows/package-tests-linux.yml
@@ -1,6 +1,8 @@
-name: Package tests for Pulsar on Linux
+name: Package tests
 on:
-  - pull_request
+  pull_request:
+  push:
+    branches: ['master']
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   ATOM_JASMINE_REPORTER: list
@@ -13,10 +15,10 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - name: Checkout the latest code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Setup node
-      uses: actions/setup-node@v2-beta
+      uses: actions/setup-node@v3
       with:
         node-version: 16
 
@@ -37,7 +39,16 @@ jobs:
       uses: actions/cache@v3
       with:
         path: pulsar.deb
-        key: pulsar-$env:GITHUB_SHA
+        key: pulsar-${{ github.sha }}
+
+    - name: Cache dependencies
+      id: cache-dependencies
+      uses: actions/cache@v3
+      with:
+        path: |
+          node_modules
+          packages
+        key: dependencies-${{ github.sha }}
 
   test:
     name: Package
@@ -93,12 +104,13 @@ jobs:
           - package: "notifications"
           - package: "open-on-github"
           - package: "package-generator"
+          - package: "pulsar-updater"
           - package: "settings-view"
           - package: "snippets"
           - package: "spell-check"
           - package: "status-bar"
           - package: "styleguide"
-          - package: "symbols-view"
+          # - package: "symbols-view"
           - package: "tabs"
           - package: "timecop"
           - package: "tree-view"
@@ -143,12 +155,27 @@ jobs:
 
     steps:
     - name: Checkout the latest code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
+    - name: Setup NodeJS
+      uses: actions/setup-node@v3
+      with:
+        node-version: 16
+
+    - name: Restore dependencies from Cache
+      id: restore-dependencies
+      uses: actions/cache@v3
+      with:
+        path: |
+          node_modules
+          packages
+        key: dependencies-${{ github.sha }}
 
     - name: Install Dependencies
+      if: steps.restore-dependencies.outputs.cache-hit != 'true'
       run: yarn install || yarn install
 
     - name: Build Dependencies
+      if: steps.restore-dependencies.outputs.cache-hit != 'true'
       run: yarn build || yarn build
 
     - name: Restore pulsar from Cache
@@ -156,7 +183,7 @@ jobs:
       uses: actions/cache@v3
       with:
         path: pulsar.deb
-        key: pulsar-$env:GITHUB_SHA
+        key: pulsar-${{ github.sha }}
 
     - name: Install Pulsar
       run: sudo dpkg -i pulsar.deb && sudo apt-get -f install -y

--- a/src/atom-paths.js
+++ b/src/atom-paths.js
@@ -19,7 +19,11 @@ const getAppDirectory = () => {
         0,
         process.execPath.indexOf('.app') + 4
       );
-    case 'linux':
+    case 'linux': 
+      if (process.env.XDG_CONFIG_HOME) {
+        return process.env.XDG_CONFIG_HOME;
+        } else { 
+          return path.join(process.env.HOME, '.config')};
     case 'win32':
       return path.join(process.execPath, '..');
   }
@@ -46,7 +50,7 @@ module.exports = {
     }
 
     // Fall back to default .atom folder in users home folder
-    process.env.ATOM_HOME = path.join(homePath, '.pulsar');
+    process.env.ATOM_HOME = path.join(getAppDirectory(), 'pulsar');
   },
 
   setUserData: app => {


### PR DESCRIPTION
Really this is just a proof of concept PR to draw attention to what we probably *should* do whilst the project is still relatively new. The Atom team rejected this change back in 2014 to avoid upsetting existing users and saying that the ATOM_HOME variables should be sufficient - https://github.com/atom/atom/pull/2261.

This is really meant to be proof of concept and may well be beyond my skills to complete so feel free to make suggestions, push to my fork or even just implement this separately. I'm simply trying to draw attention to this issue again and proving that it is possible to support.

For full details/backstory see https://github.com/orgs/pulsar-edit/discussions/68

Essentially this is a proposal to move to support the XDG base directory specification (https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html).

One of the major drivers of this is for Flatpak, due to sandboxing, Flatpak users will expect config files to be stored where it expects them - i.e. `~/.var/app/<app-id>/config`. However I strongly suspect Pulsar will just write it to the standard, non-sandboxed location in `~/.pulsar`. So to me this is a pretty big blocker to solve before we adopt Flatpak (if we decide to which I'm personally in favour of). See https://docs.flatpak.org/en/latest/conventions.html#xdg-base-directories

This change comes in two parts.
1) We need to check if `XDG_CONFIG_HOME` has actually been set and, if so, use this to store the pulsar config data.
2) As the "base" case where `XDG_CONFIG_HOME = undefined` we should be storing the profile in `~/.config`.

As part of this it also involves following convention and no longer needing the profile to be "dotted" i.e. move from `.pulsar` to just `pulsar`. (Note that by default Electron seems to already be adhering to this and creates an `$XDG_CONFIG_HOME/Pulsar` dir (note the caps). So part of the question is if we would want to use a new `pulsar` or existing `Pulsar` dir.

Now there are obviously some drawbacks:
- The existing `~/.pulsar` dir will no longer be valid so we would need an automated method or manual instructions to help people migrate.
- A lot of the docs would need updating
- Are there any packages that rely on the old dir, would this break a ton of community packages? I hope not as I assume they would be using `ATOM_HOME` but you never know...
