### PR TITLE
deps: Bump github to v0.36.15-pretranspiled

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "fuzzy-finder": "https://codeload.github.com/atom/fuzzy-finder/legacy.tar.gz/refs/tags/v1.14.3",
     "git-diff": "file:packages/git-diff",
     "git-utils": "5.7.1",
-    "github": "https://codeload.github.com/pulsar-edit/github/tar.gz/refs/tags/v0.36.14-pretranspiled-take-2",
+    "github": "https://codeload.github.com/pulsar-edit/github/tar.gz/refs/tags/v0.36.15-pretranspiled",
     "glob": "^7.1.1",
     "go-to-line": "file:packages/go-to-line",
     "grammar-selector": "file:packages/grammar-selector",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4965,9 +4965,9 @@ github-from-package@0.0.0:
   resolved "https://registry.yarnpkg.com/github-from-package/-/github-from-package-0.0.0.tgz#97fb5d96bfde8973313f20e8288ef9a167fa64ce"
   integrity sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==
 
-"github@https://codeload.github.com/pulsar-edit/github/tar.gz/refs/tags/v0.36.14-pretranspiled-take-2":
-  version "0.36.14"
-  resolved "https://codeload.github.com/pulsar-edit/github/tar.gz/refs/tags/v0.36.14-pretranspiled-take-2#22158525f8801ecbb084e23ea45ee92ba3d3f9e1"
+"github@https://codeload.github.com/pulsar-edit/github/tar.gz/refs/tags/v0.36.15-pretranspiled":
+  version "0.36.15"
+  resolved "https://codeload.github.com/pulsar-edit/github/tar.gz/refs/tags/v0.36.15-pretranspiled#6d8f680fb7f337c3ddf0127fe24b9cc6e77a7618"
   dependencies:
     "@atom/babel-plugin-chai-assert-async" "1.0.0"
     "@atom/babel7-transpiler" "1.0.0-1"


### PR DESCRIPTION
Updates login instructions for PATs instead of OAuth tokens, and rebrands the git-tab-view for certain errors.

Includes the following github package PRs:

- https://github.com/pulsar-edit/github/pull/15
- https://github.com/pulsar-edit/github/pull/17

#### Comparison:

- https://github.com/pulsar-edit/github/compare/v0.36.14-pretranspiled-take-2..pulsar-edit:github:v0.36.15-pretranspiled
  - (see: lib/views/git-tab-view.js, lib/views/github-login-view.js, package-lock.json and  package.json).