### PR TITLE
Add Setup Node to Package Tests

### DIFF
--- a/.github/workflows/package-tests-linux.yml
+++ b/.github/workflows/package-tests-linux.yml
@@ -144,7 +144,10 @@ jobs:
     steps:
     - name: Checkout the latest code
       uses: actions/checkout@v2
-
+    - name: Setup NodeJS
+      uses: actions/setup-node@v3
+      with:
+        node-version: 16
     - name: Install Dependencies
       run: yarn install || yarn install
 


### PR DESCRIPTION
Seemingly suddenly randomly our package tests are failing across the board.

These unexpected failures can be seen:

* #394 
* #374 
* #398 

The fix here was actually seen on #394 as well. Showing that we just needed to add this build step.

Not totally sure what's caused the sudden failure, but as it is an issue that would prevent any PRs from getting merged, it seems important to fix now and ask questions later.

Thanks @mauricioszabo for finding the solution on this one!