### PR TITLE
actually cache based on sha

### DIFF
--- a/.github/workflows/package-tests-linux.yml
+++ b/.github/workflows/package-tests-linux.yml
@@ -37,7 +37,7 @@ jobs:
       uses: actions/cache@v3
       with:
         path: pulsar.deb
-        key: pulsar-$env:GITHUB_SHA
+        key: pulsar-${{ github.sha }}
 
   test:
     name: Package
@@ -159,7 +159,7 @@ jobs:
       uses: actions/cache@v3
       with:
         path: pulsar.deb
-        key: pulsar-$env:GITHUB_SHA
+        key: pulsar-${{ github.sha }}
 
     - name: Install Pulsar
       run: sudo dpkg -i pulsar.deb && sudo apt-get -f install -y


### PR DESCRIPTION
I noticed that in the package tests workflow file, it used to cache pulsar based on the key of `pulsar-$env:GITHUB_SHA`. This didn't do the expected substitution, so it always cached based on key `pulsar-$env:GITHUB_SHA` exactly. I changed them to be `pulsar-${{ github.sha }}`, which does the substitution that is expected, ex. `pulsar-e8728e4f69cf3f71575a10703d54bf22396721f0` Will post links to logs here as tests run