### PR TITLE
Add fpm option to build script due to rpm upgrade issue

### DIFF
--- a/script/electron-builder.js
+++ b/script/electron-builder.js
@@ -151,7 +151,7 @@ let options = {
     afterInstall: "script/post-install.sh",
     afterRemove: "script/post-uninstall.sh",
     compression: 'xz',
-    fpm: ['--rpm-rpmbuild-define=_build_id_links none']
+    fpm: ['--rpm-rpmbuild-define=_build_id_links none', '--after-upgrade=script/post-install.sh']
   },
   "linux": {
     // Giving a single PNG icon to electron-builder prevents the correct


### PR DESCRIPTION
Just testing for the moment to get CI to build the binary, I'll add an issue in a bit and flesh this out if it works.

See https://github.com/orgs/pulsar-edit/discussions/178, seems on upgrade the rpm is performing an uninstall to remove the pulsar script from `/usr/bin` but nothing puts it back.
