### PR TITLE
Disable Failing Tests

### DIFF
--- a/packages/settings-view/spec/installed-package-view-spec.js
+++ b/packages/settings-view/spec/installed-package-view-spec.js
@@ -127,11 +127,11 @@ describe("InstalledPackageView", function() {
         snippetsTable.querySelector('tr:nth-child(2) td:nth-child(1)').textContent
       ).toBe('f');
 
-      if (shouldRunScopeTest) {
-        expect(
-          snippetsTable.querySelector('tr:nth-child(1) td:nth-child(2)').textContent
-        ).toBe('');
-      }
+      //if (shouldRunScopeTest) { # TODO FIX
+      //  expect(
+      //    snippetsTable.querySelector('tr:nth-child(1) td:nth-child(2)').textContent
+      //  ).toBe('');
+      //}
       expect(
         snippetsTable.querySelector('tr:nth-child(2) td:nth-child(3)').textContent
       ).toBe('FOO');

--- a/packages/settings-view/spec/settings-view-spec.coffee
+++ b/packages/settings-view/spec/settings-view-spec.coffee
@@ -103,7 +103,7 @@ describe "SettingsView", ->
 
       expect(settingsView.refs.panelMenu.querySelector('li[name="Panel 1"]')).toExist()
       expect(settingsView.refs.panelMenu.querySelector('li[name="Panel 2"]')).toExist()
-      expect(settingsView.refs.panelMenu.children[1]).toHaveClass 'active'
+      #expect(settingsView.refs.panelMenu.children[1]).toHaveClass 'active' # TODO FIX
 
       jasmine.attachToDOM(settingsView.element)
       settingsView.refs.panelMenu.querySelector('li[name="Panel 1"] a').click()


### PR DESCRIPTION
As discussed on Discord, we want to refrain from having to parse test failures manually.

And we decided that at least for now it may be beneficial to stop running the few failing tests, hard part is there is only a single bundled package with any failing tests, which is `settings-view`.

So this PR comments out the two failing tests that we have been seeing here.

Although obviously if they can be fixed, then that is the best solution.

And on the latter part @savetheclocktower it looks like you may have originally written one of these two tests, so I'd be curious to hear if you had any ideas about it's failure
