### PR TITLE
ci: Bump editor tests action versions

### DIFF
--- a/.github/workflows/editor-tests.yml
+++ b/.github/workflows/editor-tests.yml
@@ -7,7 +7,7 @@ env:
 
 jobs:
   tests:
-    name: tests
+    name: Tests
     if: |
       !startsWith(github.event.pull_request.title, '[skip-ci]') &&
       !startsWith(github.event.pull_request.title, '[skip-editor-ci]')
@@ -19,20 +19,20 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - name: Checkout the latest code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Setup node
-      uses: actions/setup-node@v2-beta
+      uses: actions/setup-node@v3
       with:
         node-version: 16
 
-    - name: install dependencies
+    - name: Install Dependencies
       run: yarn install
 
-    - name: build dependencies
+    - name: Build Dependencies
       run: yarn build
 
-    - name: Run tests
-      uses: GabrielBB/xvfb-action@v1
+    - name: Run Tests
+      uses: coactions/setup-xvfb@v1.0.1
       with:
         run: node script/run-tests.js spec


### PR DESCRIPTION
- Node 12 actions are deprecated
- Bump `actions/checkout` to v3
- Bump `actions/setup-node` to v3
- Replace `GabrielBB/xvfb-action@v1` with `coactions/setup-xvfb@v1.0.1` - the former appears unmaintained, and is outdated