### PR TITLE
Make CHANGELOG easier to merge and update dompurify

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,5 @@
+CHANGELOG.* merge=union
+
 # Specs depend on character counts, if we don't specify the line endings the
 # fixtures will vary depending on platform
 spec/fixtures/**/*.js text eol=lf

--- a/packages/notifications/package.json
+++ b/packages/notifications/package.json
@@ -9,7 +9,7 @@
     "atom": ">0.50.0"
   },
   "dependencies": {
-    "dompurify": "^1.0.3",
+    "dompurify": "3.0.3",
     "fs-plus": "^3.0.0",
     "marked": "^0.3.6",
     "moment": "^2.19.3",

--- a/packages/notifications/spec/notifications-spec.coffee
+++ b/packages/notifications/spec/notifications-spec.coffee
@@ -117,7 +117,7 @@ describe "Notifications", ->
       atom.notifications.addInfo('test <b>html</b> <iframe>but sanitized</iframe>')
       notification = notificationContainer.childNodes[0]
       expect(notification.querySelector('.message').innerHTML).toContain(
-        'test <b>html</b> but sanitized'
+        'test <b>html</b> '
       )
 
     describe "when a dismissable notification is added", ->

--- a/yarn.lock
+++ b/yarn.lock
@@ -3807,10 +3807,10 @@ dompurify@2.0.17:
   resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-2.0.17.tgz#505ffa126a580603df4007e034bdc9b6b738668e"
   integrity sha512-nNwwJfW55r8akD8MSFz6k75bzyT2y6JEa1O3JrZFBf+Y5R9JXXU4OsRl0B9hKoPgHTw2b7ER5yJ5Md97MMUJPg==
 
-dompurify@^1.0.3:
-  version "1.0.11"
-  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-1.0.11.tgz#fe0f4a40d147f7cebbe31a50a1357539cfc1eb4d"
-  integrity sha512-XywCTXZtc/qCX3iprD1pIklRVk/uhl8BKpkTxr+ZyMVUzSUg7wkQXRBp/euJ5J5moa1QvfpvaPQVP71z1O59dQ==
+dompurify@3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-3.0.3.tgz#4b115d15a091ddc96f232bcef668550a2f6f1430"
+  integrity sha512-axQ9zieHLnAnHh0sfAamKYiqXMJAVwu+LM/alQ7WDagoWessyWvMSFyW65CqF3owufNu8HBcE4cM2Vflu7YWcQ==
 
 dompurify@^2.0.17:
   version "2.4.1"
@@ -7220,9 +7220,9 @@ normalize-url@^6.0.1:
   integrity sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==
 
 "notifications@file:./packages/notifications":
-  version "0.72.1"
+  version "0.73.0"
   dependencies:
-    dompurify "^1.0.3"
+    dompurify "3.0.3"
     fs-plus "^3.0.0"
     marked "^0.3.6"
     moment "^2.19.3"


### PR DESCRIPTION
An unknown-ish config in `.gitattributes` is to override how things are merged. Using "union" for changelog means if both people add a line, it'll keep BOTH of them!