### PR TITLE
Make yarn sane

### DIFF
--- a/.yarnrc
+++ b/.yarnrc
@@ -1,0 +1,2 @@
+enableTelemetry false
+ignore-engines true


### PR DESCRIPTION
Basically, remove telemetry (I still don't believe **everything phones home** these days!) and ignore engines because some packages try to be smart and say _heeey, I only work on newer nodes, even though there's nothing that prevents this to run on Node 14_ like `marked` for example