### PR TITLE
Add FPM option to stop rpm buildid clash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - Removed `nslog` dependency
 - Fixed an error where the GitHub package tried to interact with a diff view after it was closed
+- Fixed RPM installation failure when Atom was installed on the same machine
 
 ## 1.104.0
 

--- a/script/electron-builder.js
+++ b/script/electron-builder.js
@@ -150,7 +150,8 @@ let options = {
   rpm: {
     afterInstall: "script/post-install.sh",
     afterRemove: "script/post-uninstall.sh",
-    compression: 'xz'
+    compression: 'xz',
+    fpm: ['--rpm-rpmbuild-define=_build_id_links none']
   },
   "linux": {
     // Giving a single PNG icon to electron-builder prevents the correct


### PR DESCRIPTION
Fixes https://github.com/pulsar-edit/pulsar/issues/227 (possibly...)

See fpm docs from:
https://www.electron.build/configuration/linux#linuxtargetspecificoptions-apk-freebsd-pacman-p5p-and-rpm-options
https://github.com/jordansissel/fpm/wiki#usage

Seems to be a common electron app issue.

Hopefully if this works we can test from the binaries built from this PR.