### PR TITLE
Update links in settings page

### DIFF
--- a/packages/autocomplete-plus/package.json
+++ b/packages/autocomplete-plus/package.json
@@ -88,7 +88,7 @@
     },
     "useCoreMovementCommands": {
       "title": "Use Core Movement Commands",
-      "description": "Disable this if you want to bind your own keystrokes to move around the suggestion list. You will also need to add definitions to your keymap. See: https://github.com/Daeraxa/pulsar/blob/master/packages/autocomplete-plus/README.md#remapping-movement-commands",
+      "description": "Disable this if you want to bind your own keystrokes to move around the suggestion list. You will also need to add definitions to your keymap. See: https://github.com/pulsar-edit/pulsar/blob/master/packages/autocomplete-plus/README.md#remapping-movement-commands",
       "type": "boolean",
       "default": true,
       "order": 5

--- a/packages/autocomplete-plus/package.json
+++ b/packages/autocomplete-plus/package.json
@@ -88,7 +88,7 @@
     },
     "useCoreMovementCommands": {
       "title": "Use Core Movement Commands",
-      "description": "Disable this if you want to bind your own keystrokes to move around the suggestion list. You will also need to add definitions to your keymap. See: https://github.com/atom/autocomplete-plus#remapping-movement-commands",
+      "description": "Disable this if you want to bind your own keystrokes to move around the suggestion list. You will also need to add definitions to your keymap. See: https://github.com/Daeraxa/pulsar/blob/master/packages/autocomplete-plus/README.md#remapping-movement-commands",
       "type": "boolean",
       "default": true,
       "order": 5
@@ -107,7 +107,7 @@
     },
     "scopeBlacklist": {
       "title": "Scope Blacklist",
-      "description": "Suggestions will not be provided for scopes matching this list. See: http://flight-manual.atom.io/behind-atom/sections/scoped-settings-scopes-and-scope-descriptors/",
+      "description": "Suggestions will not be provided for scopes matching this list. See: https://pulsar-edit.dev/docs/launch-manual/sections/behind-pulsar/#scoped-settings-scopes-and-scope-descriptors",
       "type": "array",
       "default": [],
       "items": {


### PR DESCRIPTION
This simply updates the links on the settings page (I couldn't find an existing one for this but apologies if there is an open one).

One was linking to the atom repo and the other to the flight manual. This updats both but the repo one is more substantial as it was previously linking to the package so I've changed the link to the readme file itself in the bundled version (it seems pointless just to link to the main repo page).
