### PR TITLE
Add GitHub Token to Doc CI

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -3,6 +3,9 @@ name: Documentation
 on:
   push:
     branches: [ "master" ]
+    
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 jobs:
   documentation:


### PR DESCRIPTION
Adds the GitHub token to the documentation CI, so it can finish running without getting limited as showcased in https://github.com/pulsar-edit/pulsar/actions/runs/4264106239