### PR TITLE
yeet earlier `this.keymaps.loadBundledKeymaps` call

### DIFF
--- a/src/atom-environment.js
+++ b/src/atom-environment.js
@@ -209,10 +209,6 @@ class AtomEnvironment {
       applicationDelegate: this.applicationDelegate
     });
 
-    if (this.keymaps.canLoadBundledKeymapsFromMemory()) {
-      this.keymaps.loadBundledKeymaps();
-    }
-
     this.registerDefaultCommands();
     this.registerDefaultOpeners();
     this.registerDefaultDeserializers();


### PR DESCRIPTION
This is called once in the constructor, then again in `initialize`. The constructor call was too early, and `i18n.t` had not been available yet, but it was used indirectly by `loadBundledKeymaps`, causing stuff to crash.

PS. **_PAY ATTENTION TO CI TESTS_**