### PR TITLE
Indenting with modern tree-sitter

### DIFF
--- a/packages/language-ruby/grammars/tree-sitter-2-ruby.cson
+++ b/packages/language-ruby/grammars/tree-sitter-2-ruby.cson
@@ -8,6 +8,8 @@ treeSitter:
   grammar: 'ts/grammar.wasm'
   syntaxQuery: 'ts/highlights.scm'
   localsQuery: 'ts/locals.scm'
+  foldsQuery: 'ts/folds.scm'
+  indentsQuery: 'ts/indents.scm'
 
 firstLineRegex: [
   # shebang line

--- a/packages/language-ruby/grammars/ts/indents.scm
+++ b/packages/language-ruby/grammars/ts/indents.scm
@@ -1,0 +1,41 @@
+[
+  (class)
+  (singleton_class)
+  (method)
+  (singleton_method)
+  (module)
+  (if)
+  (block)
+  (do_block)
+  (argument_list)
+  (case)
+  (while)
+  (until)
+  (for)
+  (begin)
+  (unless)
+  "("
+  "{"
+  "["
+] @indent
+
+[
+  "end"
+  ")"
+  "}"
+  "]"
+] @indent_end
+
+[
+  "end"
+  ")"
+  "}"
+  "]"
+  (when)
+  (elsif)
+  (else)
+  (rescue)
+  (ensure)
+] @branch
+
+(comment) @ignore

--- a/src/wasm-tree-sitter-grammar.js
+++ b/src/wasm-tree-sitter-grammar.js
@@ -12,6 +12,10 @@ module.exports = class WASMTreeSitterGrammar {
       const lPath = path.join(dirName, params.treeSitter.localsQuery)
       this.localsQuery = fs.readFileSync(lPath, 'utf-8')
     }
+
+    const iPath = path.join(dirName, params.treeSitter.indentsQuery)
+    this.indentsQuery = fs.readFileSync(iPath, 'utf-8')
+
     this.grammarPath = path.join(dirName, params.treeSitter.grammar)
     this.contentRegex = buildRegex(params.contentRegex);
     this.firstLineRegex = buildRegex(params.firstLineRegex);


### PR DESCRIPTION
Mandatory disclaimer: none of the languages on tree-sitter side have all the queries necessary to do things like folds and indents, so I'm using the nvim-tree-sitter implementation of these queries (https://github.com/nvim-treesitter/nvim-treesitter/tree/master/queries).

They work well, except for some exception (like for Ruby, for example, it was trying to indent assignments like `a = 10` - no idea why, so I just removed this).

I also didn't implement some of the code that I supposed have to implement, because I could not understand it and supposedly it doesn't make any difference.

Any suggestions on this PR is *highly appreciated* :)