### PR TITLE
Bump `second-mate` to 9686771

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ## [Unreleased]
 
+- Bumped to latest version of `second-mate`, fixing a memory usage issue in `vscode-oniguruma`
 - Removed a cache for native modules - fix bugs where an user rebuilds a native
 module outside of Pulsar, but Pulsar refuses to load anyway
 - Removed `nslog` dependency

--- a/package.json
+++ b/package.json
@@ -143,7 +143,7 @@
     "scoped-property-store": "^0.17.0",
     "scrollbar-style": "^4.0.1",
     "season": "^6.0.2",
-    "second-mate": "https://github.com/pulsar-edit/second-mate.git#14aa7bd",
+    "second-mate": "https://github.com/pulsar-edit/second-mate.git#9686771",
     "semver": "7.3.8",
     "service-hub": "^0.7.4",
     "settings-view": "file:packages/settings-view",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1773,9 +1773,9 @@
   integrity sha512-CRpX21/kGdzjOpFsZSkcrXMGIBWMGNIHXXBVFSH+ggkftxg+XYP20TESbh+zFvFj3EQOl5byk0HTRn1IL6hbqg==
 
 "@types/node@^14.6.2":
-  version "14.18.33"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.18.33.tgz#8c29a0036771569662e4635790ffa9e057db379b"
-  integrity sha512-qelS/Ra6sacc4loe/3MSjXNL1dNQ/GjxNHVzuChwMfmk7HuycRLVQN2qNY3XahK+fZc5E2szqQSKUyAF0E+2bg==
+  version "14.18.42"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.18.42.tgz#fa39b2dc8e0eba61bdf51c66502f84e23b66e114"
+  integrity sha512-xefu+RBie4xWlK8hwAzGh3npDz/4VhF6icY/shU+zv/1fNn+ZVG7T7CRwe9LId9sAYRPxI+59QBPuKL3WpyGRg==
 
 "@types/parse-json@^4.0.0":
   version "4.0.0"
@@ -8456,9 +8456,9 @@ season@^6.0.2:
     fs-plus "^3.0.0"
     yargs "^3.23.0"
 
-"second-mate@https://github.com/pulsar-edit/second-mate.git#14aa7bd":
+"second-mate@https://github.com/pulsar-edit/second-mate.git#9686771":
   version "8.0.0"
-  resolved "https://github.com/pulsar-edit/second-mate.git#14aa7bd94b90c47aa99f000394301b9573b8898b"
+  resolved "https://github.com/pulsar-edit/second-mate.git#9686771b4aa3159fe042528d60fcac3af3e1c655"
   dependencies:
     emissary "^1.3.3"
     event-kit "^2.5.3"


### PR DESCRIPTION
This updates `second-mate` to incorporate a couple of fixes. Most notably, some tests that only pass on the second try in CI should now pass on the first try, thereby speeding up CI test runs.