### PR TITLE
Add new `...:uri-opened` && `...:file-name-opened` Package Activation Hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ module outside of Pulsar, but Pulsar refuses to load anyway
 - Removed `nslog` dependency
 - Fixed an error where the GitHub package tried to interact with a diff view after it was closed
 - Fixed RPM installation failure when Atom was installed on the same machine
+- Added a new set of Package `activationHooks`, `...:uri-opened` lets a package activate when any URI is opened within Pulsar, and `...:file-name-opened` lets a package activate when any specific filename is opened within Pulsar.
 
 ## 1.104.0
 

--- a/spec/workspace-spec.js
+++ b/spec/workspace-spec.js
@@ -1658,7 +1658,7 @@ describe('Workspace', () => {
 
       atom.packages.triggerDeferredActivationHooks();
       atom.packages.onDidTriggerActivationHook(
-        'sample.js:opened',
+        'sample.js:file-name-opened',
         packageUsed
       );
 

--- a/spec/workspace-spec.js
+++ b/spec/workspace-spec.js
@@ -1652,6 +1652,24 @@ describe('Workspace', () => {
     });
   });
 
+  describe('the file opened hook', () => {
+    it('fires when opening a file', async () => {
+      const packageUsed = jasmine.createSpy('my-fake-package');
+
+      atom.packages.triggerDeferredActivationHooks();
+      atom.packages.onDidTriggerActivationHook(
+        'sample.js:opened',
+        packageUsed
+      );
+
+      expect(packageUsed).not.toHaveBeenCalled();
+      const editor = await atom.workspace.open('sample.js', {
+        autoIndent: false
+      });
+      expect(packageUsed).toHaveBeenCalled();
+    })
+  });
+
   describe('::reopenItem()', () => {
     it("opens the uri associated with the last closed pane that isn't currently open", () => {
       const pane = workspace.getActivePane();

--- a/src/workspace.js
+++ b/src/workspace.js
@@ -1260,11 +1260,11 @@ module.exports = class Workspace extends Model {
         } else {
           activationHookItem = "";
           activationHookText = "";
-          // We are purposefully redeclaring the text here, to fall gracefully
+          // We are purposefully redeclaring the text here, to fail gracefully
         }
       }
 
-      if (activationHookText.length > 1 && activationHookItem.length > 1) {
+      if (activationHookText?.length > 1 && activationHookItem?.length > 1) {
         this.packageManager.triggerActivationHook(
           `${activationHookItem}:${activationHookText}`
         );

--- a/src/workspace.js
+++ b/src/workspace.js
@@ -1245,23 +1245,30 @@ module.exports = class Workspace extends Model {
 
       // After emitting the open event, lets trigger any packages activation commands
       let activationHookItem;
+      let activationHookText;
 
       if (item instanceof TextEditor) {
         // This is a TextEditor opening, meaning a file
         activationHookItem = item.getTitle();
+        activationHookText = "file-name-opened";
       } else {
+        activationHookText = "uri-opened";
         if (typeof item.getURI === "function") {
           activationHookItem = item.getURI();
         } else if (typeof item.getUri === "function") {
           activationHookItem = item.getUri();
         } else {
           activationHookItem = "";
+          activationHookText = "";
+          // We are purposefully redeclaring the text here, to fall gracefully
         }
       }
 
-      this.packageManager.triggerActivationHook(
-        `${activationHookItem}:opened`
-      );
+      if (activationHookText.length > 1 && activationHookItem.length > 1) {
+        this.packageManager.triggerActivationHook(
+          `${activationHookItem}:${activationHookText}`
+        );
+      }
 
     } finally {
       resolveItem();

--- a/src/workspace.js
+++ b/src/workspace.js
@@ -1242,6 +1242,27 @@ module.exports = class Workspace extends Model {
       if (uri) {
         this.incoming.delete(uri);
       }
+
+      // After emitting the open event, lets trigger any packages activation commands
+      let activationHookItem;
+
+      if (item instanceof TextEditor) {
+        // This is a TextEditor opening, meaning a file
+        activationHookItem = item.buffer.file.getBaseName();
+      } else {
+        if (typeof item.getURI === "function") {
+          activationHookItem = item.getURI();
+        } else if (typeof item.getUri === "function") {
+          activationHookItem = item.getUri();
+        } else {
+          activationHookItem = "";
+        }
+      }
+
+      this.packageManager.triggerActivationHook(
+        `${activationHookItem}:opened`
+      );
+
     } finally {
       resolveItem();
     }

--- a/src/workspace.js
+++ b/src/workspace.js
@@ -1248,7 +1248,7 @@ module.exports = class Workspace extends Model {
 
       if (item instanceof TextEditor) {
         // This is a TextEditor opening, meaning a file
-        activationHookItem = item.buffer.file.getBaseName();
+        activationHookItem = item.getTitle();
       } else {
         if (typeof item.getURI === "function") {
           activationHookItem = item.getURI();


### PR DESCRIPTION
So for those familiar, when activating a community package we are able to define a few methods on how this happens.

The currently supported methods are:

* `core:loaded-shell-environment` When Pulsar has finished loading shell environment variables
* `scope.name:root-scope-used` When a file is opened with the specified language 
* `language-package-name:grammar-used` When a specific language package is used 

And these are fantastic methods of decreasing the amount of packages that are active, and in memory at any given time.

But I'd honestly argue we could go further with this, allowing package authors to only have their package active when it's needed.

One of the best ways we can do that right now, I feel like, is to allow packages to only be activated depending on the file name that is opened.

If we consider what each activation hook does:
* Allows the package to only be activated once certain variables are available
* Allows the package to only be active when it has a supported language open
* Allows a package to only be active when it has a supported grammar file open

Besides the first activation hooks, these others all target ensuring the package is only around to act on what it needs to, such as a YAML file, or a specific YAML grammar package.

Now the second part to my context here, is there are loads of packages that are available for a certain kind of file. Such as autocompletions for a `robots.txt` file, now up until a grammar existed for that specific file is a package had to care about this, the package would have to be active all the time (or for any `.txt` files, which is still not very specific) and then figure out itself when it was best to act.

But now with this new activation hook added in this PR, a package could declare:

```json 
"activationHooks": [ "robots.txt:opened" ]
```

And that package now will only ever be active when that specific file name is open.

This opens up better possibilities for autocompletions, snippets, or my personal hope, validators.

So that someone could create a package that validates say a specific program config file, they can now only activate the package when their configuration file is open. 

Plus the way I've written this new activationHook it'll be triggered when any pane is being open, so this means that a package (if needed) could choose to only be activated when the Welcome Guide is opened with `atom://welcome/guide:opened`.

This new hook lets packages activate during any file being opened, by declaring that filename exactly, or by activated when any specific URI is opened.

---

Since this is a new feature that I pursued without first communicating it to anyone I'm more than open to discuss it's validity, just felt that if we did use this, it's such a small footprint of change it wouldn't worry to many people. But let me know what you think