### PR TITLE
remove weird duplicate accented fixture file (hopefully?)

### DIFF
--- a/packages/markdown-preview/spec/fixtures/subdir/áccéntéd.md
+++ b/packages/markdown-preview/spec/fixtures/subdir/áccéntéd.md
@@ -1,1 +1,0 @@
-# Testing


### PR DESCRIPTION
There has been two fixture files for `markdown-preview` that both look like `áccéntéd.md`, where the second one appears to have been introduced accidentally [in this PR commit](https://github.com/pulsar-edit/markdown-preview/commit/e3078a32fa95490e53db08fb9b58d36075592b9c) (thanks @DeeDeeG for finding it). Tried to remove the right one, checked it a few times, I think I got the right one? lets see how the tests go >w<