### PR TITLE
[skip-ci] Small Readme Touchup

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,11 +26,12 @@
 
 <br>
 
-*A Community-led Hyper-Hackable Text Editor, built on **[Electron]**,*  
-*and based on everything we love about our favorite editors.*
+*A Community-led Hyper-Hackable Text Editor,*
+*Forked from [Atom], built on [Electron].*
 
-*We designed it to be deeply customizable, but still*  
+*Designed to be deeply customizable, but still*
 *approachable using the default configuration.*
+
 
 <br>
 <br>
@@ -44,6 +45,7 @@
 [OpenCollective]: https://opencollective.com/pulsar-edit
 [Discussions]: https://github.com/orgs/pulsar-edit/discussions
 [Electron]: https://github.com/electron/electron
+[Atom]: https://github.blog/2022-06-08-sunsetting-atom/
 [Discord]: https://discord.gg/7aEbB9dGRT 'Join the Pulsar Discord today!'
 [Crowdin]: https://crowdin.pulsar-edit.dev
 [Status]: https://cirrus-ci.com/github/pulsar-edit/pulsar/master


### PR DESCRIPTION
This PR addresses a few issues I've seen around the internet about our readme.

1) We don't mention in the readme that we are a fork. We thought it was enough to put on the website, and we assumed people would only know of us because of the fact we are a fork of Atom. But seems there's enough natural discoverability happening that we need to explicitly mention we are a fork rather than a new editor. So this touch up does that.
2) Additionally, the readme uses terms like `we` and `our` which was written by the Atom team, and we have been using it, which personally feels a little dishonest to me. As `we` didn't design the editor. It was already done. So this keeps the same gist of what was being said, but removes uses of `we` or `our`.

Like mentioned on Discord, we will absolutely want to do more to make this better, but for something I'm hoping can be reviewed quickly this is the simplest thing I could think of to make the needed changes.
