### PR TITLE
[core]: Implement API on `atom.` to compare Pulsar Versions

### DIFF
--- a/spec/atom-environment-spec.js
+++ b/spec/atom-environment-spec.js
@@ -48,60 +48,13 @@ describe('AtomEnvironment', () => {
     });
   });
 
-  describe('.isVersionGreater()', () => {
-    it('returns false if pulsar version is lesser than provided version string', () => {
+  describe('.versionSatisfies()', () => {
+    it('returns appropriately for provided range', () => {
       let testPulsarVersion = '0.1.0';
       spyOn(atom, 'getVersion').andCallFake(() => testPulsarVersion);
-      expect(atom.isVersionGreater('0.2.0')).toBe(false);
-      testPulsarVersion = '1.105.0';
-      expect(atom.isVersionGreater('1.105.1')).toBe(false);
-      expect(atom.isVersionGreater('1.106')).toBe(false);
-    });
-    it('returns true if pulsar version is greater than provided version string', () => {
-      let testPulsarVersion = '1.105.0';
-      spyOn(atom, 'getVersion').andCallFake(() => testPulsarVersion);
-      expect(atom.isVersionGreater('0.2.0')).toBe(true);
-      expect(atom.isVersionGreater('0.2')).toBe(true);
-      expect(atom.isVersionGreater('1.104.9')).toBe(true);
-      testPulsarVersion = '1.36.0';
-      expect(atom.isVersionGreater('0.36.0')).toBe(true);
-      expect(atom.isVersionGreater('1.35')).toBe(true);
-    });
-  });
-
-  describe('.isVersionGreaterOrEqual()', () => {
-    // Tests of this function are purposefully sparse, as it is just a
-    // reimplmentation  of `.isVersionGreater()`
-    it('returns true if pulsar version is equal to provided version string', () => {
-      let testPulsarVersion = '1.105.0';
-      spyOn(atom, 'getVersion').andCallFake(() => testPulsarVersion);
-      expect(atom.isVersionGreaterOrEqual('1.105.0')).toBe(true);
-    });
-  });
-
-  describe('.isVersionLesser()', () => {
-    it('returns false if pulsar version is greater than provided version string', () => {
-      let testPulsarVersion = '1.105.0';
-      spyOn(atom, 'getVersion').andCallFake(() => testPulsarVersion);
-      expect(atom.isVersionLesser('0.105.0')).toBe(false);
-      expect(atom.isVersionLesser('1.104.1')).toBe(false);
-    });
-    it('returns true if pulsar version is lesser than provided version string', () => {
-      let testPulsarVersion = '1.105.0';
-      spyOn(atom, 'getVersion').andCallFake(() => testPulsarVersion);
-      expect(atom.isVersionLesser('1.105.1')).toBe(true);
-      expect(atom.isVersionLesser('1.106')).toBe(true);
-      expect(atom.isVersionLesser('2.0')).toBe(true);
-    });
-  });
-
-  describe('.isVersionLesserOrEqual()', () => {
-    // Tests of this function are purposefully sparse, as it is just a
-    // reimplmentation  of `.isVerisonLesser()`
-    it('returns true if pulsar version is equal to provided version string', () => {
-      let testPulsarVersion = '1.105.0';
-      spyOn(atom, 'getVersion').andCallFake(() => testPulsarVersion);
-      expect(atom.isVersionLesserOrEqual('1.105.0')).toBe(true);
+      expect(atom.versionSatisfies('>0.2.0')).toBe(false);
+      expect(atom.versionSatisfies('>=0.x.x <=2.x.x')).toBe(true);
+      expect(atom.versionSatisfies('^0.1.x')).toBe(true);
     });
   });
 

--- a/spec/atom-environment-spec.js
+++ b/spec/atom-environment-spec.js
@@ -48,6 +48,63 @@ describe('AtomEnvironment', () => {
     });
   });
 
+  describe('.isVersionGreater()', () => {
+    it('returns false if pulsar version is lesser than provided version string', () => {
+      let testPulsarVersion = '0.1.0';
+      spyOn(atom, 'getVersion').andCallFake(() => testPulsarVersion);
+      expect(atom.isVersionGreater('0.2.0')).toBe(false);
+      testPulsarVersion = '1.105.0';
+      expect(atom.isVersionGreater('1.105.1')).toBe(false);
+      expect(atom.isVersionGreater('1.106')).toBe(false);
+    });
+    it('returns true if pulsar version is greater than provided version string', () => {
+      let testPulsarVersion = '1.105.0';
+      spyOn(atom, 'getVersion').andCallFake(() => testPulsarVersion);
+      expect(atom.isVersionGreater('0.2.0')).toBe(true);
+      expect(atom.isVersionGreater('0.2')).toBe(true);
+      expect(atom.isVersionGreater('1.104.9')).toBe(true);
+      testPulsarVersion = '1.36.0';
+      expect(atom.isVersionGreater('0.36.0')).toBe(true);
+      expect(atom.isVersionGreater('1.35')).toBe(true);
+    });
+  });
+
+  describe('.isVersionGreaterOrEqual()', () => {
+    // Tests of this function are purposefully sparse, as it is just a
+    // reimplmentation  of `.isVersionGreater()`
+    it('returns true if pulsar version is equal to provided version string', () => {
+      let testPulsarVersion = '1.105.0';
+      spyOn(atom, 'getVersion').andCallFake(() => testPulsarVersion);
+      expect(atom.isVersionGreaterOrEqual('1.105.0')).toBe(true);
+    });
+  });
+
+  describe('.isVersionLesser()', () => {
+    it('returns false if pulsar version is greater than provided version string', () => {
+      let testPulsarVersion = '1.105.0';
+      spyOn(atom, 'getVersion').andCallFake(() => testPulsarVersion);
+      expect(atom.isVersionLesser('0.105.0')).toBe(false);
+      expect(atom.isVersionLesser('1.104.1')).toBe(false);
+    });
+    it('returns true if pulsar version is lesser than provided version string', () => {
+      let testPulsarVersion = '1.105.0';
+      spyOn(atom, 'getVersion').andCallFake(() => testPulsarVersion);
+      expect(atom.isVersionLesser('1.105.1')).toBe(true);
+      expect(atom.isVersionLesser('1.106')).toBe(true);
+      expect(atom.isVersionLesser('2.0')).toBe(true);
+    });
+  });
+
+  describe('.isVersionLesserOrEqual()', () => {
+    // Tests of this function are purposefully sparse, as it is just a
+    // reimplmentation  of `.isVerisonLesser()`
+    it('returns true if pulsar version is equal to provided version string', () => {
+      let testPulsarVersion = '1.105.0';
+      spyOn(atom, 'getVersion').andCallFake(() => testPulsarVersion);
+      expect(atom.isVersionLesserOrEqual('1.105.0')).toBe(true);
+    });
+  });
+
   describe('loading default config', () => {
     it('loads the default core config schema', () => {
       expect(atom.config.get('core.excludeVcsIgnoredPaths')).toBe(true);

--- a/src/atom-environment.js
+++ b/src/atom-environment.js
@@ -587,6 +587,112 @@ class AtomEnvironment {
     return this.appVersion;
   }
 
+  /**
+   * @memberof AtomEnvironment
+   * Determines if the current Pulsar version is greater than the provided
+   * semver string.
+   * @param {string} value - The provided version string to check against.
+   * Can be any valid semver, or even just the Major and Minor versions ie. "1.2"
+   * @param {boolean} [orEqual=false] - Instructs the function to return true if the
+   * values are equal. Don't ever set this value manually, instead use
+   * `.isVersionGreaterOrEqual()`.
+   * @returns {boolean} 'true' if the current Pulsar version is greater than the
+   * provided semver, 'false' is the provided semver is greater than the current
+   * Pulsar version, or equal to it.
+   */
+  isVersionGreater(value, orEqual = false) {
+    let semverReg = /^(0|[1-9]\d*)\.(0|[1-9]\d*)(?:\.(0|[1-9]\d*))?/;
+    // Returns Semver numbers, with optional third position. Ignoring pre-release, and build metadata
+
+    let appVerArray = this.getVersion().match(semverReg) ?? [];
+    let valVerArray = value.match(semverReg) ?? [];
+
+    if (valVerArray.length === 0 || appVerArray.length === 0) {
+      // Couldn't parse the version, return false
+      return false;
+    }
+
+    for (let i = 1; i < valVerArray.length; i++) {
+      // i is initialized as 1, since first array value is full string
+      if (parseInt(appVerArray[i]) > parseInt(valVerArray[i])) {
+        return true;
+      }
+    }
+    // If all checks in the loop have passed, then the values are equal
+    if (orEqual) {
+      return true;
+    } else {
+      return false;
+    }
+  }
+
+  /**
+   * @memberof AtomEnvironment
+   * Determines if the current Pulsar version is greater than or equal to the
+   * provided semver string. Implements `.isVersionGreater()`.
+   * @param {string} value - THe provided version string to check against.
+   * Can be any valid semver, or even just the Major and Minor versions ie. "1.2"
+   * @returns {boolean} 'true' if the current Pulsar version is greater than or
+   * equal to the provided semver, 'false' otherwise.
+   */
+  isVersionGreaterOrEqual(value) {
+    return this.isVersionGreater(value, true);
+  }
+
+  /**
+   * @memberof AtomEnvironment
+   * Determines if the current Pulsar version is less than the provided semver
+   * string.
+   * @param {string} value - The provided version string to check against.
+   * Can be any valid semver, or even just the Major and Minor versions ie. "1.2"
+   * @param {boolean} [orEqual=false] - Instructs the function to return true if the
+   * values are equal. Don't ever set this value manually, instead use
+   * `.isVersionLesserOrEqual()`.
+   * @returns {boolean} 'true' if the current Pulsar version is lesser than the
+   * provided semver, 'false' if the provided semver is greater than the current
+   * Pulsar version, or equal to it.
+   */
+  isVersionLesser(value, orEqual = false) {
+    let semverReg = /^(0|[1-9]\d*)\.(0|[1-9]\d*)(?:\.(0|[1-9]\d*))?/;
+    // Returns Semver numbers, with optional third position. Ignoring pre-release, and build metadata
+
+    let appVerArray = this.getVersion().match(semverReg) ?? [];
+    let valVerArray = value.match(semverReg) ?? [];
+
+    if (valVerArray.length === 0 || appVerArray.length === 0) {
+      // Couldn't parse the version, return false
+      return false;
+    }
+
+    for (let i = 1; i < valVerArray.length; i++) {
+      // i is initialized as 1, since first array value is full string
+      if (parseInt(appVerArray[i]) < parseInt(valVerArray[i])) {
+        return true;
+      } else if (parseInt(appVerArray[i]) != parseInt(valVerArray[i])) {
+        return false;
+      }
+    }
+    // If all checks in the loop have passed, then the values are equal
+    if (orEqual) {
+      return true;
+    } else {
+      return false;
+    }
+  }
+
+  /**
+   * @memberof AtomEnvironment
+   * Determines if the current Pulsar version is less than or equal to the
+   * provided semver string. Implements `.isVersionLesser()`.
+   * @param {string} value - The provided version string to check against.
+   * Can be any valid semver, or even just the Major and Minor versions ie. "1.2"
+   * @returns {boolean} 'true' if the current Pulsar version is lesser than or
+   * equal to the provided semver, 'false' otherwise.
+   */
+  isVersionLesserOrEqual(value) {
+    return this.isVersionLesser(value, true);
+  }
+
   // Public: Gets the release channel of the Pulsar application.
   //
   // Returns the release channel as a {String}. Will return a specific release channel

--- a/src/atom-environment.js
+++ b/src/atom-environment.js
@@ -8,6 +8,7 @@ const { deprecate } = require('grim');
 const { CompositeDisposable, Disposable, Emitter } = require('event-kit');
 const fs = require('fs-plus');
 const { mapSourcePosition } = require('@atom/source-map-support');
+const semver = require("semver");
 const WindowEventHandler = require('./window-event-handler');
 const StateStore = require('./state-store');
 const registerDefaultCommands = require('./register-default-commands');
@@ -589,108 +590,14 @@ class AtomEnvironment {
 
   /**
    * @memberof AtomEnvironment
-   * Determines if the current Pulsar version is greater than the provided
-   * semver string.
-   * @param {string} value - The provided version string to check against.
-   * Can be any valid semver, or even just the Major and Minor versions ie. "1.2"
-   * @param {boolean} [orEqual=false] - Instructs the function to return true if the
-   * values are equal. Don't ever set this value manually, instead use
-   * `.isVersionGreaterOrEqual()`.
-   * @returns {boolean} 'true' if the current Pulsar version is greater than the
-   * provided semver, 'false' is the provided semver is greater than the current
-   * Pulsar version, or equal to it.
+   * Compares the current Pulsar version against any valid semver range.
+   * @param {string} value - Any valid semver range.
+   * @returns {boolean} True if the current version satisfies the range provided,
+   * false otherwise.
+   * @see {@link https://github.com/npm/node-semver#ranges}
    */
-  isVersionGreater(value, orEqual = false) {
-    let semverReg = /^(0|[1-9]\d*)\.(0|[1-9]\d*)(?:\.(0|[1-9]\d*))?/;
-    // Returns Semver numbers, with optional third position. Ignoring pre-release, and build metadata
-
-    let appVerArray = this.getVersion().match(semverReg) ?? [];
-    let valVerArray = value.match(semverReg) ?? [];
-
-    if (valVerArray.length === 0 || appVerArray.length === 0) {
-      // Couldn't parse the version, return false
-      return false;
-    }
-
-    for (let i = 1; i < valVerArray.length; i++) {
-      // i is initialized as 1, since first array value is full string
-      if (parseInt(appVerArray[i]) > parseInt(valVerArray[i])) {
-        return true;
-      }
-    }
-    // If all checks in the loop have passed, then the values are equal
-    if (orEqual) {
-      return true;
-    } else {
-      return false;
-    }
-  }
-
-  /**
-   * @memberof AtomEnvironment
-   * Determines if the current Pulsar version is greater than or equal to the
-   * provided semver string. Implements `.isVersionGreater()`.
-   * @param {string} value - THe provided version string to check against.
-   * Can be any valid semver, or even just the Major and Minor versions ie. "1.2"
-   * @returns {boolean} 'true' if the current Pulsar version is greater than or
-   * equal to the provided semver, 'false' otherwise.
-   */
-  isVersionGreaterOrEqual(value) {
-    return this.isVersionGreater(value, true);
-  }
-
-  /**
-   * @memberof AtomEnvironment
-   * Determines if the current Pulsar version is less than the provided semver
-   * string.
-   * @param {string} value - The provided version string to check against.
-   * Can be any valid semver, or even just the Major and Minor versions ie. "1.2"
-   * @param {boolean} [orEqual=false] - Instructs the function to return true if the
-   * values are equal. Don't ever set this value manually, instead use
-   * `.isVersionLesserOrEqual()`.
-   * @returns {boolean} 'true' if the current Pulsar version is lesser than the
-   * provided semver, 'false' if the provided semver is greater than the current
-   * Pulsar version, or equal to it.
-   */
-  isVersionLesser(value, orEqual = false) {
-    let semverReg = /^(0|[1-9]\d*)\.(0|[1-9]\d*)(?:\.(0|[1-9]\d*))?/;
-    // Returns Semver numbers, with optional third position. Ignoring pre-release, and build metadata
-
-    let appVerArray = this.getVersion().match(semverReg) ?? [];
-    let valVerArray = value.match(semverReg) ?? [];
-
-    if (valVerArray.length === 0 || appVerArray.length === 0) {
-      // Couldn't parse the version, return false
-      return false;
-    }
-
-    for (let i = 1; i < valVerArray.length; i++) {
-      // i is initialized as 1, since first array value is full string
-      if (parseInt(appVerArray[i]) < parseInt(valVerArray[i])) {
-        return true;
-      } else if (parseInt(appVerArray[i]) != parseInt(valVerArray[i])) {
-        return false;
-      }
-    }
-    // If all checks in the loop have passed, then the values are equal
-    if (orEqual) {
-      return true;
-    } else {
-      return false;
-    }
-  }
-
-  /**
-   * @memberof AtomEnvironment
-   * Determines if the current Pulsar version is less than or equal to the
-   * provided semver string. Implements `.isVersionLesser()`.
-   * @param {string} value - The provided version string to check against.
-   * Can be any valid semver, or even just the Major and Minor versions ie. "1.2"
-   * @returns {boolean} 'true' if the current Pulsar version is lesser than or
-   * equal to the provided semver, 'false' otherwise.
-   */
-  isVersionLesserOrEqual(value) {
-    return this.isVersionLesser(value, true);
+  versionSatisfies(value) {
+    return semver.satisfies(this.getVersion(), value);
   }
 
   // Public: Gets the release channel of the Pulsar application.


### PR DESCRIPTION
Since we have seen many hacky, and failing ways that community package authors check for minimum and maximum Pulsar versions for feature detection, this PR implements a set of API calls that can now be used by community package authors to properly, and easily compare the Pulsar version in any way they need to.

This PR utilizes our existing `semver` dependency, to expose a very flexible API to check the version of Pulsar for community packages.

This is via the new function `atom.versionSatisfies()` that accepts a string semver range, and returns true if the provided range is satisfied with Pulsar's current version, and false otherwise. The semver range that can be provided can look anything like `>0.2.0`, `>=0.x.x <=2.x.x`, `^0.1.x` or any other valid semver range. This means that users can simply and easily discover if the Pulsar version is lower than expected, higher, or even within a specific range.

This PR includes documentation for this new function, as well as a small set of appropriate tests.

<details>
<summary>Previous Implementation</summary>

This PR implements the following new functions on the main `atom.` global object:

* `isVersionGreater()`: Checks if the current Pulsar version is greater than the provided string.
* `isVersionGreaterOrEqual()`: Checks if the current Pulsar version is greater than or equal to the provided string.
* `isVersionLesser()`: Checks if the current Pulsar version is lesser than the provided string.
* `isVersionLesserOrEqual()`: Checks if the current Pulsar version is lesser than or equal to the provided string.

The provided string can be any valid semver value, or ever just the Major and Minor such as `1.105` or even `1.105.0-456`.

This PR properly includes tests, and the associated JSDoc Documentation.

</details>