### PR TITLE
Cirrus: Windows: install ppm deps with Yarn

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -204,7 +204,7 @@ windows_task:
   install_script:
     - npx yarn install --ignore-engines || sleep 1 && npx yarn install --ignore-engines || echo "There is a reason for so many tries"
   build_script:
-    - cd ppm; npm install
+    - npx yarn build:apm
     - npx yarn build || npx yarn build || npx yarn build
   build_binary_script:
     - sed -i -e "s/[0-9]*-dev/`date -u +%Y%m%d%H`/g" package.json


### PR DESCRIPTION
### Info about this PR

Effectively: install ppm's dependencies (and run its postinstall scripts) with Yarn, not npm, in Windows Cirrus CI jobs.

This makes the installation of ppm's dependencies consistently use **Yarn**, not npm, in Cirrus CI. Consistent for all OSes/arches we build for in Cirrus.

<details><summary>Optional technical note</summary>

_(* Although, at some level the postinstall scripts are run via npm as a subprocess of node as a subprocess of Yarn in a shell/console sub-process... Yes, in my opinion, ppm's postinstall scripts are way too complicated...)_

_See discussion here for some context, if you want: https://github.com/pulsar-edit/ppm/pull/58_

---

</details>

ALSO: This **fixes an oversight in PR 239** where the `build` script of the wrong project (ppm instead of core) was being run at one point, again on Windows.

So, this should make it so Pulsar's core dependencies are built for the correct Electron version instead of built for Node... Oops!

### Context:

This is something I've been wanting to do since it was made possible in https://github.com/pulsar-edit/ppm/pull/58 and merged here with the ppm bump in https://github.com/pulsar-edit/pulsar/pull/403.

This PR's main change also coincidentally changes the `cd` steps to fix the oversight/issue from https://github.com/pulsar-edit/pulsar/pull/239, thus making "rebuilding the editor's dependencies for Electron" happen again, as before / as intended.

#### Details of the oversight from PR 239, and the fix:

It just so happens to fix an issue that was unnoticed until now from https://github.com/pulsar-edit/pulsar/pull/239, where `yarn run build` is now happening in the wrong folder (under `ppm/` instead of the root of the repo), so it's running ppm's `build` package.json script, instead of the core main package.json's `build` script... Meaning the core editor's dependencies are built for CI's NodeJS on the PATH, yet not being rebuilt for Electron. ... Oops! Should have read that change very carefully, it was only moving lines around, not changing the lines themselves, but it effectively changed the meaning. Should have been more careful merging that. Ah, well, here is the hotfix.