### PR TITLE
Update documentation commands

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -3,6 +3,7 @@ name: Documentation
 on:
   push:
     branches: [ "master" ]
+  workflow_dispatch:
     
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/.jsdoc.json
+++ b/docs/.jsdoc.json
@@ -1,0 +1,11 @@
+{
+    "recurseDepth": 10,
+    "source": {
+        "include": ["src", "packages"],
+        "exclude": ["node_modules"],
+        "excludePattern": "((^|\\/|\\\\)_|node_modules)"
+    },
+    "opts": {
+        "recurse": true
+    }
+}

--- a/package.json
+++ b/package.json
@@ -273,8 +273,8 @@
     "build:apm": "cd ppm && yarn install",
     "start": "electron --no-sandbox --enable-logging . -f",
     "dist": "node script/electron-builder.js",
-    "js-docs": "jsdoc2md ./src/**/*.js ./packages/**/*.js > ./docs/Pulsar-API-Documentation.md",
-    "private-js-docs": "jsdoc2md --private ./src/**/*.js ./packages/**/*.js > ./docs/Source-Code-Documentation.md"
+    "js-docs": "jsdoc2md --files src --configure docs/.jsdoc.json > ./docs/Pulsar-API-Documentation.md",
+    "private-js-docs": "jsdoc2md --private --files src --configure docs/.jsdoc.json > ./docs/Source-Code-Documentation.md"
   },
   "devDependencies": {
     "@electron/notarize": "^1.2.3",


### PR DESCRIPTION
- Adds a config file used by `jsdoc2md` to be passed to `jsdoc` to filter inputs
- Adds the `workflow_dispatch` event to the Documentation CI, allowing it to be run whenever we need to (or in instances like this: actually _test_ the changes)
- Updates the `js-docs` and `private-js-docs` commands to use the new config