### PR TITLE
[git-diff]: Bump all Deps

### DIFF
--- a/packages/git-diff/package-lock.json
+++ b/packages/git-diff/package-lock.json
@@ -9,11 +9,11 @@
       "version": "1.3.9",
       "license": "MIT",
       "dependencies": {
-        "atom-select-list": "^0.7.0"
+        "atom-select-list": "^0.8.1"
       },
       "devDependencies": {
-        "fs-plus": "^3.0.0",
-        "temp": "~0.8.1"
+        "fs-plus": "^3.1.1",
+        "temp": "^0.9.4"
       },
       "engines": {
         "atom": "*"
@@ -26,11 +26,11 @@
       "dev": true
     },
     "node_modules/atom-select-list": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/atom-select-list/-/atom-select-list-0.7.2.tgz",
-      "integrity": "sha512-a707OB1DhLGjzqtFrtMQKH7BBxFuCh8UBoUWxgFOrLrSwVh3g+/TlVPVDOz12+U0mDu3mIrnYLqQyhywQOTxhw==",
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/atom-select-list/-/atom-select-list-0.8.1.tgz",
+      "integrity": "sha512-MpwlZmmI81odx7rY+HpJrRmDW9aXlkFDFDNt70JxrPibxEh8h9HCZZj22woa4CKFKVXC8sEiLMcNtuDeE10jog==",
       "dependencies": {
-        "etch": "^0.12.6",
+        "etch": "^0.14.0",
         "fuzzaldrin": "^2.1.0"
       }
     },
@@ -57,9 +57,9 @@
       "dev": true
     },
     "node_modules/etch": {
-      "version": "0.12.8",
-      "resolved": "https://registry.npmjs.org/etch/-/etch-0.12.8.tgz",
-      "integrity": "sha512-dFLRe4wLroVtwzyy1vGlE3BSDZHiL0kZME5XgNGzZIULcYTvVno8vbiIleAesoKJmwWaxDTzG+4eppg2zk14JQ=="
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/etch/-/etch-0.14.1.tgz",
+      "integrity": "sha512-+IwqSDBhaQFMUHJu4L/ir0dhDoW5IIihg4Z9lzsIxxne8V0PlSg0gnk2STaKWjGJQnDR4cxpA+a/dORX9kycTA=="
     },
     "node_modules/fs-plus": {
       "version": "3.1.1",
@@ -184,11 +184,12 @@
       }
     },
     "node_modules/temp": {
-      "version": "0.8.4",
-      "resolved": "https://registry.npmjs.org/temp/-/temp-0.8.4.tgz",
-      "integrity": "sha512-s0ZZzd0BzYv5tLSptZooSjK8oj6C+c19p7Vqta9+6NPOf7r+fxq0cJe6/oN4LTC79sy5NY8ucOJNgwsKCSbfqg==",
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/temp/-/temp-0.9.4.tgz",
+      "integrity": "sha512-yYrrsWnrXMcdsnu/7YMYAofM1ktpL5By7vZhf15CrXijWWrEYZks5AXBudalfSWJLlnen/QUJUB5aoB0kqZUGA==",
       "dev": true,
       "dependencies": {
+        "mkdirp": "^0.5.1",
         "rimraf": "~2.6.2"
       },
       "engines": {

--- a/packages/git-diff/package.json
+++ b/packages/git-diff/package.json
@@ -9,11 +9,11 @@
     "atom": "*"
   },
   "dependencies": {
-    "atom-select-list": "^0.7.0"
+    "atom-select-list": "^0.8.1"
   },
   "devDependencies": {
-    "fs-plus": "^3.0.0",
-    "temp": "~0.8.1"
+    "fs-plus": "^3.1.1",
+    "temp": "^0.9.4"
   },
   "configSchema": {
     "showIconsInEditorGutter": {


### PR DESCRIPTION
Another small, inconsequential PR. Bumped all dependencies within `git-diff`. We've got zero API changes here, so it was simple.