### PR TITLE
Fix tree-view sticky headers of one-dark & one-light themes

### DIFF
--- a/packages/one-dark-ui/styles/config.less
+++ b/packages/one-dark-ui/styles/config.less
@@ -126,31 +126,5 @@
     &:focus .selected .project-root-header.project-root-header  {
       background: @button-background-color-selected;
     }
-
-    // Fix sticky header from covering auto-revealed files
-    .entry.file.selected {
-      padding-top: @ui-tab-height;
-      margin-top: -@ui-tab-height;
-    }
-
-    // Fix sticky header from covering auto-revealed directories when using up/down keys
-    // for directories, scroll test moves to .header, see https://github.com/atom/tree-view/blob/d2857ad4d7eeb7dad5cf94b33257a8740211480e/lib/tree-view.coffee#L839
-    .entry.directory.selected:not(.project-root) {
-      & > .header {
-        padding-top: @ui-tab-height;
-        margin-top: -@ui-tab-height;
-      }
-      &::before {
-        margin-top: @ui-tab-height;
-      }
-    }
-
-    // Fix above directory is not being clickable
-    .entry.directory:not(.project-root) > .header {
-      z-index: 2;
-    }
-    .entry.directory.selected:not(.project-root) > .header {
-      z-index: 1;
-    }
   }
 }

--- a/packages/one-light-ui/styles/config.less
+++ b/packages/one-light-ui/styles/config.less
@@ -126,31 +126,5 @@
     &:focus .selected .project-root-header.project-root-header  {
       background: @button-background-color-selected;
     }
-
-    // Fix sticky header from covering auto-revealed files
-    .entry.file.selected {
-      padding-top: @ui-tab-height;
-      margin-top: -@ui-tab-height;
-    }
-
-    // Fix sticky header from covering auto-revealed directories when using up/down keys
-    // for directories, scroll test moves to .header, see https://github.com/atom/tree-view/blob/d2857ad4d7eeb7dad5cf94b33257a8740211480e/lib/tree-view.coffee#L839
-    .entry.directory.selected:not(.project-root) {
-      & > .header {
-        padding-top: @ui-tab-height;
-        margin-top: -@ui-tab-height;
-      }
-      &::before {
-        margin-top: @ui-tab-height;
-      }
-    }
-
-    // Fix above directory is not being clickable
-    .entry.directory:not(.project-root) > .header {
-      z-index: 2;
-    }
-    .entry.directory.selected:not(.project-root) > .header {
-      z-index: 1;
-    }
   }
 }


### PR DESCRIPTION
The fixes of sticky headers are outdated and it generate some bugs now, like:

* https://github.com/atom/one-dark-ui/issues/257
* https://github.com/atom/one-light-ui/pull/133

I have just deleted old fixes and everything looks working perfectly...