### PR TITLE
meta: Change version string to end in "-dev"

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "pulsar",
   "author": "Pulsar-Edit <admin@pulsar-edit.dev>",
   "productName": "Pulsar",
-  "version": "1.104.0",
+  "version": "1.104.0-dev",
   "description": "A Community-led Hyper-Hackable Text Editor",
   "branding": {
     "id": "pulsar",


### PR DESCRIPTION
Follow-up to PR https://github.com/pulsar-edit/pulsar/pull/490.

Sets things up for  the Cirrus CI scripts to update the version number of Pulsar to match the Cirrus build ID, giving each Rolling release a unique version number traceable back to the Cirrus run that it was built in.

This is a hotfix to make sure Rolling release version numbers turn out correctly as expected -- without this change, all Rolling releases will have the exact same version number as Regular, `v1.104.0`.