### PR TITLE
Fix Ripgrep download issues in CirrusCI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,5 +1,7 @@
 env:
   PYTHON_VERSION: 3.10
+  GITHUB_TOKEN: ENCRYPTED[13da504dc34d1608564d891fb7f456b546019d07d1abb059f9ab4296c56ccc0e6e32c7b313629776eda40ab74a54e95c]
+  # The above token, is a GitHub API Token, that allows us to download RipGrep without concern of API limits
 
 linux_task:
   alias: linux


### PR DESCRIPTION
Now that our tests are totally passing, the last thing holding us back, in regards to false failures, is Ripgrep downloads within Cirrus CI.

As we saw when downloading Ripgrep in our GitHub Action tests, we had to add a GitHub token to increase our rate limit.

This PR does the same thing but for Cirrus.

I've added a personal access token, that has permissions to nothing, except my identity, and encrypted it within Cirrus, and added that here.

This token does expire in 90 days, I'll ensure to renew it, but if this ever fails, you'll just need to make a new access token, encrypt it in Cirrus, then add that value here instead of mine.
