### PR TITLE
Hardcode NSIS GUID

### DIFF
--- a/script/electron-builder.js
+++ b/script/electron-builder.js
@@ -227,6 +227,11 @@ let options = {
     "runAfterFinish": true,
     "createDesktopShortcut": true,
     "createStartMenuShortcut": true,
+    "guid": "0949b555-c22c-56b7-873a-a960bdefa81f"
+    // The GUID is generated from Electron-Builder based on our AppID
+    // Hardcoding it here means it will always be used as generated from
+    // the AppID 'dev.pulsar-edit.pulsar'. If this value ever changes,
+    // A PR to GitHub Desktop must be made with the updated value
   },
   "extraMetadata": {
   },


### PR DESCRIPTION
As inspired by #565 this PR hardcodes our GUID.

While the [Electron-Builder docs](https://www.electron.build/configuration/nsis#guid-vs-application-name) recommend against this, this is the GUID we have already been using on Windows as generated from `dev.pulsar-edit.pulsar`, so this isn't actually changing our GUID at all. This just ensures that even if we ever change the `AppID` in the future the GUID will remain the same.

Once this PR is merged, we can then create a PR to GitHub Desktop to allow integration, being confident knowing we won't accidentally break that integration.

But even if we ever do, I've added a comment explaining the purpose of hardcoding this value, and what needs to be done if it ever changes, to ensure anyone working on this can be on the same page.