### PR TITLE
Properly localize Download/Stargazer Counts within `settings-view`

### DIFF
--- a/packages/settings-view/lib/package-card.js
+++ b/packages/settings-view/lib/package-card.js
@@ -299,8 +299,9 @@ export default class PackageCard {
           this.refs.downloadIcon.classList.add('icon-git-branch')
           this.refs.downloadCount.textContent = this.pack.apmInstallSource.sha.substr(0, 8)
         } else {
-          this.refs.stargazerCount.textContent = data.stargazers_count ? data.stargazers_count.toLocaleString() : ''
-          this.refs.downloadCount.textContent = data.downloads ? data.downloads.toLocaleString() : ''
+
+          this.refs.stargazerCount.textContent = data.stargazers_count ? parseInt(data.stargazers_count).toLocaleString() : ''
+          this.refs.downloadCount.textContent = data.downloads ? parseInt(data.downloads).toLocaleString() : ''
         }
       }
     })


### PR DESCRIPTION
Getting to the bottom of this issue, seems to stem from as soon as the backend migrated to the new package builder.

The backend now returns strings for both `stargazer_count` and `downloads` instead of integers.

Meaning that when `settings-view` used:

```javascript
this.refs.downloadCount.textContent = data.downloads ? data.downloads.toLocaleString() : '';
```

That `.toLocaleString()` would just return the same string it received, rather than operate on it. So that a string of `1000` stayed as `1000` rather than `1,000`.

So what I've done here is first parsed any strings on these values to integers, then we localize the value itself, to match with how the user expects in their region.

I've confirmed that attempting to convert any integers to an integer has no negative effects, so that when this is fixed on the backend (which it also should be) this solution will not cause any issues.

Really while I do plan on fixing it on the backend, it still makes sense to me to fix it here as well, to ensure we always show the user what they want to see.

So beyond that lets look at the before and after:

## Before 
![image](https://github.com/pulsar-edit/pulsar/assets/26921489/08a3a333-5b6e-4cd1-8123-f710d1b5f8a5)

## After 

![image](https://github.com/pulsar-edit/pulsar/assets/26921489/547a645b-2170-40d9-9885-057f0c78f47a)


---

Resolves #441 