### PR TITLE
Add bookmarks service for consumption by other packages

### DIFF
--- a/packages/bookmarks/lib/bookmarks-provider.js
+++ b/packages/bookmarks/lib/bookmarks-provider.js
@@ -1,0 +1,31 @@
+
+class BookmarksProvider {
+  constructor(main) {
+    this.main = main
+  }
+
+  // Returns all bookmarks present in the given editor.
+  //
+  // Each bookmark tracks a buffer range and is represented by an instance of
+  // {DisplayMarker}.
+  //
+  // Will return an empty array if there are no bookmarks in the given editor.
+  //
+  // Keep in mind that a single bookmark can span multiple buffer rows and/or
+  // screen rows. Thus there isn't necessarily a 1:1 correlation between the
+  // number of bookmarks in the editor and the number of bookmark icons that
+  // the user will see in the gutter.
+  getBookmarksForEditor(editor) {
+    let instance = this.getInstanceForEditor(editor)
+    if (!instance) return null
+    return instance.getAllBookmarks()
+  }
+
+  // Returns the instance of the `Bookmarks` class that is responsible for
+  // managing bookmarks in the given editor.
+  getInstanceForEditor(editor) {
+    return this.main.editorsBookmarks.find(b => b.editor.id === editor.id)
+  }
+}
+
+module.exports = BookmarksProvider

--- a/packages/bookmarks/lib/main.js
+++ b/packages/bookmarks/lib/main.js
@@ -2,9 +2,10 @@ const {CompositeDisposable} = require('atom')
 
 const Bookmarks = require('./bookmarks')
 const BookmarksView = require('./bookmarks-view')
+const BookmarksProvider = require('./bookmarks-provider')
 
 module.exports = {
-  activate (bookmarksByEditorId) {
+  activate(bookmarksByEditorId) {
     this.bookmarksView = null
     this.editorsBookmarks = []
     this.disposables = new CompositeDisposable()
@@ -44,7 +45,7 @@ module.exports = {
     })
   },
 
-  deactivate () {
+  deactivate() {
     if (this.bookmarksView != null) {
       this.bookmarksView.destroy()
       this.bookmarksView = null
@@ -56,11 +57,16 @@ module.exports = {
     this.disposables.dispose()
   },
 
-  serialize () {
+  serialize() {
     const bookmarksByEditorId = {}
     for (let bookmarks of this.editorsBookmarks) {
       bookmarksByEditorId[bookmarks.editor.id] = bookmarks.serialize()
     }
     return bookmarksByEditorId
+  },
+
+  provideBookmarks() {
+    this.bookmarksProvider ??= new BookmarksProvider(this)
+    return this.bookmarksProvider
   }
 }

--- a/packages/bookmarks/package.json
+++ b/packages/bookmarks/package.json
@@ -10,5 +10,14 @@
   },
   "dependencies": {
     "atom-select-list": "^0.7.0"
+  },
+
+  "providedServices": {
+    "bookmarks": {
+      "description": "Provides a list of bookmarks to any package that wants to know about them.",
+      "versions": {
+        "1.0.0": "provideBookmarks"
+      }
+    }
   }
 }


### PR DESCRIPTION
### Description of the Change

I wanted to write a symbol provider for bookmarks, but the `bookmarks` package has never exposed its information to other packages. So I wrote a pretty simple `bookmarks` service.

### Alternate Designs

I could’ve gone with something more complex. For instance, the `onDidChangeBookmarks` event could include metadata about which bookmark were added or removed. But I figured it was overkill. If I’m wrong, that can be added in a later version.

### Possible Drawbacks

All I had in mind was for consumers of this service to be able to _read_ bookmark data, but since we’re exposing the entire class that manages bookmarks for an editor, they can just as easily _change_ bookmark data.

I don’t really think this is a problem; anyone who’s hell-bent on changing bookmark data could’ve done it already by directly manipulating the `bookmarks` package.

### Verification Process

Instead of writing any new specs, I added assertions to existing specs in various places:

* making sure that the data obtained through the service matches what you’d get otherwise
* ensuring that `onDidChangeBookmarks` is called each time a bookmark is added
* ensuring that `onDidChangeBookmarks` is called each time a bookmark is removed
* ensuring that `onDidChangeBookmarks` is called each time a bookmark is implicitly destroyed

### Release Notes

* Added a service for the `bookmarks` package to provide to other packages that want to read bookmark data.