### PR TITLE
Add hyper-specific yet new Exclusions

### DIFF
--- a/script/electron-builder.js
+++ b/script/electron-builder.js
@@ -126,7 +126,7 @@ let options = {
       // "!node_modules/loophole", // Note: We do need these packages. Because our PegJS files _aren't_ all pre-compiled.
       // "!node_modules/pegjs",    // Note: if these files are excluded, 'snippets' package breaks.
       // "!node_modules/.bin/pegjs", // Note: https://github.com/pulsar-edit/pulsar/pull/206
-    // Extranious exclusions to reduce install size.
+    // Extraneous exclusions to reduce install size.
     "!**/node_modules/second-mate/src",
     "!**/node_modules/second-mate/Gruntfile.js",
     "!**/node_modules/document-register-element/bower.json",

--- a/script/electron-builder.js
+++ b/script/electron-builder.js
@@ -126,6 +126,19 @@ let options = {
       // "!node_modules/loophole", // Note: We do need these packages. Because our PegJS files _aren't_ all pre-compiled.
       // "!node_modules/pegjs",    // Note: if these files are excluded, 'snippets' package breaks.
       // "!node_modules/.bin/pegjs", // Note: https://github.com/pulsar-edit/pulsar/pull/206
+    // Extranious exclusions to reduce install size.
+    "!**/node_modules/second-mate/src",
+    "!**/node_modules/second-mate/Gruntfile.js",
+    "!**/node_modules/document-register-element/bower.json",
+    "!**/node_modules/document-register-element/index.html",
+    "!**/node_modules/document-register-element/Makefile",
+    "!**/node_modules/document-register-element/testrunner.js",
+    "!**/node_modules/document-register-element/src",
+    "!**/node_modules/document-register-element/template",
+    "!**/node_modules/autocomplete-css/cssValueDefinitionSyntaxExtractor.js",
+    "!**/node_modules/autocomplete-css/manual-property-desc.json",
+    "!**/node_modules/autocomplete-css/update.js",
+    "!**/node_modules/autocomplete-html/update"
   ],
   "extraResources": [
     {

--- a/script/electron-builder.js
+++ b/script/electron-builder.js
@@ -89,6 +89,7 @@ let options = {
     "!**/*.{iml,o,hprof,orig,pyc,pyo,rbc,swp,csproj,sln,xproj}",
     "!**/{.jshintrc,.pairs,.lint,.lintignore,.eslintrc,.jshintignore}",
     "!**/{.coffeelintignore,.editorconfig,.nycrc,.coffeelint.json,.vscode,coffeelint.json}",
+    "!**/{Jenkinsfile,AUTHORS,CODE_OF_CONDUCT.md,eslintrc.json}",
 
     // Common File Exclusions
     "!**/{.DS_Store,.hg,.svn,CVS,RCS,SCCS}",


### PR DESCRIPTION
To get Pulsar back onto Chocolatey we need to reduce about `20MB` of the Pulsar installer size.

So while this may not provide the largest savings of space it can hopefully help us get closer to that goal.

This PR adds some minor exclusions that are newer within the built binary.

* Excludes the PegJS source from `second-mate` as the built JavaScript is present in the repo itself.
* Excludes the `second-mate` `Gruntfile.js`
* Excludes `document-register-element`:
  - `bower.json`
  - `index.html`
  - `Makefile`
  - `testrunner.js`
  - `src` exists within `build/` in the repo itself
  - `template` builds into the `build/` folder in the repo itself
* Excludes `autocomplete-css` and `autocomplete-html` files and scripts that facilitate updating the completions, but do not contribute to the source code itself.
* Adds some more generic exclusions to additional dev files that are still getting picked up