### PR TITLE
Lower-case-ing the heredoc language

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ## [Unreleased]
 
+- Fixed default tokenization of heredocs in Ruby (should be tokenized as string)
 - Added a modern implementation of Tree-sitter grammars behind an experimental flag. Enable the “Use Modern Tree-Sitter Implementation” in the Core settings to try it out.
 
 ## 1.105.0

--- a/packages/language-ruby/grammars/ts/highlights.scm
+++ b/packages/language-ruby/grammars/ts/highlights.scm
@@ -330,6 +330,7 @@
   (bare_string)
   (heredoc_body)
   (heredoc_beginning)
+  (heredoc_content)
 ] @string.unquoted.ruby
 
 ((heredoc_body) @meta.embedded

--- a/packages/language-ruby/lib/main.js
+++ b/packages/language-ruby/lib/main.js
@@ -4,7 +4,7 @@ exports.activate = function() {
   atom.grammars.addInjectionPoint('source.ruby', {
     type: 'heredoc_body',
     language(node) {
-      return node.lastChild.text;
+      return node.lastChild.text?.toLowerCase();
     },
     content(node) {
       return node.descendantsOfType('heredoc_content')


### PR DESCRIPTION
Two small fixes here:

1. Usually, on Ruby, "heredocs" are always uppercase. So I'm lower-casing so that it tries to get the right grammar
2. When a grammar is not found, heredocs are highlighted as strings