### PR TITLE
Improved Windows Install (`PATH`, `ATOM_HOME`, `InstallLocation`)

### DIFF
--- a/packages/settings-view/lib/system-windows-panel.js
+++ b/packages/settings-view/lib/system-windows-panel.js
@@ -20,11 +20,14 @@ export default class SystemPanel {
     WinShell.fileHandler.isRegistered((i) => { this.refs.fileHandlerCheckbox.checked = i })
     WinShell.fileContextMenu.isRegistered((i) => { this.refs.fileContextMenuCheckbox.checked = i })
     WinShell.folderContextMenu.isRegistered((i) => { this.refs.folderContextMenuCheckbox.checked = i })
-    WinShell.pathUser.isRegistered((i) => { this.refs.addToPathCheckbox.checked = i })
-    WinShell.pathMachine.isRegistered((i) => { this.refs.addToPathMachineCheckbox.checked = i })
 
-    // Check if Pulsar is running as Admin. To know if the user can modify the machine path
-    WinShell.runningAsAdmin((i) => { this.refs.addToPathMachineCheckbox.disabled = !i })
+    if (this.isLikelyUserInstall()) {
+      WinShell.pathUser.isRegistered((i) => { this.refs.addToPathCheckbox.checked = i })
+    } else {
+      WinShell.pathMachine.isRegistered((i) => { this.refs.addToPathMachineCheckbox.checked = i })
+      // Check if Pulsar is running as Admin. To know if the user can modify the machine path
+      WinShell.runningAsAdmin((i) => { this.refs.addToPathMachineCheckbox.disabled = !i })
+    }
   }
 
   destroy () {
@@ -100,46 +103,7 @@ export default class SystemPanel {
                     </div>
                   </div>
                 </div>
-                <div className='control-group'>
-                  <div className='controls'>
-                    <div className='checkbox'>
-                      <label for='system.windows.add-to-path'>
-                        <input
-                          ref='addToPathCheckbox'
-                          id='system.windows.add-to-path'
-                          className='input-checkbox'
-                          type='checkbox'
-                          onclick={(e) => {
-                            this.setRegistration(WinShell.pathUser, e.target.checked)
-                          }} />
-                        <div className='setting-title'>Add Pulsar to PATH</div>
-                        <div className='setting-description'>
-                          Add Pulsar to Windows PATH to enable CLI usage.
-                        </div>
-                      </label>
-                    </div>
-                  </div>
-                </div>
-                <div className='control-group'>
-                  <div className='controls'>
-                    <div className='checkbox'>
-                      <label for='system.windows.add-to-path-machine'>
-                        <input
-                          ref='addToPathMachineCheckbox'
-                          id='system.windows.add-to-path-machine'
-                          className='input-checkbox'
-                          type='checkbox'
-                          onclick={(e) => {
-                            this.setRegistration(WinShell.pathMachine, e.target.checked)
-                          }} />
-                        <div className='setting-title'>Add Pulsar to PATH (Machine Install)</div>
-                        <div className='setting-description'>
-                          Add Pulsar to Windows PATH for Machine Installs. Requires Administrative Privileges.
-                        </div>
-                      </label>
-                    </div>
-                  </div>
-                </div>
+                { this.getPathUI() }
               </div>
             </div>
           </div>
@@ -153,6 +117,65 @@ export default class SystemPanel {
       return option.register(function () {})
     } else {
       return option.deregister(function () {})
+    }
+  }
+
+  isLikelyUserInstall() {
+    let resourcePath = atom.applicationDelegate.getWindowLoadSettings().resourcePath;
+    if (resourcePath.includes("AppData\\Local\\Programs\\pulsar")) {
+      return true;
+    } else {
+      return false;
+    }
+  }
+
+  getPathUI() {
+    if (this.isLikelyUserInstall()) {
+      return (
+        <div className='control-group'>
+          <div className='controls'>
+            <div className='checkbox'>
+              <label for='system.windows.add-to-path'>
+                <input
+                  ref='addToPathCheckbox'
+                  id='system.windows.add-to-path'
+                  className='input-checkbox'
+                  type='checkbox'
+                  onclick={(e) => {
+                    this.setRegistration(WinShell.pathUser, e.target.checked)
+                  }} />
+                <div className='setting-title'>Add Pulsar to PATH (User Install)</div>
+                <div className='setting-description'>
+                  Add Pulsar to Windows PATH to enable CLI usage.
+                </div>
+              </label>
+            </div>
+          </div>
+        </div>
+      );
+    } else {
+      return (
+        <div className='control-group'>
+          <div className='controls'>
+            <div className='checkbox'>
+              <label for='system.windows.add-to-path-machine'>
+                <input
+                  ref='addToPathMachineCheckbox'
+                  id='system.windows.add-to-path-machine'
+                  className='input-checkbox'
+                  type='checkbox'
+                  onclick={(e) => {
+                    this.setRegistration(WinShell.pathMachine, e.target.checked)
+                  }} />
+                <div className='setting-title'>Add Pulsar to PATH (Machine Install)</div>
+                <div className='setting-description'>
+                  Add Pulsar to Windows PATH for Machine Installs. Requires Administrative Privileges.
+                </div>
+              </label>
+            </div>
+          </div>
+        </div>
+      );
     }
   }
 

--- a/packages/settings-view/lib/system-windows-panel.js
+++ b/packages/settings-view/lib/system-windows-panel.js
@@ -169,7 +169,7 @@ export default class SystemPanel {
                   }} />
                 <div className='setting-title'>Add Pulsar to PATH (Machine Install)</div>
                 <div className='setting-description'>
-                  Add Pulsar to Windows PATH for Machine Installs. Requires Administrative Privileges.
+                  Add Pulsar to Windows PATH for machine installs. Requires administrative privileges.
                 </div>
               </label>
             </div>

--- a/packages/settings-view/lib/system-windows-panel.js
+++ b/packages/settings-view/lib/system-windows-panel.js
@@ -20,6 +20,7 @@ export default class SystemPanel {
     WinShell.fileHandler.isRegistered((i) => { this.refs.fileHandlerCheckbox.checked = i })
     WinShell.fileContextMenu.isRegistered((i) => { this.refs.fileContextMenuCheckbox.checked = i })
     WinShell.folderContextMenu.isRegistered((i) => { this.refs.folderContextMenuCheckbox.checked = i })
+    WinShell.path.isRegistered((i) => { this.refs.addToPathCheckbox.checked = i })
   }
 
   destroy () {
@@ -36,7 +37,7 @@ export default class SystemPanel {
           <div className='settings-panel'>
             <div className='section-container'>
               <div className='block section-heading icon icon-device-desktop'>System Settings</div>
-              <div className='text icon icon-question'>These settings determine how Atom integrates with your operating system.</div>
+              <div className='text icon icon-question'>These settings determine how Pulsar integrates with your operating system.</div>
               <div className='section-body'>
                 <div className='control-group'>
                   <div className='controls'>
@@ -90,6 +91,26 @@ export default class SystemPanel {
                         <div className='setting-title'>Show in folder context menus</div>
                         <div className='setting-description'>
                           Add "Open with {WinShell.appName}" to the File Explorer context menu for folders.
+                        </div>
+                      </label>
+                    </div>
+                  </div>
+                </div>
+                <div className='control-group'>
+                  <div className='controls'>
+                    <div className='checkbox'>
+                      <label for='system.windows.add-to-path'>
+                        <input
+                          ref='addToPathCheckbox'
+                            id='system.windows.add-to-path'
+                            className='input-checkbox'
+                            type='checkbox'
+                            onclick={(e) => {
+                              this.setRegistration(WinShell.path, e.target.checked)
+                            }} />
+                        <div className='setting-title'>Add Pulsar to PATH</div>
+                        <div className='setting-description'>
+                          Add Pulsar to Windows PATH to enable CLI usage.
                         </div>
                       </label>
                     </div>

--- a/packages/settings-view/lib/system-windows-panel.js
+++ b/packages/settings-view/lib/system-windows-panel.js
@@ -20,7 +20,11 @@ export default class SystemPanel {
     WinShell.fileHandler.isRegistered((i) => { this.refs.fileHandlerCheckbox.checked = i })
     WinShell.fileContextMenu.isRegistered((i) => { this.refs.fileContextMenuCheckbox.checked = i })
     WinShell.folderContextMenu.isRegistered((i) => { this.refs.folderContextMenuCheckbox.checked = i })
-    WinShell.path.isRegistered((i) => { this.refs.addToPathCheckbox.checked = i })
+    WinShell.pathUser.isRegistered((i) => { this.refs.addToPathCheckbox.checked = i })
+    WinShell.pathMachine.isRegistered((i) => { this.refs.addToPathMachineCheckbox.checked = i })
+
+    // Check if Pulsar is running as Admin. To know if the user can modify the machine path
+    WinShell.runningAsAdmin((i) => { this.refs.addToPathMachineCheckbox.disabled = !i })
   }
 
   destroy () {
@@ -102,15 +106,35 @@ export default class SystemPanel {
                       <label for='system.windows.add-to-path'>
                         <input
                           ref='addToPathCheckbox'
-                            id='system.windows.add-to-path'
-                            className='input-checkbox'
-                            type='checkbox'
-                            onclick={(e) => {
-                              this.setRegistration(WinShell.path, e.target.checked)
-                            }} />
+                          id='system.windows.add-to-path'
+                          className='input-checkbox'
+                          type='checkbox'
+                          onclick={(e) => {
+                            this.setRegistration(WinShell.pathUser, e.target.checked)
+                          }} />
                         <div className='setting-title'>Add Pulsar to PATH</div>
                         <div className='setting-description'>
                           Add Pulsar to Windows PATH to enable CLI usage.
+                        </div>
+                      </label>
+                    </div>
+                  </div>
+                </div>
+                <div className='control-group'>
+                  <div className='controls'>
+                    <div className='checkbox'>
+                      <label for='system.windows.add-to-path-machine'>
+                        <input
+                          ref='addToPathMachineCheckbox'
+                          id='system.windows.add-to-path-machine'
+                          className='input-checkbox'
+                          type='checkbox'
+                          onclick={(e) => {
+                            this.setRegistration(WinShell.pathMachine, e.target.checked)
+                          }} />
+                        <div className='setting-title'>Add Pulsar to PATH (Machine Install)</div>
+                        <div className='setting-description'>
+                          Add Pulsar to Windows PATH for Machine Installs. Requires Administrative Privileges.
                         </div>
                       </label>
                     </div>

--- a/resources/win/installer.nsh
+++ b/resources/win/installer.nsh
@@ -1,23 +1,15 @@
 !macro customInstall
   # Set the 'InstallLocation' Registry Key for GitHub Desktop
   WriteRegStr SHELL_CONTEXT "${UNINSTALL_REGISTRY_KEY}" "InstallLocation" "$INSTDIR"
-  # Add Pulsar to the PATH, depending on if this is user install or machine
-  ${if} $installMode === "all"
-    # Machine Install
-    ExecWait "powershell -ExecutionPolicy Bypass -WindowStyle Hidden -File .\modifyWindowsPath.ps1 -installMode Machine -installdir $INSTDIR -remove 0"
-  ${else}
-    # User Install
-    ExecWait "powershell -ExecutionPolicy Bypass -WindowStyle Hidden -File .\modifyWindowsPath.ps1 -installMode User -installdir $INSTDIR -remove 0"
-  ${endif}
 !macroend
 
-!macro customUninstall
+!macro customUnInstall
   # This uninstall script is ready to go. Just a question if we want to modify PATH on uninstall
-  ${if} $installMode === "all"
+  ${if} $installMode == "all"
     # Machine Install
-    ExecWait "powershell -ExecutionPolicy Bypass -WindowStyle Hidden -File .\modifyWindowsPath.ps1 -installMode Machine -installdir $INSTDIR -remove 1"
+    #ExecWait 'powershell -ExecutionPolicy Bypass -WindowStyle Hidden -File "$INSTDIR\resources\modifyWindowsPath.ps1" -installMode Machine -installdir "$INSTDIR" -remove 1'
   ${else}
     # User Install
-    ExecWait "powershell -ExecutionPolicy Bypass -WindowStyle Hidden -File .\modifyWindowsPath.ps1 -installMode User -installdir $INSTDIR -remove 1"
+    #ExecWait 'powershell -ExecutionPolicy Bypass -WindowStyle Hidden -File "$INSTDIR\resources\modifyWindowsPath.ps1" -installMode User -installdir "$INSTDIR" -remove 1'
   ${endif}
 !macroend

--- a/resources/win/installer.nsh
+++ b/resources/win/installer.nsh
@@ -1,0 +1,23 @@
+!macro customInstall
+  # Set the 'InstallLocation' Registry Key for GitHub Desktop
+  WriteRegStr SHELL_CONTEXT "${UNINSTALL_REGISTRY_KEY}" "InstallLocation" "$INSTDIR"
+  # Add Pulsar to the PATH, depending on if this is user install or machine
+  ${if} $installMode === "all"
+    # Machine Install
+    ExecWait "powershell -ExecutionPolicy Bypass -WindowStyle Hidden -File .\modifyWindowsPath.ps1 -installMode Machine -installdir $INSTDIR -remove 0"
+  ${else}
+    # User Install
+    ExecWait "powershell -ExecutionPolicy Bypass -WindowStyle Hidden -File .\modifyWindowsPath.ps1 -installMode User -installdir $INSTDIR -remove 0"
+  ${endif}
+!macroend
+
+!macro customUninstall
+  # This uninstall script is ready to go. Just a question if we want to modify PATH on uninstall
+  ${if} $installMode === "all"
+    # Machine Install
+    ExecWait "powershell -ExecutionPolicy Bypass -WindowStyle Hidden -File .\modifyWindowsPath.ps1 -installMode Machine -installdir $INSTDIR -remove 1"
+  ${else}
+    # User Install
+    ExecWait "powershell -ExecutionPolicy Bypass -WindowStyle Hidden -File .\modifyWindowsPath.ps1 -installMode User -installdir $INSTDIR -remove 1"
+  ${endif}
+!macroend

--- a/resources/win/modifyWindowsPath.ps1
+++ b/resources/win/modifyWindowsPath.ps1
@@ -1,0 +1,28 @@
+# This is all handled within a PowerShell file to avoid length limits within NSIS Scripts
+# And to avoid having to include plugins for NSIS, PowerShell can do this natively
+
+# -remove 0 is FALSE | -remove 1 is TRUE
+param ($installMode,$installdir,[boolean]$remove=$false)
+
+if (-not $remove) {
+  if ($installMode -eq "User" -or $installMode -eq "Machine") {
+    [Environment]::SetEnvironmentVariable("Path", $env:Path + ";$installdir\resources;$installdir\resources\app\ppm\bin", $installMode)
+  }
+  # Now only add the ATOM_HOME env var if a user install, since we don't have a plan
+  # on it's location for a machine install
+  if ($installMode -eq "User") {
+    [Environment]::SetEnvironmentVariable("ATOM_HOME", "$env:USERPROFILE\.pulsar", "User")
+  }
+} else {
+  if ($installMode -eq "User" -or $installMode -eq "Machine") {
+    $path = [Environment]::GetEnvironmentVariable("PATH", $installMode)
+    # Remove unwanted element from path
+    $path = ($path.Split(";") | Where-Object { $_ -ne "$installdir\resources" }) -join ";"
+    $path = ($path.Split(";") | Where-Object { $_ -ne "$installdir\resources\app\ppm\bin" }) -join ";"
+    # Set our new path
+    [Environment]::SetEnvironmentVariable("Path", $path, $installMode)
+  } # Else we have been given bad params, and will silently exit
+  if ($installMode -eq "User") {
+    [Environment]::SetEnvironmentVariable("ATOM_HOME", $null, "User")
+  }
+}

--- a/resources/win/modifyWindowsPath.ps1
+++ b/resources/win/modifyWindowsPath.ps1
@@ -1,17 +1,23 @@
-# This is all handled within a PowerShell file to avoid length limits within NSIS Scripts
-# And to avoid having to include plugins for NSIS, PowerShell can do this natively
+# Modify Windows PATH for Pulsar
+# Sets Pulsar & PPM into PATH, adds 'ATOM_HOME' env var
 
-# -remove 0 is FALSE | -remove 1 is TRUE
+# Example Usage:
+# Pulsar User Installation:
+# .\_.ps1 -installMode User -installdir "$INSTDIR" -remove 0
+# Pulsar Machine Installation:
+# .\_.ps1 -installMode Machine -installdir "$INSTDIR" -remove 0
+# Pulsar User Uninstallation:
+# .\_.ps1 -installMode User -installdir "$INSTDIR" -remove 1
+# Pulsar Machine Uninstallation:
+# .\_.ps1 -installMode Machine -installdir "$INSTDIR" -remove 1
+
 param ($installMode,$installdir,[boolean]$remove=$false)
 
 if (-not $remove) {
   if ($installMode -eq "User" -or $installMode -eq "Machine") {
     [Environment]::SetEnvironmentVariable("Path", $env:Path + ";$installdir\resources;$installdir\resources\app\ppm\bin", $installMode)
-  }
-  # Now only add the ATOM_HOME env var if a user install, since we don't have a plan
-  # on it's location for a machine install
-  if ($installMode -eq "User") {
-    [Environment]::SetEnvironmentVariable("ATOM_HOME", "$env:USERPROFILE\.pulsar", "User")
+    # By using '%USERPROFILE%' this will work either for User installs or Machine
+    [Environment]::SetEnvironmentVariable("ATOM_HOME", "%USERPROFILE%\.pulsar", $installMode)
   }
 } else {
   if ($installMode -eq "User" -or $installMode -eq "Machine") {
@@ -21,8 +27,7 @@ if (-not $remove) {
     $path = ($path.Split(";") | Where-Object { $_ -ne "$installdir\resources\app\ppm\bin" }) -join ";"
     # Set our new path
     [Environment]::SetEnvironmentVariable("Path", $path, $installMode)
+    # Set ATOM_HOME path
+    [Environment]::SetEnvironmentVariable("ATOM_HOME", $null, $installMode)
   } # Else we have been given bad params, and will silently exit
-  if ($installMode -eq "User") {
-    [Environment]::SetEnvironmentVariable("ATOM_HOME", $null, "User")
-  }
 }

--- a/resources/win/modifyWindowsPath.ps1
+++ b/resources/win/modifyWindowsPath.ps1
@@ -57,12 +57,12 @@ if (-not $remove) {
     # the variable, and instead creates the directory of the same name
     # within the current folder. But only when opened via the context menu, terminal
     # is fine.
-    [Environment]::SetEnvironmentVariable("ATOM_HOME", "$env:UserProfile\.pulsar", $installMode)
+    $exitCode = [Environment]::SetEnvironmentVariable("ATOM_HOME", "$env:UserProfile\.pulsar", $installMode)
 
     $prog = 100
     Write-Progress -Activity "Modifying Pulsar ($installdir) on the PATH..." -Status "$prog% Complete:" -PercentComplete $prog
 
-    Exit $?
+    Exit $exitCode
   }
 } else {
   if ($installMode -eq "User" -or $installMode -eq "Machine") {
@@ -89,11 +89,11 @@ if (-not $remove) {
     Write-Progress -Activity "Modifying Pulsar ($installdir) on the PATH..." -Status "$prog% Complete:" -PercentComplete $prog
 
     # Set ATOM_HOME path
-    [Environment]::SetEnvironmentVariable("ATOM_HOME", $null, $installMode)
+    $exitCode = [Environment]::SetEnvironmentVariable("ATOM_HOME", $null, $installMode)
 
     $prog = 100
     Write-Progress -Activity "Modifying Pulsar ($installdir) on the PATH..." -Status "$prog% Complete:" -PercentComplete $prog
 
-    Exit $?
+    Exit $exitCode
   } # Else we have been given bad params, and will silently exit
 }

--- a/resources/win/modifyWindowsPath.ps1
+++ b/resources/win/modifyWindowsPath.ps1
@@ -11,23 +11,89 @@
 # Pulsar Machine Uninstallation:
 # .\_.ps1 -installMode Machine -installdir "$INSTDIR" -remove 1
 
-param ($installMode,$installdir,[boolean]$remove=$false)
+param ($installMode,$installdir,$remove)
+
+# When self-elevating, we can't pass a raw boolean. Meaning we accept anything then convert
+$remove = [System.Convert]::ToBoolean($remove)
+
+# Only when modifying the Machine PATH, it takes much longer than expected. So here's a loading bar
+$prog = 1
+Write-Progress -Activity "Modifying Pulsar ($installdir) on the PATH..." -Status "$prog% Complete:" -PercentComplete $prog
+
+if ($installMode -eq "Machine") {
+  # PowerShell needs to be running as Admin to modify the Machine Variables
+  # So lets attempt to self-elevate
+  if (-Not ([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole] 'Administrator')) {
+    if ([int](Get-CimInstance -Class Win32_OperatingSystem | Select-Object -ExpandProperty BuildNumber) -ge 6000) {
+
+      $processOptions = @{
+        FilePath = "PowerShell.exe"
+        Wait = $true
+        PassThru = $true
+        Verb = "RunAs"
+        ArgumentList = "-File `"" + $MyInvocation.MyCommand.Path + "`" -installMode $installMode -installdir `"" + $installdir + "`" -remove $remove"
+      }
+
+      Start-Process @processOptions
+
+      Exit
+    }
+  }
+}
 
 if (-not $remove) {
   if ($installMode -eq "User" -or $installMode -eq "Machine") {
+
+    $prog = 25
+    Write-Progress -Activity "Modifying Pulsar ($installdir) on the PATH..." -Status "$prog% Complete:" -PercentComplete $prog
+
     [Environment]::SetEnvironmentVariable("Path", $env:Path + ";$installdir\resources;$installdir\resources\app\ppm\bin", $installMode)
-    # By using '%USERPROFILE%' this will work either for User installs or Machine
-    [Environment]::SetEnvironmentVariable("ATOM_HOME", "%USERPROFILE%\.pulsar", $installMode)
+
+    $prog = 50
+    Write-Progress -Activity "Modifying Pulsar ($installdir) on the PATH..." -Status "$prog% Complete:" -PercentComplete $prog
+
+    # While this originally attempting to use the string '%USERPROFILE%' to avoid taking
+    # space on the PATH, whatever reads this path at startup in Pulsar, can't handle
+    # the variable, and instead creates the directory of the same name
+    # within the current folder. But only when opened via the context menu, terminal
+    # is fine.
+    [Environment]::SetEnvironmentVariable("ATOM_HOME", "$env:UserProfile\.pulsar", $installMode)
+
+    $prog = 100
+    Write-Progress -Activity "Modifying Pulsar ($installdir) on the PATH..." -Status "$prog% Complete:" -PercentComplete $prog
+
+    Exit $?
   }
 } else {
   if ($installMode -eq "User" -or $installMode -eq "Machine") {
-    $path = [Environment]::GetEnvironmentVariable("PATH", $installMode)
+
+    $prog = 25
+    Write-Progress -Activity "Modifying Pulsar ($installdir) on the PATH..." -Status "$prog% Complete:" -PercentComplete $prog
+
+    $path = [Environment]::GetEnvironmentVariable("Path", $installMode)
+
+    $prog = 50
+    Write-Progress -Activity "Modifying Pulsar ($installdir) on the PATH..." -Status "$prog% Complete:" -PercentComplete $prog
+
     # Remove unwanted element from path
     $path = ($path.Split(";") | Where-Object { $_ -ne "$installdir\resources" }) -join ";"
     $path = ($path.Split(";") | Where-Object { $_ -ne "$installdir\resources\app\ppm\bin" }) -join ";"
+
+    $prog = 75
+    Write-Progress -Activity "Modifying Pulsar ($installdir) on the PATH..." -Status "$prog% Complete:" -PercentComplete $prog
+
     # Set our new path
     [Environment]::SetEnvironmentVariable("Path", $path, $installMode)
+
+    $prog = 90
+    Write-Progress -Activity "Modifying Pulsar ($installdir) on the PATH..." -Status "$prog% Complete:" -PercentComplete $prog
+
     # Set ATOM_HOME path
     [Environment]::SetEnvironmentVariable("ATOM_HOME", $null, $installMode)
+
+    $prog = 100
+    Write-Progress -Activity "Modifying Pulsar ($installdir) on the PATH..." -Status "$prog% Complete:" -PercentComplete $prog
+
+    Exit $?
   } # Else we have been given bad params, and will silently exit
 }

--- a/script/electron-builder.js
+++ b/script/electron-builder.js
@@ -213,6 +213,10 @@ let options = {
         "from": "resources/win/pulsar.js",
         "to": "pulsar.js"
       },
+      {
+        "from": "resources/win/modifyWindowsPath.ps1",
+        "to": "modifyWindowsPath.ps1"
+      }
     ],
     "target": [
       { "target": "nsis" },
@@ -227,11 +231,12 @@ let options = {
     "runAfterFinish": true,
     "createDesktopShortcut": true,
     "createStartMenuShortcut": true,
-    "guid": "0949b555-c22c-56b7-873a-a960bdefa81f"
+    "guid": "0949b555-c22c-56b7-873a-a960bdefa81f",
     // The GUID is generated from Electron-Builder based on our AppID
     // Hardcoding it here means it will always be used as generated from
     // the AppID 'dev.pulsar-edit.pulsar'. If this value ever changes,
     // A PR to GitHub Desktop must be made with the updated value
+    "include": "resources/win/installer.nsh"
   },
   "extraMetadata": {
   },

--- a/src/main-process/win-shell.js
+++ b/src/main-process/win-shell.js
@@ -87,6 +87,8 @@ class PathOption {
     // So we will pretend a user install is all that matters here
     this.isRegistered = this.isRegistered.bind(this);
     this.register = this.register.bind(this);
+    this.deregister = this.deregister.bind(this);
+    this.getPulsarPath = this.getPulsarPath.bind(this);
   }
 
   isRegistered(callback) {
@@ -109,9 +111,9 @@ class PathOption {
             }
           }
         }
+        callback(isUserInstalled);
       }
     });
-    return isUserInstalled;
   }
 
   register(callback) {
@@ -119,6 +121,7 @@ class PathOption {
       const child = ChildProcess.execFile(
           `${pulsarPath}\\resources\\modifyWindowsPath.ps1`,
           ['-installMode', 'User', '-installdir', `"${pulsarPath}"`, '-remove', '0'],
+          { shell: "powershell.exe" },
           (error, stdout, stderr) =>
           {
         if (error) {
@@ -139,6 +142,7 @@ class PathOption {
           const child = ChildProcess.execFile(
               `${pulsarPath}\\resources\\modifyWindowsPath.ps1`,
               ['-installMode', 'User', '-installdir', `"${pulsarPath}"`, '-remove', '1'],
+              { shell: "powershell.exe" },
               (error, stdout, stderr) =>
               {
             if (error) {

--- a/src/main-process/win-shell.js
+++ b/src/main-process/win-shell.js
@@ -115,42 +115,40 @@ class PathOption {
   }
 
   register(callback) {
-    let {err, pulsarPath} = this.getPulsarPath();
-    if (err) {
-      return callback(err)
-    }
-
-    const child = ChildProcess.execFile(
-        `${pulsarPath}\\resources\\modifyWindowsPath.ps1`,
-        ['-installMode', 'User', '-installdir', `"${pulsarPath}"`, '-remove', '0'],
-        (error, stdout, stderr) =>
-        {
-      if (error) {
-        callback(error);
-      } else {
-        return callback();
-      }
+    this.getPulsarPath().then((pulsarPath) => {
+      const child = ChildProcess.execFile(
+          `${pulsarPath}\\resources\\modifyWindowsPath.ps1`,
+          ['-installMode', 'User', '-installdir', `"${pulsarPath}"`, '-remove', '0'],
+          (error, stdout, stderr) =>
+          {
+        if (error) {
+          callback(error);
+        } else {
+          return callback();
+        }
+      });
+    }).catch((err) => {
+      return callback(err);
     });
   }
 
   deregister(callback) {
     this.isRegistered(isRegistered => {
       if (isRegistered) {
-        let {err, pulsarPath} = this.getPulsarPath();
-        if (err) {
+        this.getPulsarPath().then((pulsarPath) => {
+          const child = ChildProcess.execFile(
+              `${pulsarPath}\\resources\\modifyWindowsPath.ps1`,
+              ['-installMode', 'User', '-installdir', `"${pulsarPath}"`, '-remove', '1'],
+              (error, stdout, stderr) =>
+              {
+            if (error) {
+              callback(error);
+            } else {
+              return callback();
+            }
+          });
+        }).catch((err) => {
           return callback(err);
-        }
-
-        const child = ChildProcess.execFile(
-            `${pulsarPath}\\resources\\modifyWindowsPath.ps1`,
-            ['-installMode', 'User', '-installdir', `"${pulsarPath}"`, '-remove', '1'],
-            (error, stdout, stderr) =>
-            {
-          if (error) {
-            callback(error);
-          } else {
-            return callback();
-          }
         });
       } else {
         callback(null, false);
@@ -159,23 +157,24 @@ class PathOption {
   }
 
   getPulsarPath() {
-    let pulsarPath;
-    let pulsarPathReg = new Registry({
-      hive: "HKCU",
-      key: this.HKCUInstallReg
-    }).get("InstallLocation", (err, val) => {
-      if (err) {
-        return {err, null};
-      } else {
-        pulsarPath = val.value;
-      }
+    return new Promise((resolve, reject) => {
+      let pulsarPath = "";
+      let pulsarPathReg = new Registry({
+        hive: "HKCU",
+        key: this.HKCUInstallReg
+      }).get("InstallLocation", (err, val) => {
+        if (err) {
+          reject(err);
+        } else {
+          pulsarPath = val.value;
+
+          if (pulsarPath.length === 0) {
+            reject("Unable to find Pulsar Install Path");
+          }
+          resolve(pulsarPath);
+        }
+      });
     });
-
-    if (pulsarPath.length === 0) {
-      return {"Unable to find Pulsar Install Path", null};
-    }
-
-    return {null, pulsarPath};
   }
 }
 

--- a/src/main-process/win-shell.js
+++ b/src/main-process/win-shell.js
@@ -136,14 +136,13 @@ class PathOption {
           (error, stdout, stderr) =>
           {
         if (error) {
-          atom.notifications.addError(error.toString());
+          atom.notifications.addError(`Error Running Script: ${error.toString()}`);
           callback(error);
         } else {
           return callback();
         }
       });
     }).catch((err) => {
-      atom.notifications.addError(err.toString());
       return callback(err);
     });
   }
@@ -159,14 +158,13 @@ class PathOption {
               (error, stdout, stderr) =>
               {
             if (error) {
-              atom.notifications.addError(error.toString());
+              atom.notifications.addError(`Error Running Script: ${error.toString()}`);
               callback(error);
             } else {
               return callback();
             }
           });
         }).catch((err) => {
-          atom.notifications.addError(err.toString());
           return callback(err);
         });
       } else {


### PR DESCRIPTION
Alright, so while this PR initially aimed to solve one thing, I've ended up taking the time to make many of the improvements I've wanted to see on Windows for a while now.

## What this PR Does 

### During Installation

Now during installation, we use a custom NSIS script that will set the `InstallLocation` into the registry, which allows our GitHub Desktop Integration working.

### Within Settings 

Now within settings on the familiar "System" page, underneath the options:

  - Register as file handler 
  - Show in file context menus
  - Show in folder context menus

We will now show: "Add Pulsar to PATH"

Technically, there are two versions of this button that will appear. Since Pulsar can be installed two ways on windows, either under the User account or Machine account. So when this page loads Pulsar will quickly check if it believes this was a user installation and if so show "Add Pulsar to PATH (User)" but if it doesn't think it's a user install, Pulsar will instead show "Add Pulsar to PATH (Machine)" which the user can only click if Pulsar is open as an administrator, which is required to be able to make those changes.

The additional functionality to handle this has been placed within `./main-process/win-shell.js` along with the rest of the handling for this page. Creating a new class `PathOption` that assists in setting and unsetting these values on the PATH.

Since of course there's issues with setting the PATH directly within the registry, this function will now callout to the included PowerShell script on Windows that can modify the PATH safely. 

This now means that GitHub Desktop should work for all users, and within Windows there's a very easy way for users to add or remove Pulsar, PPM, and the `ATOM_HOME` value from their PATH.

---

One note all of this has made me think about, is in #274 there are concerns about some registry edits not being removed on an uninstall. Do we possibly want to build in some functionality to do a total cleanup of Pulsar on uninstall? This would mean removing Pulsar, PPM, ATOM_HOME from the Path, (and user environment variables) as well as removing Pulsar from the file/folder context menu, and as a file handler.

This is possible, would just need to be explicit if this is something we wanted to pursue.

The last note I'd like to make here, is since we can't access the machine variables within the registry, unless Pulsar is launched as Administrator on Windows, we can't set any of these variables as the machine user. We could add a second checkbox to accomplish this, that informs Pulsar must be relaunched as admin, or otherwise I don't think it's the biggest issue if we can't.

---

EDIT: Relates to #565 