### PR TITLE
[language-toml]: Allow spaces within Array

### DIFF
--- a/packages/language-toml/grammars/toml.cson
+++ b/packages/language-toml/grammars/toml.cson
@@ -95,11 +95,11 @@
   'values':
     'patterns': [
       {
-        'begin': '\\['
+        'begin': '\\[\\s*'
         'beginCaptures':
           '0':
             'name': 'punctuation.definition.array.begin.toml'
-        'end': '\\]'
+        'end': '\\s*\\]'
         'endCaptures':
           '0':
             'name': 'punctuation.definition.array.end.toml'
@@ -108,7 +108,7 @@
             'include': '#comment'
           }
           {
-            'match': ','
+            'match': ',\\s*'
             'name': 'punctuation.definition.separator.comma.toml'
           }
           {


### PR DESCRIPTION
This PR works to fix our `language-toml` TextMate grammar. The changes here are simplistic intentionally, since a much better fix is in the works to get more aspects of `language-toml` working for the long run. 

But at the very least this fix can allow people to work within `language-toml` files in the meantime.

Resolves #574 

![image](https://github.com/pulsar-edit/pulsar/assets/26921489/64abb6ad-db49-44e7-9428-96240ccd1ab1)

---

Some bonus details on why this solution isn't amazing but works.
Essentially, the complexity of the grammar file itself is obviously the collection of all the elements. But because spacing and newlines seem to be handled by the top level patterns, that leaves the array inclusion list rather short, and seemingly the raw value handling of everything within didn't account for any spacing. The spacing seemed to be handled within the key value pair patterns. So since the only place this should occur as an issue is within an array, I've thought it'd work well enough to add the space handling to points in the array pattern, such as after `[ `, before ` ]`, and after `, `