### PR TITLE
check thing returned by optionalTravelDownObjectPath is string

### DIFF
--- a/src/i18n.js
+++ b/src/i18n.js
@@ -151,7 +151,7 @@ class I18n {
     if (languageObj === undefined) return undefined;
 
     const str = optionalTravelDownObjectPath(languageObj, path);
-    if (str !== undefined) {
+    if (typeof str === "string") {
       return this.format(ns, path, str, lang, opts);
     } else {
       return undefined;


### PR DESCRIPTION
`optionalTravelDownObjectPath` could return an object (like, not yet reached the end and found a string), which wouldn't work here.

Currently it checks that `str` isn't undefined, but in a scenario where a key actually has more nested strings and isn't a string, it wouldn't work. Ex:

```json
{
   "core": {
      "key": {
         "value": "string"
      }
   }
}
```

the key `core.key.value` would be okay, but `core.key` would be an invalid string. It would have passed the previous check though.