### PR TITLE
Show Settings Icon in Status Bar

### DIFF
--- a/packages/settings-view/lib/main.js
+++ b/packages/settings-view/lib/main.js
@@ -75,6 +75,13 @@ module.exports = {
         statusView.initialize(statusBar, packageManager, updates)
       }
     })
+
+    // Attach a settings button to the status bar
+    if (atom.config.get("settings-view.showSettingsIconInStatusBar")) {
+      const SettingsIconStatusView = require('./settings-icon-status-view')
+      statusViewIcon = new SettingsIconStatusView(statusBar)
+      statusViewIcon.attach()
+    }
   },
 
   consumeSnippets (snippets) {

--- a/packages/settings-view/lib/settings-icon-status-view.js
+++ b/packages/settings-view/lib/settings-icon-status-view.js
@@ -1,0 +1,40 @@
+/** @babel */
+
+import {Disposable, CompositeDisposable} from 'atom'
+
+export default class SettingsIconStatusView {
+  constructor(statusBar) {
+    this.statusBar = statusBar
+    this.disposables = new CompositeDisposable()
+
+    this.element = document.createElement('div')
+    this.element.classList.add('settings-icon', 'inline-block')
+
+    const iconPackage = document.createElement('span')
+    iconPackage.classList.add('icon', 'icon-gear')
+    this.element.appendChild(iconPackage)
+
+    const clickHandler = () => {
+      atom.workspace.open("atom://config")
+    }
+    this.element.addEventListener('click', clickHandler)
+    this.disposables.add(new Disposable(() => { this.element.removeEventListener('click', clickHandler) }))
+
+  }
+
+  attach () {
+    this.tile = this.statusBar.addRightTile({
+      item: this,
+      priority: -99
+    })
+  }
+
+  destroy () {
+    this.disposables.dispose()
+    this.element.remove()
+    if (this.tile) {
+      this.tile.destroy()
+      this.tile = null
+    }
+  }
+}

--- a/packages/settings-view/package.json
+++ b/packages/settings-view/package.json
@@ -14,6 +14,12 @@
       "description": "Limit how many processes run simultaneously during package updates. If your machine slows down while updating many packages at once, set this value to a small positive number (e.g., `1` or `2`).",
       "type": "integer",
       "default": -1
+    },
+    "showSettingsIconInStatusBar": {
+      "title": "Show Settings Icon in Status Bar",
+      "description": "Whether or not to show a settings icon in the Pulsar Status Bar.",
+      "type": "boolean",
+      "default": true
     }
   },
   "dependencies": {


### PR DESCRIPTION
Simple PR, adds the a settings icon into the status bar.

Within `settings-view` further utilizes the `statusBar` service, which it already consumes.

![image](https://user-images.githubusercontent.com/26921489/224516827-16ff9423-5b53-4bb4-bebf-4d595aee2669.png)

When clicking it will open up the settings via the `atom.workspace()` API.

Resolves #313 

---

Additionally this is totally configurable. By default displaying the icon, but can always be turned off via `showSettingsIconInStatusBar`
