### PR TITLE
[settings-view] Return Settings or Preferences as tab title depending on OS

### DIFF
--- a/packages/settings-view/lib/settings-view.js
+++ b/packages/settings-view/lib/settings-view.js
@@ -358,10 +358,10 @@ export default class SettingsView {
   }
 
   getTitle () {
-    if (process.platform === 'darwin') {
-      return "Preferences";
+    if (process.platform === 'win32') {
+      return "Settings";
     } else {
-      return 'Settings'
+      return 'Preferences'
     }
   }
 

--- a/packages/settings-view/lib/settings-view.js
+++ b/packages/settings-view/lib/settings-view.js
@@ -124,7 +124,7 @@ export default class SettingsView {
     if (atom.config.get("settings-view.enableSettingsSearch")) {
       this.addCorePanel('Search', 'search', () => new SearchSettingsPanel(this))
     }
-    
+
     this.addCorePanel('Core', 'settings', () => new GeneralPanel())
     this.addCorePanel('Editor', 'code', () => new EditorPanel())
     if (atom.config.getSchema('core.uriHandlerRegistration').type !== 'any') {
@@ -358,7 +358,11 @@ export default class SettingsView {
   }
 
   getTitle () {
-    return 'Settings'
+    if (process.platform === 'darwin') {
+      return "Preferences";
+    } else {
+      return 'Settings'
+    }
   }
 
   getIconName () {

--- a/packages/settings-view/lib/settings-view.js
+++ b/packages/settings-view/lib/settings-view.js
@@ -124,7 +124,7 @@ export default class SettingsView {
     if (atom.config.get("settings-view.enableSettingsSearch")) {
       this.addCorePanel('Search', 'search', () => new SearchSettingsPanel(this))
     }
-
+    
     this.addCorePanel('Core', 'settings', () => new GeneralPanel())
     this.addCorePanel('Editor', 'code', () => new EditorPanel())
     if (atom.config.getSchema('core.uriHandlerRegistration').type !== 'any') {


### PR DESCRIPTION
Currently when a user opens the `settings-view` package the tab title is always "Settings", even though the menu option to open this is calling "Settings" on Windows, but is called "Preferences" on macOS and Linux.

So this PR simply checks what OS the user is on, and returns the tab title depending on that.

Would look like the following on macOS and Linux:

![image](https://github.com/pulsar-edit/pulsar/assets/26921489/672c5232-4828-460c-a3f2-39f7d7be39bc)

And would be unchanged on Windows.

---

When an issue was originally made for this, there was some debate about having to update the docs, but from the docs I've looked at, they make zero reference to the name of the tab title, only describing the menu bar items that need to be clicked on, which already depend on the OS the user is on.

Sure many screenshots do show usage of "Settings" as the tab title, but I'm not sure if we really need to be that worried about that, as the screenshot is still accurate if it was taken on Windows.

Resolves #331 
