### PR TITLE
CI: cache and restore dependencies, plus skip rebuilding all over the place (saves a lot of time)

### DIFF
--- a/.github/workflows/package-tests-linux.yml
+++ b/.github/workflows/package-tests-linux.yml
@@ -157,10 +157,22 @@ jobs:
       uses: actions/setup-node@v3
       with:
         node-version: 16
+
+    - name: Restore dependencies from Cache
+      id: restore-dependencies
+      uses: actions/cache@v3
+      with:
+        path: |
+          node_modules
+          packages
+        key: dependencies-${{ github.sha }}
+
     - name: Install Dependencies
+      if: steps.restore-dependencies.outputs.cache-hit != 'true'
       run: yarn install || yarn install
 
     - name: Build Dependencies
+      if: steps.restore-dependencies.outputs.cache-hit != 'true'
       run: yarn build || yarn build
 
     - name: Restore pulsar from Cache

--- a/.github/workflows/package-tests-linux.yml
+++ b/.github/workflows/package-tests-linux.yml
@@ -39,6 +39,15 @@ jobs:
         path: pulsar.deb
         key: pulsar-${{ github.sha }}
 
+    - name: Cache dependencies
+      id: cache-dependencies
+      uses: actions/cache@v3
+      with:
+        path: |
+          node_modules
+          packages
+        key: dependencies-${{ github.sha }}
+
   test:
     name: Package
     needs: setup


### PR DESCRIPTION
**In GitHub Actions CI for the package tests, cache and restore the editor's dependencies**, which would naturally include the various bundled packages and their sub-dependencies.

_(Context: We already have to install/build these once in the first job, which builds the editor (as a `.deb`), which we are already caching and restoring for installation/use in all the individual package test jobs. Following in that pattern, we can go further and cache the dependencies now, too.)_

Allows us to quickly restore all the dependencies from said cache in each individual test's respective job. **Saves a bunch of time** per job, something like ~8 minutes minimum per test job down to ~30 seconds minimum per test job.

**Should save an estimated ~1 hour 10 minutes over the whole CI run?** (Very loosely/unscientifically estimated at the moment, based on one control and one test run).

Also benefits scenarios other than a full run, such as re-running just the failing tests. For example, "re-run failed tests" for our expected 3 or 4 packages failing takes about ~3-4 minutes now!

<details>

Pros:

- Saves a lot of time

Cons:

- ???

Step 3:

- Profit

</details>

Shout out to @Meadowsys for figuring out the GitHub Actions yml syntax to properly key these caches, demonstrating the feasibility of proper caching and prompting the impulse to do this. (See: https://github.com/pulsar-edit/pulsar/pull/412).