### PR TITLE
Add "icon only" class to settings view icon

### DIFF
--- a/packages/settings-view/lib/settings-icon-status-view.js
+++ b/packages/settings-view/lib/settings-icon-status-view.js
@@ -11,7 +11,7 @@ export default class SettingsIconStatusView {
     this.element.classList.add('settings-icon', 'inline-block')
 
     const iconPackage = document.createElement('span')
-    iconPackage.classList.add('icon', 'icon-gear')
+    iconPackage.classList.add('icon', 'icon-gear', 'is-icon-only')
     this.element.appendChild(iconPackage)
 
     const clickHandler = () => {


### PR DESCRIPTION
This PR adds the `.is-icon-only` class to the new settings icon from PR #421.

![image](https://user-images.githubusercontent.com/58074586/229651200-15872fa9-a281-4967-9ea2-b122d2743e9c.png)

As shown above, I noticed that this doesn't show correctly centred in its div because Pulsar automatically adds a margin to the right of it - this is 4px in settings-view:

https://github.com/pulsar-edit/pulsar/blob/252065412e6658c61bf7f24585c148469e979a23/packages/status-bar/styles/status-bar.less#L84-L91

and `.25em` in one-dark-ui (and light):
https://github.com/pulsar-edit/pulsar/blob/252065412e6658c61bf7f24585c148469e979a23/packages/one-dark-ui/styles/status-bar.less#L50-L57

However both one-light and one-dark have an additional rule to disable margins for "icon only" items.
https://github.com/pulsar-edit/pulsar/blob/252065412e6658c61bf7f24585c148469e979a23/packages/one-light-ui/styles/status-bar.less#L87-L93

So this PR simply adds this class to the icon's classes rather than creating new CSS rules for every the base case and every theme.

What I'm not sure about is if we should actually be adding this basic `is-icon-only` class to the standard status-bar package styling to account for themes that have not added this rule. For example I don't *think* this is provided in `atom-light/dark-ui`.

So it might be that we think it sensible to add this class to the base status-bar package theme in which case I'm happy to add it to the scope of this PR.