### PR TITLE
[core]: Bump `less-cache` to `v2.0.0` Upgrades `less` to `4.1.3`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ## [Unreleased]
 
+- Bumped `less-cache` to `v2.0.0` which uses `less@4.1.3`. This adds many new features of Less, while causing breaking changes to existing Less StyleSheets. Read more about these changes [here](https://github.com/pulsar-edit/less-cache/releases/tag/v2.0.0).
+
 ## 1.106.0
 
 - Fixed bug that happens on some systems when trying to launch Pulsar using the Cinnamon desktop environment

--- a/package.json
+++ b/package.json
@@ -122,7 +122,7 @@
     "language-typescript": "file:packages/language-typescript",
     "language-xml": "file:packages/language-xml",
     "language-yaml": "file:packages/language-yaml",
-    "less-cache": "1.1.0",
+    "less-cache": "pulsar-edit/less-cache#v2.0.0",
     "line-ending-selector": "file:packages/line-ending-selector",
     "line-top-index": "0.3.1",
     "link": "file:packages/link",

--- a/packages/about/styles/about.less
+++ b/packages/about/styles/about.less
@@ -102,7 +102,7 @@
   align-items: center;
   padding: @component-padding;
   border: 1px solid @base-border-color;
-  border-radius: @component-border-radius * 2;
+  border-radius: (@component-border-radius * 2);
   background-color: @background-color-highlight;
 }
 

--- a/packages/atom-dark-ui/styles/editor.less
+++ b/packages/atom-dark-ui/styles/editor.less
@@ -4,7 +4,7 @@ atom-text-editor[mini] {
   border: 1px solid @input-border-color;
   box-shadow: inset 0 1px 1px rgba(0, 0, 0, .075);
   border-radius: @component-border-radius;
-  padding-left: @component-padding/2;
+  padding-left: (@component-padding/2);
 
   .cursor { border-color: #fff; }
   .selection .region { background-color: lighten(@input-background-color, 10%); }

--- a/packages/atom-dark-ui/styles/lists.less
+++ b/packages/atom-dark-ui/styles/lists.less
@@ -91,16 +91,16 @@
 .select-list.popover-list {
   background-color: @overlay-background-color;
   box-shadow: 0 0 10px @base-border-color;
-  padding: @component-padding/2;
+  padding: (@component-padding/2);
   border-radius: @component-border-radius;
   border: 1px solid @overlay-border-color;
 
   atom-text-editor {
-    margin-bottom: @component-padding/2;
+    margin-bottom: (@component-padding/2);
   }
 
   .list-group li {
-    padding-left: @component-padding/2;
+    padding-left: (@component-padding/2);
   }
 }
 

--- a/packages/atom-dark-ui/styles/overlays.less
+++ b/packages/atom-dark-ui/styles/overlays.less
@@ -19,7 +19,7 @@ atom-panel.modal, .overlay {
       padding: @component-padding;
       border-bottom: 1px solid @overlay-background-color;
 
-      &.two-lines { padding: @component-padding/2 @component-padding; }
+      &.two-lines { padding: (@component-padding/2) @component-padding; }
 
       .status.icon {
         float: right;

--- a/packages/atom-dark-ui/styles/tabs.less
+++ b/packages/atom-dark-ui/styles/tabs.less
@@ -8,7 +8,7 @@
 @tab-max-width: 160px;
 
 .tab-bar {
-  height: @tab-height + @tab-top-padding + @tab-bottom-border-height;
+  height: (@tab-height + @tab-top-padding + @tab-bottom-border-height);
   background: @tab-bar-background-color;
   box-shadow: inset 0 -8px 8px -4px rgba(0,0,0, .15);
   padding: 0 10px 0 25px;
@@ -75,7 +75,7 @@
 
     &.modified:not(:hover) .close-icon {
       right: 0;
-      top: @tab-height/2 - @modified-icon-width/2 + 1px;
+      top: (@tab-height/2 - @modified-icon-width/2 + 1px);
       width: @modified-icon-width;
       height: @modified-icon-width;
     }
@@ -99,13 +99,13 @@
     box-shadow: inset -1px 1px 0 @tab-border-color, 4px -4px 4px rgba(0,0,0,.1);
 
     .close-icon {
-      line-height: @tab-height - 1px;
+      line-height: (@tab-height - 1px);
       color: @text-color;
     }
 
     &, &:before, &:after {
       background-image: -webkit-linear-gradient(top, lighten(@tab-background-color-active, 7%), @tab-background-color-active);
-      height: @tab-height + 1px;
+      height: (@tab-height + 1px);
     }
 
     &:before {
@@ -130,13 +130,13 @@
   }
 
   .placeholder {
-    height: @tab-height + @tab-top-padding + @tab-bottom-border-height;
+    height: (@tab-height + @tab-top-padding + @tab-bottom-border-height);
     pointer-events: none;
     &:before {
       margin-left: -9px; // center between tabs
     }
     &:after {
-      top: @tab-height + @tab-top-padding + @tab-bottom-border-height - 2px;
+      top: (@tab-height + @tab-top-padding + @tab-bottom-border-height - 2px);
       margin-left: -10px; // center between tabs
     }
   }

--- a/packages/atom-dark-ui/styles/utilities.less
+++ b/packages/atom-dark-ui/styles/utilities.less
@@ -8,8 +8,8 @@
   border-radius: @component-border-radius;
   margin-left: @component-icon-padding;
   font-family: Helvetica, Arial, sans-serif;
-  font-size: @font-size - 1px;
-  padding: @component-padding / 2;
+  font-size: (@font-size - 1px);
+  padding: (@component-padding / 2);
 }
 
 .badge {

--- a/packages/atom-light-ui/styles/editor.less
+++ b/packages/atom-light-ui/styles/editor.less
@@ -5,7 +5,7 @@ atom-text-editor[mini] {
 
   box-shadow: inset 0 1px 1px rgba(0, 0, 0, .075);
   border-radius: @component-border-radius;
-  padding-left: @component-padding/2;
+  padding-left: (@component-padding/2);
 
   .cursor { border-color: #000; }
   .selection .region { background-color: rgba(0, 0, 0, .2); }

--- a/packages/atom-light-ui/styles/lists.less
+++ b/packages/atom-light-ui/styles/lists.less
@@ -90,16 +90,16 @@
 .select-list.popover-list {
   background-color: @overlay-background-color;
   box-shadow: 0 0 10px @base-border-color;
-  padding: @component-padding/2;
+  padding: (@component-padding/2);
   border-radius: @component-border-radius;
   border: 1px solid @overlay-border-color;
 
   atom-text-editor {
-    margin-bottom: @component-padding/2;
+    margin-bottom: (@component-padding/2);
   }
 
   .list-group li {
-    padding-left: @component-padding/2;
+    padding-left: (@component-padding/2);
   }
 }
 

--- a/packages/atom-light-ui/styles/overlays.less
+++ b/packages/atom-light-ui/styles/overlays.less
@@ -22,7 +22,7 @@ atom-panel.modal, .overlay {
       border-right: 1px solid @inset-panel-border-color;
       &:last-child { border-bottom: 1px solid @inset-panel-border-color; }
 
-      &.two-lines { padding: @component-padding/2 @component-padding; }
+      &.two-lines { padding: (@component-padding/2) @component-padding; }
       &.selected {
         color: @text-color;
         background-color: @background-color-highlight;

--- a/packages/atom-light-ui/styles/panels.less
+++ b/packages/atom-light-ui/styles/panels.less
@@ -40,7 +40,7 @@ atom-panel, .tool-panel {
 
 .panel-heading {
   border-bottom: none;
-  padding: @component-padding - 2px @component-padding;
+  padding: (@component-padding - 2px) @component-padding;
 
   background-color: transparent;
   background-image: -webkit-linear-gradient(@panel-heading-background-color, darken(@panel-heading-background-color, 10%));

--- a/packages/atom-light-ui/styles/tabs.less
+++ b/packages/atom-light-ui/styles/tabs.less
@@ -8,7 +8,7 @@
 @tab-max-width: 160px;
 
 .tab-bar {
-  height: @tab-height + @tab-top-padding + @tab-bottom-border-height;
+  height: (@tab-height + @tab-top-padding + @tab-bottom-border-height);
   background-image: -webkit-linear-gradient(top, @tab-bar-background-color, lighten(@tab-bar-background-color, 9%));
   box-shadow: inset 0 -8px 8px -4px rgba(0,0,0, .15);
   padding: 0 10px 0 25px;
@@ -77,7 +77,7 @@
 
     &.modified:not(:hover) .close-icon {
       right: 0;
-      top: @tab-height/2 - @modified-icon-width/2 + 1px;
+      top: (@tab-height/2 - @modified-icon-width/2 + 1px);
       width: @modified-icon-width;
       height: @modified-icon-width;
     }
@@ -89,8 +89,8 @@
     .title {
       position: relative;
       z-index: 1;
-      margin-top: -@tab-top-padding - 1px;
-      padding-top: @tab-top-padding + 1px;
+      margin-top: (-@tab-top-padding - 1px);
+      padding-top: (@tab-top-padding + 1px);
       padding-right: 10px;
     }
   }
@@ -100,13 +100,13 @@
     color: @text-color-highlight;
 
     .close-icon {
-      line-height: @tab-height - 1px;
+      line-height: (@tab-height - 1px);
       color: @text-color;
     }
 
     &, &:before, &:after {
       background: @tab-background-color-active;
-      height: @tab-height + 1px;
+      height: (@tab-height + 1px);
       box-shadow: none;
     }
   }
@@ -124,13 +124,13 @@
   }
 
   .placeholder {
-    height: @tab-height + @tab-top-padding + @tab-bottom-border-height;
+    height: (@tab-height + @tab-top-padding + @tab-bottom-border-height);
     pointer-events: none;
     &:before {
       margin-left: -9px; // center between tabs
     }
     &:after {
-      top: @tab-height + @tab-top-padding + @tab-bottom-border-height - 2px;
+      top: (@tab-height + @tab-top-padding + @tab-bottom-border-height - 2px);
       margin-left: -10px; // center between tabs
     }
   }

--- a/packages/atom-light-ui/styles/utilities.less
+++ b/packages/atom-light-ui/styles/utilities.less
@@ -7,8 +7,8 @@
   border-radius: @component-border-radius;
   margin-left: @component-icon-padding;
   font-family: Helvetica, Arial, sans-serif;
-  font-size: @font-size - 1px;
-  padding: @component-padding / 2;
+  font-size: (@font-size - 1px);
+  padding: (@component-padding / 2);
 }
 
 .badge {

--- a/packages/autocomplete-plus/styles/autocomplete.less
+++ b/packages/autocomplete-plus/styles/autocomplete.less
@@ -42,7 +42,7 @@ autocomplete-suggestion-list.select-list.popover-list {
   }
 
   .suggestion-description-content {
-    font-size: @font-size + 1px;
+    font-size: (@font-size + 1px);
     font-family: @font-family;
     max-height: 33vh;
     display: block;
@@ -51,7 +51,7 @@ autocomplete-suggestion-list.select-list.popover-list {
   }
 
   .suggestion-description-more-link {
-    font-size: @font-size + 1px;
+    font-size: (@font-size + 1px);
     font-family: @font-family;
     color: @text-color-info;
   }

--- a/packages/background-tips/styles/background-tips.less
+++ b/packages/background-tips/styles/background-tips.less
@@ -19,7 +19,7 @@ background-tips {
     cursor: default;
 
     .message {
-      padding: 0 @component-padding*3;
+      padding: 0 (@component-padding*3);
       opacity: 0;
       transition: opacity .3s ease-in-out;
       &.fade-in {
@@ -28,8 +28,8 @@ background-tips {
 
       .keystroke {
         border: 2px solid;
-        padding: 0 @component-padding/2;
-        border-radius: @component-border-radius * 3;
+        padding: 0 (@component-padding/2);
+        border-radius: (@component-border-radius * 3);
         font-family: "Helvetica Neue", Arial, sans-serif;
       }
     }

--- a/packages/find-and-replace/styles/find-and-replace.less
+++ b/packages/find-and-replace/styles/find-and-replace.less
@@ -40,16 +40,16 @@ atom-workspace.find-visible {
   @min-width: 200px; // min width before it starts scrolling
 
   -webkit-user-select: none;
-  padding: @component-padding/2;
+  padding: (@component-padding/2);
   overflow-x: auto;
 
   .header {
-    padding: @component-padding/4 @component-padding/2;
+    padding: (@component-padding/4) (@component-padding/2);
     min-width: @min-width;
     line-height: 1.75;
   }
   .header-item {
-    margin: @component-padding/4 0;
+    margin: (@component-padding/4) 0;
   }
 
   .input-block {
@@ -61,7 +61,7 @@ atom-workspace.find-visible {
   .input-block-item {
     display: flex;
     flex: 1;
-    padding: @component-padding / 2;
+    padding: (@component-padding / 2);
   }
 
   .btn-group {
@@ -170,7 +170,7 @@ atom-workspace.find-visible {
     position: absolute;
     top: 1px;
     right: 0;
-    margin: @component-padding/2 @component-padding/2 0 0;
+    margin: (@component-padding/2) (@component-padding/2) 0 0;
     z-index: 2;
     font-size: .9em;
     line-height: @component-line-height;
@@ -182,7 +182,7 @@ atom-workspace.find-visible {
 }
 
 .find-wrap-icon {
-  @wrap-size: @font-size * 10;
+  @wrap-size: (@font-size * 10);
 
   opacity: 0;
   transition: opacity 0.5s;
@@ -197,16 +197,16 @@ atom-workspace.find-visible {
   right: initial !important;
   bottom: initial !important;
 
-  margin-top: @wrap-size * -0.5;
-  margin-left: @wrap-size * -0.5;
+  margin-top: (@wrap-size * -0.5);
+  margin-left: (@wrap-size * -0.5);
 
   background: fadeout(darken(@syntax-background-color, 4%), 55%);
-  border-radius: @component-border-radius * 2;
+  border-radius: (@component-border-radius * 2);
   text-align: center;
   pointer-events: none;
   &:before {
     // Octicons look best in sizes that are multiples of 16px
-    font-size: @wrap-size - mod(@wrap-size, 16px) - 32px;
+    font-size: (@wrap-size - mod(@wrap-size, 16px) - 32px);
     line-height: @wrap-size;
     height: @wrap-size;
     width: @wrap-size;
@@ -244,7 +244,7 @@ atom-workspace.find-visible {
   .preview-header {
     display: flex;
     flex-wrap: wrap;
-    padding: @component-padding/2;
+    padding: (@component-padding/2);
     align-items: center;
     justify-content: space-between;
     overflow: hidden;
@@ -254,14 +254,14 @@ atom-workspace.find-visible {
   }
 
   .preview-count {
-    margin: @component-padding/2;
+    margin: (@component-padding/2);
   }
 
   .preview-controls {
     display: flex;
     flex-wrap: wrap;
     .btn-group {
-      margin: @component-padding/2;
+      margin: (@component-padding/2);
     }
   }
 

--- a/packages/fuzzy-finder/styles/fuzzy-finder.less
+++ b/packages/fuzzy-finder/styles/fuzzy-finder.less
@@ -13,7 +13,7 @@
 
   &.has-avatar {
     // add some extra space for the avatar
-    padding-right: @size + (@component-padding * 2) !important;
+    padding-right: (@size + (@component-padding * 2)) !important;
   }
 
   &-avatar {

--- a/packages/markdown-preview/styles/markdown-preview-default.less
+++ b/packages/markdown-preview/styles/markdown-preview-default.less
@@ -37,7 +37,7 @@
   h1, h2, h3, h4, h5, h6 {
     line-height: 1.2;
     margin-top: @margin;
-    margin-bottom: @margin/3;
+    margin-bottom: (@margin/3);
     color: @fg-strong;
   }
 
@@ -105,7 +105,7 @@
   // HR --------------------
 
   hr {
-    margin: @margin*2 0;
+    margin: (@margin*2) 0;
     border-top: 2px dashed @border;
     background: none;
   }

--- a/packages/notifications/styles/notifications-log.less
+++ b/packages/notifications/styles/notifications-log.less
@@ -58,14 +58,14 @@
           bottom: 0;
           width: @icon-size;
           height: 100%;
-          padding-top: @component-padding/2;
+          padding-top: (@component-padding/2);
           text-align: center;
         }
 
         .message {
           flex: 0 1 auto;
           word-wrap: break-word;
-          padding: @component-padding/2 @component-padding;
+          padding: (@component-padding/2) @component-padding;
           border-left: 1px solid @base-border-color;
         }
 
@@ -81,7 +81,7 @@
 
           .btn-copy-report {
             vertical-align: middle;
-            margin-left: @component-padding/2;
+            margin-left: (@component-padding/2);
 
             &::before {
               margin: 0;

--- a/packages/notifications/styles/notifications.less
+++ b/packages/notifications/styles/notifications.less
@@ -6,7 +6,7 @@
 @width-detail: 450px;
 @max-height-message: 200px;
 @max-height-detail: 500px;
-@max-height: @max-height-message + @max-height-detail + 100px; // 100px for footer. This is only used for the closing animation
+@max-height: (@max-height-message + @max-height-detail + 100px); // 100px for footer. This is only used for the closing animation
 @notification-gap: 2px;
 @font-family-monospace: Consolas, "Liberation Mono", Menlo, Courier, monospace;
 
@@ -37,7 +37,7 @@ atom-notifications {
       display: block;
     }
     .message {
-      padding-right: @component-padding * 2 + 95px; // space for icon and button
+      padding-right: (@component-padding * 2 + 95px); // space for icon and button
     }
   }
 
@@ -49,7 +49,7 @@ atom-notifications {
       padding-right: inherit;
     }
     &.has-close .message {
-      padding-right: @component-padding + 24px; // space for icon
+      padding-right: (@component-padding + 24px); // space for icon
     }
   }
 
@@ -118,7 +118,7 @@ atom-notifications {
     }
 
     &.has-close .message {
-      padding-right: @component-padding + 24px; // space for icon
+      padding-right: (@component-padding + 24px); // space for icon
     }
 
     .content {

--- a/packages/one-dark-ui/styles/badges.less
+++ b/packages/one-dark-ui/styles/badges.less
@@ -1,14 +1,14 @@
 .badge {
-  padding: @ui-padding/4 @ui-padding/2.5;
-  min-width: @ui-padding*1.25;
+  padding: (@ui-padding/4) (@ui-padding/2.5);
+  min-width: (@ui-padding*1.25);
   .text(highlight);
-  border-radius: @ui-size*2;
+  border-radius: (@ui-size*2);
   background-color: @badge-background-color;
 
   // Icon ----------------------
   &.icon {
     font-size: @ui-size;
-    padding: @ui-padding-icon @ui-padding-icon*1.5;
+    padding: @ui-padding-icon (@ui-padding-icon*1.5);
   }
 
 }

--- a/packages/one-dark-ui/styles/buttons.less
+++ b/packages/one-dark-ui/styles/buttons.less
@@ -1,6 +1,6 @@
 
 @btn-border: 1px solid @button-border-color;
-@btn-padding: 0 @ui-size/1.25;
+@btn-padding: 0 (@ui-size/1.25);
 
 // Mixins -----------------------
 
@@ -96,19 +96,19 @@
 
 .btn.btn-xs,
 .btn-group-xs > .btn {
-  font-size: @ui-size*.8;
+  font-size: (@ui-size*.8);
   line-height: @ui-line-height;
   padding: @btn-padding;
 }
 .btn.btn-sm,
 .btn-group-sm > .btn {
-  font-size: @ui-size*.9;
+  font-size: (@ui-size*.9);
   line-height: @ui-line-height;
   padding: @btn-padding;
 }
 .btn.btn-lg,
 .btn-group-lg > .btn {
-  font-size: @ui-size * 1.5;
+  font-size: (@ui-size * 1.5);
   line-height: @ui-line-height;
   padding: @btn-padding;
 }

--- a/packages/one-dark-ui/styles/config.less
+++ b/packages/one-dark-ui/styles/config.less
@@ -53,12 +53,12 @@
   .tab.active {
     flex: 0 0 auto;
     min-width: 2.75em;
-    max-width: @tab-min-width * 3.3;
+    max-width: (@tab-min-width * 3.3);
   }
   atom-dock {
     .tab,
     .tab.active {
-      max-width: @tab-min-width * 2;
+      max-width: (@tab-min-width * 2);
     }
   }
 }

--- a/packages/one-dark-ui/styles/editor.less
+++ b/packages/one-dark-ui/styles/editor.less
@@ -14,8 +14,8 @@ atom-text-editor[mini] {
   overflow: auto;
   font-size: @ui-input-size;
   line-height: @ui-line-height;
-  max-height: @ui-line-height * 5; // rows
-  padding-left: @ui-padding/3;
+  max-height: (@ui-line-height * 5); // rows
+  padding-left: (@ui-padding/3);
   border-radius: @component-border-radius;
   color: @text-color-highlight;
   border: 1px solid @input-border-color;

--- a/packages/one-dark-ui/styles/key-binding.less
+++ b/packages/one-dark-ui/styles/key-binding.less
@@ -1,11 +1,11 @@
 .key-binding {
   display: inline-block;
   margin-left: @ui-padding-icon;
-  padding: 0 @ui-padding/4;
+  padding: 0 (@ui-padding/4);
   line-height: 2;
   font-family: inherit;
-  font-size: max(1em, @ui-size*.85);
-  letter-spacing: @ui-size/10;
+  font-size: max(1em, (@ui-size*.85));
+  letter-spacing: (@ui-size/10);
   border-radius: @component-border-radius;
   color: @accent-bg-text-color;
   background-color: @accent-bg-color;

--- a/packages/one-dark-ui/styles/lists.less
+++ b/packages/one-dark-ui/styles/lists.less
@@ -106,7 +106,7 @@
 }
 
 .select-list.popover-list {
-  @popover-list-padding: (@ui-padding/4;)
+  @popover-list-padding: (@ui-padding/4);
   background-color: @overlay-background-color;
   box-shadow: 0 2px 8px 1px rgba(0, 0, 0, 0.3);
   padding: @popover-list-padding;

--- a/packages/one-dark-ui/styles/lists.less
+++ b/packages/one-dark-ui/styles/lists.less
@@ -106,7 +106,7 @@
 }
 
 .select-list.popover-list {
-  @popover-list-padding: @ui-padding/4;
+  @popover-list-padding: (@ui-padding/4;)
   background-color: @overlay-background-color;
   box-shadow: 0 2px 8px 1px rgba(0, 0, 0, 0.3);
   padding: @popover-list-padding;

--- a/packages/one-dark-ui/styles/messages.less
+++ b/packages/one-dark-ui/styles/messages.less
@@ -4,7 +4,7 @@ background-tips ul.background-message {
   color: @text-color-faded;
 
   .message {
-    padding: 0 @component-padding * 10;
+    padding: 0 (@component-padding * 10);
 
     .keystroke {
       white-space: nowrap;

--- a/packages/one-dark-ui/styles/modal.less
+++ b/packages/one-dark-ui/styles/modal.less
@@ -1,5 +1,5 @@
 
-@modal-padding: @ui-padding/2 @ui-padding/1.5;
+@modal-padding: (@ui-padding/2) (@ui-padding/1.5);
 @modal-width: @ui-size * 50;
 
 atom-panel-container.modal {
@@ -15,14 +15,14 @@ atom-panel.modal {
   left: initial;
   color: @text-color;
   background-color: transparent;
-  padding: @ui-padding/2;
+  padding: (@ui-padding/2);
 
   &.from-top {
-    top: @component-padding * 5;
+    top: (@component-padding * 5);
   }
 
   atom-text-editor[mini] {
-    margin-bottom: @ui-padding/2;
+    margin-bottom: (@ui-padding/2);
   }
 
   .select-list ol.list-group,
@@ -68,8 +68,8 @@ atom-panel.modal {
 
   .select-list .key-binding {
     margin-top: -1px;
-    margin-left: @ui-padding/2;
-    margin-right: calc( -@ui-padding/3 ~"+" 1px);
+    margin-left: (@ui-padding/2);
+    margin-right: calc( (-@ui-padding/3) ~"+" 1px);
   }
 
   .select-list .primary-line {
@@ -96,7 +96,7 @@ atom-panel.modal {
     bottom: 0;
     z-index: 0;
     background-color: @overlay-background-color;
-    border-radius: @component-border-radius*2;
+    border-radius: (@component-border-radius*2);
     box-shadow: 0 6px 12px -2px hsla(0,0%,0%,.4);
   }
 

--- a/packages/one-dark-ui/styles/notifications.less
+++ b/packages/one-dark-ui/styles/notifications.less
@@ -1,6 +1,6 @@
 
 atom-notifications {
-  font-size: @ui-size * 1.2;
+  font-size: (@ui-size * 1.2);
 
   atom-notification {
     width: 32em;
@@ -16,7 +16,7 @@ atom-notifications {
       padding-right: 2.5em;
     }
     .item {
-      padding: @ui-padding/2;
+      padding: (@ui-padding/2);
     }
 
     .detail,

--- a/packages/one-dark-ui/styles/packages.less
+++ b/packages/one-dark-ui/styles/packages.less
@@ -4,9 +4,9 @@
 
 .find-and-replace,
 .project-find {
-  padding: @ui-padding/4;
+  padding: (@ui-padding/4);
   .input-block-item {
-    padding: @ui-padding/4;
+    padding: (@ui-padding/4);
   }
 }
 
@@ -14,19 +14,19 @@
 .find-and-replace {
   .header,
   .input-block {
-    min-width: @ui-size*22;
+    min-width: (@ui-size*22);
   }
 
   .input-block-item {
-    flex: 1 1 @ui-size*22;
+    flex: 1 1 (@ui-size*22);
   }
   .input-block-item--flex {
-    flex: 100 1 @ui-size*22;
+    flex: 100 1 (@ui-size*22);
   }
 
   .btn,
   .btn-group-options .btn {
-    font-size: @ui-size*1.1;
+    font-size: (@ui-size*1.1);
     padding: 0;
   }
 
@@ -38,12 +38,12 @@
   }
 
   .find-container atom-text-editor {
-    padding-right: @ui-size*5; // leave some room for the results count
+    padding-right: (@ui-size*5); // leave some room for the results count
   }
   .find-meta-container {
     top: 0;
     font-size: @ui-size;
-    line-height: @ui-size*2.5;
+    line-height: (@ui-size*2.5);
   }
 }
 
@@ -51,18 +51,18 @@
 .project-find {
   .header,
   .input-block {
-    min-width: @ui-size*15;
+    min-width: (@ui-size*15);
   }
 
   .input-block-item {
-    flex: 1 1 @ui-size*14;
+    flex: 1 1 (@ui-size*14);
   }
   .input-block-item--flex {
-    flex: 100 1 @ui-size*20;
+    flex: 100 1 (@ui-size*20);
   }
 
   .btn {
-    font-size: @ui-size*1.1;
+    font-size: (@ui-size*1.1);
     padding: 0;
   }
   .btn-group-options .btn {
@@ -106,12 +106,12 @@
 
 .timecop {
   .timecop-panel {
-    padding: @component-padding/2;
+    padding: (@component-padding/2);
     background-color: @level-2-color;
   }
 
   .tool-panel {
-    padding: @component-padding/2;
+    padding: (@component-padding/2);
     background-color: @level-2-color;
   }
 

--- a/packages/one-dark-ui/styles/progress.less
+++ b/packages/one-dark-ui/styles/progress.less
@@ -31,7 +31,7 @@
   }
   &::after {
     border-color: transparent lighten(@accent-color, 15%) transparent transparent;
-    -webkit-animation-delay: @spinner-duration/2;
+    -webkit-animation-delay: (@spinner-duration/2);
   }
 
   &.inline-block {

--- a/packages/one-dark-ui/styles/settings.less
+++ b/packages/one-dark-ui/styles/settings.less
@@ -2,15 +2,15 @@
 // Settings
 
 // Modular Scale (1.125): http://www.modularscale.com/?1&em&1.125&web&table
-@ms-6: @ui-size * 2.027;
-@ms-5: @ui-size * 1.802;
-@ms-4: @ui-size * 1.602;
-@ms-3: @ui-size * 1.424;
-@ms-2: @ui-size * 1.266;
-@ms-1: @ui-size * 1.125;
-@ms-0: @ui-size * 1;
-@ms_1: @ui-size * 0.889;
-@ms_2: @ui-size * 0.790;
+@ms-6: (@ui-size * 2.027);
+@ms-5: (@ui-size * 1.802);
+@ms-4: (@ui-size * 1.602);
+@ms-3: (@ui-size * 1.424);
+@ms-2: (@ui-size * 1.266);
+@ms-1: (@ui-size * 1.125);
+@ms-0: (@ui-size * 1);
+@ms_1: (@ui-size * 0.889);
+@ms_2: (@ui-size * 0.790);
 
 
 
@@ -20,7 +20,7 @@
 
 	.config-menu {
 		position: relative;
-		min-width: @ui-size * 15;
+		min-width: (@ui-size * 15);
 		max-width: @ui-size * 20;
 		border-width: 0 1px 0 0;
 		border-image: linear-gradient(@level-2-color 10px, @base-border-color 200px) 0 1 0 0 stretch;
@@ -30,7 +30,7 @@
 			white-space: initial;
 			font-size: @ms_1;
 			line-height: 1;
-			padding: @ui-padding/3 @ui-padding/2;
+			padding: (@ui-padding/3) (@ui-padding/2);
 			&::before {
 				vertical-align: middle;
 			}
@@ -40,7 +40,7 @@
 	}
 	.nav {
 		& > li > a {
-			padding: @ui-padding/2 @ui-padding;
+			padding: (@ui-padding/2) @ui-padding;
 			line-height: @ui-line-height;
 		}
 	}
@@ -53,24 +53,24 @@
 	}
 
 	.section-container {
-		max-width: @ui-size*60;
+		max-width: (@ui-size*60);
 	}
 
 	.section,
 	.section:first-child,
 	.section:last-child {
-		padding: @ui-padding*3;
+		padding: (@ui-padding*3);
 	}
 
 	.themes-panel .control-group {
-		margin-top: @ui-padding*2;
+		margin-top: (@ui-padding*2);
 	}
 
 
 	// Titles ------------------------------
 
 	.section .section-heading {
-		margin-bottom: @ui-padding/1.5;
+		margin-bottom: (@ui-padding/1.5);
 	}
 
 	.sub-section-heading.icon:before,
@@ -83,13 +83,13 @@
 	// Cards ------------------------------
 
 	.sub-section:not(.collapsed) .package-container {
-		padding-bottom: @component-padding*3;
+		padding-bottom: (@component-padding*3);
 	}
 
 	.package-card {
 		padding: @ui-padding;
 		.meta-controls .status-indicator {
-			width: @ui-padding/4;
+			width: (@ui-padding/4);
 			&:before {
 				content: "\00a0"; // fixes 0 height
 			}
@@ -108,7 +108,7 @@
 	}
 
 	.form-control {
-		font-size: @ui-size*1.25;
+		font-size: (@ui-size*1.25);
 		height: @ui-line-height;
 		padding-top: 0;
 		padding-bottom: 0;

--- a/packages/one-dark-ui/styles/status-bar.less
+++ b/packages/one-dark-ui/styles/status-bar.less
@@ -21,7 +21,7 @@
 
   .inline-block {
     margin: 0; // override default
-    padding: 0 @status-bar-padding/2;
+    padding: 0 (@status-bar-padding/2);
     vertical-align: top;
 
     &:hover {

--- a/packages/one-dark-ui/styles/tabs.less
+++ b/packages/one-dark-ui/styles/tabs.less
@@ -179,7 +179,7 @@
     // arrow
     &:after {
       z-index: 0;
-      top: @ui-tab-height/2;
+      top: (@ui-tab-height/2);
       margin: -4px 0 0 -3px;
       border-radius: 0;
       border: 4px solid @accent-color;

--- a/packages/one-dark-ui/styles/tooltips.less
+++ b/packages/one-dark-ui/styles/tooltips.less
@@ -1,6 +1,6 @@
 .tooltip {
   white-space: nowrap;
-  font-size: @ui-size*1.15;
+  font-size: (@ui-size*1.15);
 
   &.in {
     opacity: 1;
@@ -9,7 +9,7 @@
 
   .tooltip-inner {
     line-height: 1;
-    padding: @ui-padding*.5 @ui-padding*.65;
+    padding: (@ui-padding*.5) (@ui-padding*.65);
     border-radius: @component-border-radius;
     background-color: @tooltip-background-color;
     color: @tooltip-text-color;
@@ -18,10 +18,10 @@
   }
 
   .keystroke {
-    font-size: max(1em, @ui-size*.85);
+    font-size: max(1em, (@ui-size*.85));
     padding: .1em .4em;
-    margin: 0 @ui-padding*-.35 0 @ui-padding*.25;
-    border-radius: max(2px, @component-border-radius / 2);
+    margin: 0 (@ui-padding*-.35) 0 (@ui-padding*.25);
+    border-radius: max(2px, (@component-border-radius / 2));
     color: @tooltip-text-key-color;
     background: @tooltip-background-key-color;
   }

--- a/packages/one-dark-ui/styles/ui-variables-custom.less
+++ b/packages/one-dark-ui/styles/ui-variables-custom.less
@@ -24,17 +24,17 @@
 .ui-saturation();
 
 .ui-lightness() when (@ui-s-l <  @ui-inv) {
-  @ui-lightness: @ui-s-l + 8%; // increase lightness when too dark
-  @ui-lightness-border: @ui-lightness*.3;
+  @ui-lightness: (@ui-s-l + 8%); // increase lightness when too dark
+  @ui-lightness-border: (@ui-lightness*.3);
 }
 .ui-lightness() when (@ui-s-l >= @ui-inv) {
   @ui-lightness: min(@ui-s-l, 20%); // limit max lightness (for light syntax themes)
-  @ui-lightness-border: @ui-lightness*.6;
+  @ui-lightness-border: (@ui-lightness*.6);
 }
 .ui-lightness();
 
 // Main colors -----------------
-@ui-fg:     hsl(@ui-hue, min(@ui-saturation, 18%), max(@ui-lightness*3, 66%) );
+@ui-fg:     hsl(@ui-hue, min(@ui-saturation, 18%), max((@ui-lightness*3), 66%) );
 @ui-bg:     hsl(@ui-hue, @ui-saturation, @ui-lightness); // normalized @syntax-background-color
 @ui-border: hsl(@ui-hue, @ui-saturation, @ui-lightness-border);
 
@@ -74,7 +74,7 @@
 @accent-text-color:       contrast(@accent-color, hsl(@ui-hue,100%,10%), #fff, 25% );
 
 // used for button, tooltip (larger things)
-@accent-bg-color:         mix( hsv( @ui-hue, 66%, 66%), hsl( @ui-hue, 66%, 60%), @accent-luma * 2 ); // mix hsv + hsl (favor hsl for dark, hsv for light colors)
+@accent-bg-color:         mix( hsv( @ui-hue, 66%, 66%), hsl( @ui-hue, 66%, 60%), (@accent-luma * 2) ); // mix hsv + hsl (favor hsl for dark, hsv for light colors)
 @accent-bg-text-color:    contrast(@accent-bg-color, hsl(@ui-hue,100%,10%), #fff, 30% );
 
 // used for text only
@@ -92,7 +92,7 @@
 @input-selection-color:             mix(@accent-color, @input-background-color, 25%);
 @input-selection-color-focus:       mix(@accent-color, @input-background-color, 50%);
 
-@overlay-backdrop-color:            hsl(@ui-hue, @ui-saturation, @ui-lightness*0.2);
+@overlay-backdrop-color:            hsl(@ui-hue, @ui-saturation, (@ui-lightness*0.2));
 @overlay-backdrop-opacity:          .75;
 
 @progress-background-color:         @accent-color;
@@ -120,12 +120,12 @@
 // Sizes (Custom) -----------------
 
 @ui-size:                 1em;
-@ui-input-size:           @ui-size*1.15;
-@ui-padding:              @ui-size*1.5;
-@ui-padding-pane:         @ui-size*.5;
-@ui-padding-icon:         @ui-padding/3.3;
-@ui-line-height:          @ui-size*2;
-@ui-tab-height:           @ui-size*2.5;
+@ui-input-size:           (@ui-size*1.15);
+@ui-padding:              (@ui-size*1.5);
+@ui-padding-pane:         (@ui-size*.5);
+@ui-padding-icon:         (@ui-padding/3.3);
+@ui-line-height:          (@ui-size*2);
+@ui-tab-height:           (@ui-size*2.5);
 
 
 

--- a/packages/one-light-ui/styles/badges.less
+++ b/packages/one-light-ui/styles/badges.less
@@ -1,14 +1,14 @@
 .badge {
-  padding: @ui-padding/4 @ui-padding/2.5;
-  min-width: @ui-padding*1.25;
+  padding: (@ui-padding/4) (@ui-padding/2.5);
+  min-width: (@ui-padding*1.25);
   .text(highlight);
-  border-radius: @ui-size*2;
+  border-radius: (@ui-size*2);
   background-color: @badge-background-color;
 
   // Icon ----------------------
   &.icon {
     font-size: @ui-size;
-    padding: @ui-padding-icon @ui-padding-icon*1.5;
+    padding: @ui-padding-icon (@ui-padding-icon*1.5);
   }
 
 }

--- a/packages/one-light-ui/styles/buttons.less
+++ b/packages/one-light-ui/styles/buttons.less
@@ -1,6 +1,6 @@
 
 @btn-border: 1px solid @button-border-color;
-@btn-padding: 0 @ui-size/1.25;
+@btn-padding: 0 (@ui-size/1.25);
 
 // Mixins -----------------------
 
@@ -96,19 +96,19 @@
 
 .btn.btn-xs,
 .btn-group-xs > .btn {
-  font-size: @ui-size*.8;
+  font-size: (@ui-size*.8);
   line-height: @ui-line-height;
   padding: @btn-padding;
 }
 .btn.btn-sm,
 .btn-group-sm > .btn {
-  font-size: @ui-size*.9;
+  font-size: (@ui-size*.9);
   line-height: @ui-line-height;
   padding: @btn-padding;
 }
 .btn.btn-lg,
 .btn-group-lg > .btn {
-  font-size: @ui-size * 1.5;
+  font-size: (@ui-size * 1.5);
   line-height: @ui-line-height;
   padding: @btn-padding;
 }

--- a/packages/one-light-ui/styles/config.less
+++ b/packages/one-light-ui/styles/config.less
@@ -53,12 +53,12 @@
   .tab.active {
     flex: 0 0 auto;
     min-width: 2.75em;
-    max-width: @tab-min-width * 3.3;
+    max-width: (@tab-min-width * 3.3);
   }
   atom-dock {
     .tab,
     .tab.active {
-      max-width: @tab-min-width * 2;
+      max-width: (@tab-min-width * 2);
     }
   }
 }

--- a/packages/one-light-ui/styles/editor.less
+++ b/packages/one-light-ui/styles/editor.less
@@ -14,8 +14,8 @@ atom-text-editor[mini] {
   overflow: auto;
   font-size: @ui-input-size;
   line-height: @ui-line-height;
-  max-height: @ui-line-height * 5; // rows
-  padding-left: @ui-padding/3;
+  max-height: (@ui-line-height * 5); // rows
+  padding-left: (@ui-padding/3);
   border-radius: @component-border-radius;
   color: @text-color-highlight;
   border: 1px solid @input-border-color;

--- a/packages/one-light-ui/styles/key-binding.less
+++ b/packages/one-light-ui/styles/key-binding.less
@@ -1,11 +1,11 @@
 .key-binding {
   display: inline-block;
   margin-left: @ui-padding-icon;
-  padding: 0 @ui-padding/4;
+  padding: 0 (@ui-padding/4);
   line-height: 2;
   font-family: inherit;
-  font-size: max(1em, @ui-size*.85);
-  letter-spacing: @ui-size/10;
+  font-size: max(1em, (@ui-size*.85));
+  letter-spacing: (@ui-size/10);
   border-radius: @component-border-radius;
   color: @accent-bg-text-color;
   background-color: @accent-bg-color;

--- a/packages/one-light-ui/styles/lists.less
+++ b/packages/one-light-ui/styles/lists.less
@@ -106,7 +106,7 @@
 }
 
 .select-list.popover-list {
-  @popover-list-padding: @ui-padding/4;
+  @popover-list-padding: (@ui-padding/4);
   background-color: @overlay-background-color;
   box-shadow: 0 2px 8px 1px rgba(0, 0, 0, 0.3);
   padding: @popover-list-padding;

--- a/packages/one-light-ui/styles/messages.less
+++ b/packages/one-light-ui/styles/messages.less
@@ -4,7 +4,7 @@ background-tips ul.background-message {
   color: @text-color-faded;
 
   .message {
-    padding: 0 @component-padding * 10;
+    padding: 0 (@component-padding * 10);
 
     .keystroke {
       white-space: nowrap;

--- a/packages/one-light-ui/styles/modal.less
+++ b/packages/one-light-ui/styles/modal.less
@@ -1,6 +1,6 @@
 
-@modal-padding: @ui-padding/2 @ui-padding/1.5;
-@modal-width: @ui-size * 50;
+@modal-padding: (@ui-padding/2) (@ui-padding/1.5);
+@modal-width: (@ui-size * 50);
 
 atom-panel-container.modal {
   position: absolute;
@@ -15,14 +15,14 @@ atom-panel.modal {
   left: initial;
   color: @text-color;
   background-color: transparent;
-  padding: @ui-padding/2;
+  padding: (@ui-padding/2);
 
   &.from-top {
-    top: @component-padding * 5;
+    top: (@component-padding * 5);
   }
 
   atom-text-editor[mini] {
-    margin-bottom: @ui-padding/2;
+    margin-bottom: (@ui-padding/2);
   }
 
   .select-list ol.list-group,
@@ -68,8 +68,8 @@ atom-panel.modal {
 
   .select-list .key-binding {
     margin-top: -1px;
-    margin-left: @ui-padding/2;
-    margin-right: calc( -@ui-padding/3 ~"+" 1px);
+    margin-left: (@ui-padding/2);
+    margin-right: calc( (-@ui-padding/3) ~"+" 1px);
   }
 
   .select-list .primary-line {
@@ -96,7 +96,7 @@ atom-panel.modal {
     bottom: 0;
     z-index: 0;
     background-color: @overlay-background-color;
-    border-radius: @component-border-radius*2;
+    border-radius: (@component-border-radius*2);
     box-shadow: 0 6px 12px -2px hsla(0,0%,0%,.4);
   }
 

--- a/packages/one-light-ui/styles/notifications.less
+++ b/packages/one-light-ui/styles/notifications.less
@@ -1,6 +1,6 @@
 
 atom-notifications {
-  font-size: @ui-size * 1.2;
+  font-size: (@ui-size * 1.2);
 
   atom-notification {
     width: 32em;
@@ -16,7 +16,7 @@ atom-notifications {
       padding-right: 2.5em;
     }
     .item {
-      padding: @ui-padding/2;
+      padding: (@ui-padding/2);
     }
 
     .detail,

--- a/packages/one-light-ui/styles/packages.less
+++ b/packages/one-light-ui/styles/packages.less
@@ -4,9 +4,9 @@
 
 .find-and-replace,
 .project-find {
-  padding: @ui-padding/4;
+  padding: (@ui-padding/4);
   .input-block-item {
-    padding: @ui-padding/4;
+    padding: (@ui-padding/4);
   }
 }
 
@@ -14,19 +14,19 @@
 .find-and-replace {
   .header,
   .input-block {
-    min-width: @ui-size*22;
+    min-width: (@ui-size*22);
   }
 
   .input-block-item {
-    flex: 1 1 @ui-size*22;
+    flex: 1 1 (@ui-size*22);
   }
   .input-block-item--flex {
-    flex: 100 1 @ui-size*22;
+    flex: 100 1 (@ui-size*22);
   }
 
   .btn,
   .btn-group-options .btn {
-    font-size: @ui-size*1.1;
+    font-size: (@ui-size*1.1);
     padding: 0;
   }
 
@@ -38,12 +38,12 @@
   }
 
   .find-container atom-text-editor {
-    padding-right: @ui-size*5; // leave some room for the results count
+    padding-right: (@ui-size*5); // leave some room for the results count
   }
   .find-meta-container {
     top: 0;
     font-size: @ui-size;
-    line-height: @ui-size*2.5;
+    line-height: (@ui-size*2.5);
   }
 }
 
@@ -51,18 +51,18 @@
 .project-find {
   .header,
   .input-block {
-    min-width: @ui-size*15;
+    min-width: (@ui-size*15);
   }
 
   .input-block-item {
-    flex: 1 1 @ui-size*14;
+    flex: 1 1 (@ui-size*14);
   }
   .input-block-item--flex {
-    flex: 100 1 @ui-size*20;
+    flex: 100 1 (@ui-size*20);
   }
 
   .btn {
-    font-size: @ui-size*1.1;
+    font-size: (@ui-size*1.1);
     padding: 0;
   }
   .btn-group-options .btn {
@@ -106,12 +106,12 @@
 
 .timecop {
   .timecop-panel {
-    padding: @component-padding/2;
+    padding: (@component-padding/2);
     background-color: @level-2-color;
   }
 
   .tool-panel {
-    padding: @component-padding/2;
+    padding: (@component-padding/2);
     background-color: @level-2-color;
   }
 

--- a/packages/one-light-ui/styles/progress.less
+++ b/packages/one-light-ui/styles/progress.less
@@ -31,7 +31,7 @@
   }
   &::after {
     border-color: transparent lighten(@accent-color, 15%) transparent transparent;
-    -webkit-animation-delay: @spinner-duration/2;
+    -webkit-animation-delay: (@spinner-duration/2);
   }
 
   &.inline-block {

--- a/packages/one-light-ui/styles/settings.less
+++ b/packages/one-light-ui/styles/settings.less
@@ -2,15 +2,15 @@
 // Settings
 
 // Modular Scale (1.125): http://www.modularscale.com/?1&em&1.125&web&table
-@ms-6: @ui-size * 2.027;
-@ms-5: @ui-size * 1.802;
-@ms-4: @ui-size * 1.602;
-@ms-3: @ui-size * 1.424;
-@ms-2: @ui-size * 1.266;
-@ms-1: @ui-size * 1.125;
-@ms-0: @ui-size * 1;
-@ms_1: @ui-size * 0.889;
-@ms_2: @ui-size * 0.790;
+@ms-6: (@ui-size * 2.027);
+@ms-5: (@ui-size * 1.802);
+@ms-4: (@ui-size * 1.602);
+@ms-3: (@ui-size * 1.424);
+@ms-2: (@ui-size * 1.266);
+@ms-1: (@ui-size * 1.125);
+@ms-0: (@ui-size * 1);
+@ms_1: (@ui-size * 0.889);
+@ms_2: (@ui-size * 0.790);
 
 
 
@@ -20,8 +20,8 @@
 
 	.config-menu {
 		position: relative;
-		min-width: @ui-size * 15;
-		max-width: @ui-size * 20;
+		min-width: (@ui-size * 15);
+		max-width: (@ui-size * 20);
 		border-width: 0 1px 0 0;
 		border-image: linear-gradient(@level-2-color 10px, @base-border-color 200px) 0 1 0 0 stretch;
 		background: @level-2-color;
@@ -30,7 +30,7 @@
 			white-space: initial;
 			font-size: @ms_1;
 			line-height: 1;
-			padding: @ui-padding/3 @ui-padding/2;
+			padding: (@ui-padding/3) (@ui-padding/2);
 			&::before {
 				vertical-align: middle;
 			}
@@ -40,7 +40,7 @@
 	}
 	.nav {
 		& > li > a {
-			padding: @ui-padding/2 @ui-padding;
+			padding: (@ui-padding/2) @ui-padding;
 			line-height: @ui-line-height;
 		}
 	}
@@ -53,24 +53,24 @@
 	}
 
 	.section-container {
-		max-width: @ui-size*60;
+		max-width: (@ui-size*60);
 	}
 
 	.section,
 	.section:first-child,
 	.section:last-child {
-		padding: @ui-padding*3;
+		padding: (@ui-padding*3);
 	}
 
 	.themes-panel .control-group {
-		margin-top: @ui-padding*2;
+		margin-top: (@ui-padding*2);
 	}
 
 
 	// Titles ------------------------------
 
 	.section .section-heading {
-		margin-bottom: @ui-padding/1.5;
+		margin-bottom: (@ui-padding/1.5);
 	}
 
 	.sub-section-heading.icon:before,
@@ -83,13 +83,13 @@
 	// Cards ------------------------------
 
 	.sub-section:not(.collapsed) .package-container {
-		padding-bottom: @component-padding*3;
+		padding-bottom: (@component-padding*3);
 	}
 
 	.package-card {
 		padding: @ui-padding;
 		.meta-controls .status-indicator {
-			width: @ui-padding/4;
+			width: (@ui-padding/4);
 			&:before {
 				content: "\00a0"; // fixes 0 height
 			}
@@ -108,7 +108,7 @@
 	}
 
 	.form-control {
-		font-size: @ui-size*1.25;
+		font-size: (@ui-size*1.25);
 		height: @ui-line-height;
 		padding-top: 0;
 		padding-bottom: 0;

--- a/packages/one-light-ui/styles/status-bar.less
+++ b/packages/one-light-ui/styles/status-bar.less
@@ -21,7 +21,7 @@
 
   .inline-block {
     margin: 0; // override default
-    padding: 0 @status-bar-padding/2;
+    padding: 0 (@status-bar-padding/2);
     vertical-align: top;
 
     &:hover {

--- a/packages/one-light-ui/styles/tabs.less
+++ b/packages/one-light-ui/styles/tabs.less
@@ -179,7 +179,7 @@
     // arrow
     &:after {
       z-index: 0;
-      top: @ui-tab-height/2;
+      top: (@ui-tab-height/2);
       margin: -4px 0 0 -3px;
       border-radius: 0;
       border: 4px solid @accent-color;

--- a/packages/one-light-ui/styles/tooltips.less
+++ b/packages/one-light-ui/styles/tooltips.less
@@ -1,6 +1,6 @@
 .tooltip {
   white-space: nowrap;
-  font-size: @ui-size*1.15;
+  font-size: (@ui-size*1.15);
 
   &.in {
     opacity: 1;
@@ -9,7 +9,7 @@
 
   .tooltip-inner {
     line-height: 1;
-    padding: @ui-padding*.5 @ui-padding*.65;
+    padding: (@ui-padding*.5) (@ui-padding*.65);
     border-radius: @component-border-radius;
     background-color: @tooltip-background-color;
     color: @tooltip-text-color;
@@ -18,10 +18,10 @@
   }
 
   .keystroke {
-    font-size: max(1em, @ui-size*.85);
+    font-size: max(1em, (@ui-size*.85));
     padding: .1em .4em;
-    margin: 0 @ui-padding*-.35 0 @ui-padding*.25;
-    border-radius: max(2px, @component-border-radius / 2);
+    margin: 0 (@ui-padding*-.35) 0 (@ui-padding*.25);
+    border-radius: max(2px, (@component-border-radius / 2));
     color: @tooltip-text-key-color;
     background: @tooltip-background-key-color;
   }

--- a/packages/one-light-ui/styles/ui-variables-custom.less
+++ b/packages/one-light-ui/styles/ui-variables-custom.less
@@ -17,7 +17,7 @@
 @ui-lightness:    max(  lightness(@ui-syntax-color), 92%); // min lightness
 
 // Main colors -----------------
-@ui-fg:     hsl(@ui-hue, @ui-saturation, @ui-lightness - 72%);
+@ui-fg:     hsl(@ui-hue, @ui-saturation, (@ui-lightness - 72%));
 @ui-bg:     hsl(@ui-hue, @ui-saturation, @ui-lightness); // normalized @syntax-background-color
 @ui-border: darken(@level-3-color, 6%);
 
@@ -53,15 +53,15 @@
 @accent-luma:             luma( hsl(@ui-hue, 50%, 50%) ); // get lightness of current hue
 
 // used for marker, inputs (smaller things)
-@accent-color:            mix( hsv( @ui-hue, 60%, 60%), hsl( @ui-hue, 100%, 68%), @accent-luma * 2 ); // mix hsv + hsl (favor hsl for dark, hsv for light colors)
+@accent-color:            mix( hsv( @ui-hue, 60%, 60%), hsl( @ui-hue, 100%, 68%), (@accent-luma * 2) ); // mix hsv + hsl (favor hsl for dark, hsv for light colors)
 @accent-text-color:       contrast(@accent-color, hsl(@ui-hue,100%,16%), #fff, 40% );
 
 // used for button, tooltip (larger things)
-@accent-bg-color:         mix( hsv( @ui-hue, 40%, 72%), hsl( @ui-hue, 100%, 66%), @accent-luma * 2 ); // mix hsv + hsl (favor hsl for dark, hsv for light colors)
+@accent-bg-color:         mix( hsv( @ui-hue, 40%, 72%), hsl( @ui-hue, 100%, 66%), (@accent-luma * 2) ); // mix hsv + hsl (favor hsl for dark, hsv for light colors)
 @accent-bg-text-color:    contrast(@accent-bg-color, hsl(@ui-hue,100%,10%), #fff, 40% );
 
 // used for text only
-@accent-only-text-color: mix( hsv( @ui-hue, 70%, 50%), hsl( @ui-hue, 100%, 60%), @accent-luma * 2 ); // mix hsv + hsl (favor hsl for dark, hsv for light colors)
+@accent-only-text-color: mix( hsv( @ui-hue, 70%, 50%), hsl( @ui-hue, 100%, 60%), (@accent-luma * 2) ); // mix hsv + hsl (favor hsl for dark, hsv for light colors)
 
 
 // Components (Custom) -----------------
@@ -73,10 +73,10 @@
 @checkbox-background-color:         fade(@accent-bg-color, 33%);
 
 @input-background-color-focus:      hsl(@ui-hue, 100%, 96%);
-@input-selection-color:             mix( hsv( @ui-hue, 33%, 95%), hsl( @ui-hue, 100%, 98%), @accent-luma * 2 ); // mix hsv + hsl (favor hsl for dark, hsv for light colors)
-@input-selection-color-focus:       mix( hsv( @ui-hue, 44%, 90%), hsl( @ui-hue, 100%, 94%), @accent-luma * 2 ); // mix hsv + hsl (favor hsl for dark, hsv for light colors)
+@input-selection-color:             mix( hsv( @ui-hue, 33%, 95%), hsl( @ui-hue, 100%, 98%), (@accent-luma * 2) ); // mix hsv + hsl (favor hsl for dark, hsv for light colors)
+@input-selection-color-focus:       mix( hsv( @ui-hue, 44%, 90%), hsl( @ui-hue, 100%, 94%), (@accent-luma * 2) ); // mix hsv + hsl (favor hsl for dark, hsv for light colors)
 
-@overlay-backdrop-color:            hsl(@ui-hue, @ui-saturation*0.4, @ui-lightness*0.8);
+@overlay-backdrop-color:            hsl(@ui-hue, (@ui-saturation*0.4), (@ui-lightness*0.8));
 @overlay-backdrop-opacity:          .66;
 
 @progress-background-color:         @accent-color;
@@ -102,12 +102,12 @@
 // Sizes (Custom) -----------------
 
 @ui-size:                 1em;
-@ui-input-size:           @ui-size*1.15;
-@ui-padding:              @ui-size*1.5;
-@ui-padding-pane:         @ui-size*.5;
-@ui-padding-icon:         @ui-padding/3.3;
-@ui-line-height:          @ui-size*2;
-@ui-tab-height:           @ui-size*2.5;
+@ui-input-size:           (@ui-size*1.15);
+@ui-padding:              (@ui-size*1.5);
+@ui-padding-pane:         (@ui-size*.5);
+@ui-padding-icon:         (@ui-padding/3.3);
+@ui-line-height:          (@ui-size*2);
+@ui-tab-height:           (@ui-size*2.5);
 
 
 

--- a/packages/settings-view/styles/docks.less
+++ b/packages/settings-view/styles/docks.less
@@ -17,7 +17,7 @@ atom-dock.right .settings-view {
     flex-wrap: wrap;
     align-items: center;
     justify-content: center;
-    padding: @component-padding/2;
+    padding: (@component-padding/2);
     min-width: 0;
     max-width: none;
     border: none;
@@ -44,8 +44,8 @@ atom-dock.right .settings-view {
       .icon-link-external {
         font-size: 0;
         width: auto;
-        margin: 0 @component-padding/2;
-        padding: @component-padding/4 @component-padding/2;
+        margin: 0 (@component-padding/2);
+        padding: (@component-padding/4) (@component-padding/2);
         overflow: hidden;
         &:before {
           font-size: 16px;
@@ -61,7 +61,7 @@ atom-dock.right .settings-view {
 
   .section,
   .section:first-child, .settings-view .section:last-child {
-    padding: @component-padding*1.5;
+    padding: (@component-padding*1.5);
   }
 
   .sub-section:not(.collapsed) .package-container {
@@ -143,10 +143,10 @@ atom-dock.right .settings-view {
 
   .themes-panel {
     .themes-picker-item {
-      margin-top: @component-padding*1.5;
+      margin-top: (@component-padding*1.5);
     }
     .theme-description {
-      margin: @component-padding/2 0;
+      margin: (@component-padding/2) 0;
     }
   }
 

--- a/packages/settings-view/styles/package-card.less
+++ b/packages/settings-view/styles/package-card.less
@@ -7,11 +7,11 @@
   // TODO: Somehow unify the "card".
 
   .package-card {
-    padding: @component-padding*1.5;
+    padding: (@component-padding*1.5);
     margin-bottom: @component-padding;
     list-style-type: none;
     font-size: 1.2em;
-    border-radius: @component-border-radius*2;
+    border-radius: (@component-border-radius*2);
     border: 1px solid @base-border-color;
     background-color: @package-card-background-color;
     overflow: hidden;
@@ -47,7 +47,7 @@
       margin: 0;
       min-height: 140px;
       color: @text-color;
-      border-radius: @component-border-radius*2;
+      border-radius: (@component-border-radius*2);
       border: 1px solid @base-border-color;
       background-color: @package-card-background-color;
 
@@ -119,7 +119,7 @@
     .stats {
 
       .stats-item {
-        margin-left: @component-padding*1.5;
+        margin-left: (@component-padding*1.5);
         height: 26px;
         display: inline-block;
         line-height: 24px;
@@ -213,7 +213,7 @@
     }
 
     .meta-controls {
-      margin-top: @component-padding/2;
+      margin-top: (@component-padding/2);
 
       .install-button.is-installing,
       .uninstall-button.is-uninstalling {
@@ -225,7 +225,7 @@
 
       .status-indicator {
         padding: 0;
-        width: @component-padding/2;
+        width: (@component-padding/2);
         min-width: 4px;
         pointer-events: none;
         transition: background .4s;
@@ -237,7 +237,7 @@
 
       .btn-toolbar > .btn-group {
         float: left;
-        margin: @component-padding/2 0 0 @component-padding/2;
+        margin: (@component-padding/2) 0 0 (@component-padding/2);
       }
     }
 

--- a/packages/settings-view/styles/package-card.less
+++ b/packages/settings-view/styles/package-card.less
@@ -114,10 +114,6 @@
       margin: 0 0 .2em 0;
       font-size: 1.2em;
       line-height: 1.4;
-
-      .css-truncate-target {
-        color: $greenDark;
-      }
     }
 
     .stats {
@@ -145,12 +141,6 @@
             margin-right: 0px;
           }
         }
-      }
-    }
-
-    .body {
-      .css-truncate-target {
-        max-width: 100%;
       }
     }
 
@@ -183,16 +173,6 @@
 
       a.linked-octicon {
         text-decoration: none;
-
-        &:hover {
-          .octicon {
-            color: $greenDark;
-          }
-
-          .value {
-            color: $greenDark;
-          }
-        }
       }
 
       .action {
@@ -269,7 +249,7 @@
 
     &.blank-slate {
       text-align: center;
-      color: $beigeDark;
+      //color: $beigeDark;
       height: 132px;
       line-height: 132px;
     }

--- a/packages/settings-view/styles/search-results-card.less
+++ b/packages/settings-view/styles/search-results-card.less
@@ -5,11 +5,11 @@
 .settings-view {
 
   .search-result {
-    padding: @component-padding*1.5;
+    padding: (@component-padding*1.5);
     margin-bottom: @component-padding;
     list-style-type: none;
     font-size: 1.2em;
-    border-radius: @component-border-radius*2;
+    border-radius: (@component-border-radius*2);
     border: 1px solid @base-border-color;
     background-color: @package-card-background-color;
     overflow: hidden;

--- a/packages/settings-view/styles/search-results-card.less
+++ b/packages/settings-view/styles/search-results-card.less
@@ -68,16 +68,6 @@
       margin: 0 0 .2em 0;
       font-size: 1.2em;
       line-height: 1.4;
-
-      .css-truncate-target {
-        color: $greenDark;
-      }
-    }
-
-    .body {
-      .css-truncate-target {
-        max-width: 100%;
-      }
     }
 
     .search-package-name {

--- a/packages/settings-view/styles/settings-view.less
+++ b/packages/settings-view/styles/settings-view.less
@@ -2,8 +2,8 @@
 @import "octicon-utf-codes";
 @import "ui-variables";
 
-@section-padding: 2 * @component-padding;
-@breadcrumb-padding: 2 * @component-padding;
+@section-padding: (2 * @component-padding);
+@breadcrumb-padding: (2 * @component-padding);
 
 .settings-view {
   display: flex;
@@ -80,7 +80,7 @@
     .error-link {
       color: inherit;
       text-decoration: underline;
-      margin-left: @component-padding/2;
+      margin-left: (@component-padding/2);
     }
   }
 
@@ -152,7 +152,7 @@
   }
 
   .editor-container {
-    margin: @component-padding*2 0;
+    margin: (@component-padding*2) 0;
     &:last-child {
       margin-bottom: 0;
     }
@@ -211,7 +211,7 @@
 
   section .section-heading,
   .section .section-heading {
-    margin-bottom: @component-padding*2;
+    margin-bottom: (@component-padding*2);
     color: @text-color-highlight;
     font-size: 1.75em;
     font-weight: bold;
@@ -222,7 +222,7 @@
 
   .sub-section-heading.icon:before,
   .section-heading.icon:before {
-    margin-right: @component-padding*.8;
+    margin-right: (@component-padding*.8);
   }
 
   .section-heading-count {
@@ -265,7 +265,7 @@
 
     .sub-section-body {
       margin-top: @component-padding;
-      margin-bottom: @component-padding*3;
+      margin-bottom: (@component-padding*3);
       margin-left: 6px;
       padding-left: 14px;
       border-left: 1px solid @base-border-color;
@@ -487,7 +487,7 @@
 
   .themes-panel {
     .control-group {
-      margin-top:  @component-padding*3;
+      margin-top:  (@component-padding*3);
     }
     .themes-picker {
       display: flex;
@@ -517,7 +517,7 @@
     }
 
     .theme-chooser {
-      padding-top: @component-padding*2;
+      padding-top: (@component-padding*2);
     }
 
     .theme-description {
@@ -532,18 +532,18 @@
     .search-container {
       display: flex;
       flex-wrap: wrap;
-      margin: 0 -@component-padding/2;
-      padding-top: @component-padding*1.5;
+      margin: 0 (-@component-padding/2);
+      padding-top: (@component-padding*1.5);
 
 
       .editor-container {
         flex: 1;
         min-width: 130px;
-        margin: @component-padding/2;
+        margin: (@component-padding/2);
       }
 
       .btn-group {
-        margin: @component-padding/2;
+        margin: (@component-padding/2);
         padding-left: 1px; // Counter balance since btns have margin-left: -1px
       }
     }
@@ -608,7 +608,7 @@
     }
 
     th {
-      padding: @component-padding - 2px @component-padding;
+      padding: (@component-padding - 2px) @component-padding;
       padding-left: 0;
     }
 
@@ -663,7 +663,7 @@
     }
 
     td, th {
-      padding: 0 @component-padding @component-padding/2 0;
+      padding: 0 @component-padding (@component-padding/2) 0;
     }
   }
 }
@@ -715,7 +715,7 @@
   }
 
   .update-all-button:last-child {
-    margin-left: @component-padding/2;
+    margin-left: (@component-padding/2);
   }
 
   .keybinding-panel .is-user {
@@ -724,7 +724,7 @@
   }
 
   .btn-wrap-group .btn {
-    margin: 0 @component-padding/2 @component-padding/2 0;
+    margin: 0 (@component-padding/2) (@component-padding/2) 0;
   }
 }
 

--- a/packages/status-bar/styles/status-bar.less
+++ b/packages/status-bar/styles/status-bar.less
@@ -4,8 +4,8 @@
 status-bar {
   display: block;
   font-size: 11px;
-  line-height: @component-line-height - 3px;
-  height: @component-line-height + 1px;
+  line-height: (@component-line-height - 3px);
+  height: (@component-line-height + 1px);
   position: relative;
   -webkit-user-select: none;
   cursor: default;
@@ -18,7 +18,7 @@ status-bar {
   }
 
   .flexbox-repaint-hack {
-    padding: 0 @component-line-height/2;
+    padding: 0 (@component-line-height/2);
     position: absolute;
     top: 0;
     right: 0;
@@ -38,7 +38,7 @@ status-bar {
     padding-left: @component-padding;
     .inline-block {
       margin-right: 0;
-      margin-left: @component-padding*1.5;
+      margin-left: (@component-padding*1.5);
       & > .inline-block {
         margin-left: 0;
       }

--- a/packages/styleguide/styles/styleguide.less
+++ b/packages/styleguide/styles/styleguide.less
@@ -1,7 +1,7 @@
 @import "ui-variables";
 @import "syntax-variables";
 
-@styleguide-spacing: @component-padding *1.5;
+@styleguide-spacing: (@component-padding *1.5);
 @styleguide-bg: darken(@base-background-color, 2%);
 
 .styleguide {
@@ -101,14 +101,14 @@
   display: flex;
   flex-wrap: wrap;
   border-radius: @component-border-radius;
-  padding: @component-padding / 2;
+  padding: (@component-padding / 2);
 
   .example-rendered,
   .example-code {
     position: relative;
     flex: 1 1 300px;
     min-width: 0;
-    margin: @component-padding / 2;
+    margin: (@component-padding / 2);
     border-radius: @component-border-radius;
     border: 1px solid @tool-panel-border-color;
   }

--- a/packages/styleguide/styles/variables.less
+++ b/packages/styleguide/styles/variables.less
@@ -93,17 +93,17 @@
     vertical-align: middle;
   }
   .is-color:before {
-    margin-right: @component-padding*1.5;
+    margin-right: (@component-padding*1.5);
     width: 20%;
   }
   .is-size:after {
-    margin-left: @component-padding*1.5;
+    margin-left: (@component-padding*1.5);
     height: 4px;
     background-color: @text-color;
   }
   .is-radius:after {
     width: 20px;
-    margin-left: @component-padding*1.5;
+    margin-left: (@component-padding*1.5);
     background-color: @text-color;
   }
   .is-font:after {

--- a/packages/tabs/styles/tabs.less
+++ b/packages/tabs/styles/tabs.less
@@ -12,7 +12,7 @@
     font-size: 11px;
     position: relative;
     padding-left: 10px;
-    padding-right: 10px + @close-icon-size + 2px;
+    padding-right: (10px + @close-icon-size + 2px);
     -webkit-user-drag: element;
     flex: 1;
     max-width: 175px;

--- a/packages/timecop/styles/timecop.less
+++ b/packages/timecop/styles/timecop.less
@@ -44,8 +44,8 @@
   }
 
   .list-item {
-    margin-top: @component-padding / 2;;
-    margin-bottom: @component-padding / 2;
+    margin-top: (@component-padding / 2);
+    margin-bottom: (@component-padding / 2);
   }
 
   .package {

--- a/packages/welcome/styles/welcome.less
+++ b/packages/welcome/styles/welcome.less
@@ -68,7 +68,7 @@
   &-card {
     margin: 1em 0;
 
-    border-radius: @component-border-radius*2;
+    border-radius: (@component-border-radius*2);
     border: 1px solid @base-border-color;
     background-color: lighten(@base-background-color, 3%);
   }
@@ -108,8 +108,8 @@
       margin-bottom: 0;
     }
     .btn {
-      margin-top: @component-padding/3;
-      margin-bottom: @component-padding/3;
+      margin-top: (@component-padding/3);
+      margin-bottom: (@component-padding/3);
     }
   }
 

--- a/spec/style-manager-spec.js
+++ b/spec/style-manager-spec.js
@@ -141,6 +141,28 @@ describe('StyleManager', () => {
       });
     });
 
+    describe('css mathematical expression calc() wrap upgrades', () => {
+      beforeEach(() => {
+        // attach styles element to the DOM to parse CSS rules
+        styleManager.onDidAddStyleElement(styleElement => {
+          jasmine.attachToDOM(styleElement);
+        });
+      });
+
+      it('does not wrap, already wrapped math', () => {
+        styleManager.addStyleSheet(`
+          p { padding: calc(10px/2); }
+        `);
+
+        let styleMap = Array.from(styleManager.getStyleElements()[0].sheet.cssRules).map(
+          r => r.styleMap
+        );
+        let value = styleMap[0].get('padding').toString();
+        expect(value).toEqual('calc(5px)');
+      });
+
+    });
+
     describe('when a sourcePath parameter is specified', () => {
       it('ensures a maximum of one style element for the given source path, updating a previous if it exists', () => {
         styleManager.addStyleSheet('a {color: red}', {

--- a/spec/style-manager-spec.js
+++ b/spec/style-manager-spec.js
@@ -185,6 +185,27 @@ describe('StyleManager', () => {
         expect(upgradedSheet.source).toEqual("p { padding: calc(10px / 2); }");
       });
 
+      it('upgrades multiple math expressions in a single line', () => {
+        let upgradedSheet = mathStyleManager.upgradeDeprecatedMathUsageForStyleSheet(
+          "p { padding: 10px/2 10px/3; }",
+          {}
+        );
+        expect(upgradedSheet.source).toEqual("p { padding: calc(10px/2) calc(10px/3); }");
+      });
+
+      it('does not upgrade base64 strings', () => {
+        // Regression Check
+        // TODO This test is currently failing, as a math expression is found within this string, and needs to be prevented
+        // The reason for this test: ./static/atom-ui/style/mixins/mixins.less#67
+        let upgradedSheet = mathStyleManager.upgradeDeprecatedMathUsageForStyleSheet(
+          "p { cursor: -webkit-image-set(url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAQAAAC1+jfqAAAAL0lEQVQoz2NgCD3x//9/BhBYBWdhgFVAiVW4JBFKGIa4AqD0//9D3pt4I4tAdAMAHTQ/j5Zom30AAAAASUVORK5CYII=')); }",
+          {}
+        );
+        expect(upgradedSheet.source).toEqual(
+          "p { cursor: -webkit-image-set(url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAQAAAC1+jfqAAAAL0lEQVQoz2NgCD3x//9/BhBYBWdhgFVAiVW4JBFKGIa4AqD0//9D3pt4I4tAdAMAHTQ/j5Zom30AAAAASUVORK5CYII=')); }"
+        );
+      });
+
     });
 
     describe('when a sourcePath parameter is specified', () => {

--- a/src/config-schema.js
+++ b/src/config-schema.js
@@ -383,6 +383,16 @@ const configSchema = {
             description: 'Use sRGB color profile'
           }
         ]
+      },
+      transformDeprecatedStyleSheetSelectors: {
+        description: 'Whether Pulsar should transform deprecated DOM Selectors in community package style sheets. Increases compatibility, as well as startup time.',
+        type: 'boolean',
+        default: true
+      },
+      transformDeprecatedStyleSheetMathExpressions: {
+        description: 'Whether Pulsar should transform deprecated Mathematical Expressions in community package style sheets. Increases compatibility, as well as startup time.',
+        type: 'boolean',
+        default: true
       }
     }
   },

--- a/src/package.js
+++ b/src/package.js
@@ -314,7 +314,8 @@ module.exports = class Package {
           sourcePath,
           priority,
           context,
-          skipDeprecatedSelectorsTransformation: this.bundledPackage
+          skipDeprecatedSelectorsTransformation: this.bundledPackage,
+          skipDeprecatedMathUsageTransformation: this.bundledPackage
         })
       );
     }

--- a/src/package.js
+++ b/src/package.js
@@ -314,8 +314,10 @@ module.exports = class Package {
           sourcePath,
           priority,
           context,
-          skipDeprecatedSelectorsTransformation: this.bundledPackage,
-          skipDeprecatedMathUsageTransformation: this.bundledPackage
+          skipDeprecatedSelectorsTransformation:
+            this.bundledPackage ? this.bundledPackage : !this.config.get("core.transformDeprecatedStyleSheetSelectors"),
+          skipDeprecatedMathUsageTransformation:
+            this.bundledPackage ? this.bundledPackage : !this.config.get("core.transformDeprecatedStyleSheetMathExpressions")
         })
       );
     }

--- a/src/style-manager.js
+++ b/src/style-manager.js
@@ -160,11 +160,9 @@ module.exports = class StyleManager {
       }
     }
 
-    if (params.skipDeprecatedMathUsageTransformation) {
-      styleElement.textContent = source;
-    } else {
+    if (!params.skipDeprecatedMathUsageTransformation) {
       const transformed = this.upgradeDeprecatedMathUsageForStyleSheet(
-        source,
+        styleElement.textContent,
         params.context
       );
       styleElement.textContent = transformed.source;

--- a/src/style-manager.js
+++ b/src/style-manager.js
@@ -442,14 +442,23 @@ function transformDeprecatedMathUsage(css, context) {
         if (typeof node.value === "string") {
           let containsMath = node.value.match(mathExpressionRegex);
 
-          if (containsMath !== null && !node.value.includes(`calc(${containsMath[0]})`)) {
+          if (containsMath !== null) {
             let nodeOriginal = node.value;
-            node.value = node.value.replace(containsMath[0], `calc(${containsMath[0]})`);
-            transformedProperties.push({
-              property: node.prop,
-              valueBefore: nodeOriginal,
-              valueAfter: node.value
-            });
+            let appliedChanges = false;
+            for (let i = 0; i < containsMath.length; i++) {
+              let match = containsMath[i];
+              if (!node.value.includes(`calc(${match})`)) {
+                node.value = node.value.replace(match, `calc(${match})`);
+                appliedChanges = true;
+              }
+            }
+            if (appliedChanges) {
+              transformedProperties.push({
+                property: node.prop,
+                valueBefore: nodeOriginal,
+                valueAfter: node.value
+              });
+            }
           }
         }
 

--- a/src/theme-manager.js
+++ b/src/theme-manager.js
@@ -190,7 +190,8 @@ module.exports = class ThemeManager {
   requireStylesheet(
     stylesheetPath,
     priority,
-    skipDeprecatedSelectorsTransformation
+    skipDeprecatedSelectorsTransformation,
+    skipDeprecatedMathUsageTransformation
   ) {
     let fullPath = this.resolveStylesheet(stylesheetPath);
     if (fullPath) {
@@ -199,7 +200,8 @@ module.exports = class ThemeManager {
         fullPath,
         content,
         priority,
-        skipDeprecatedSelectorsTransformation
+        skipDeprecatedSelectorsTransformation,
+        skipDeprecatedMathUsageTransformation
       );
     } else {
       throw new Error(`Could not find a file at path '${stylesheetPath}'`);
@@ -357,12 +359,13 @@ On linux there are currently problems with watch sizes. See
     }
   }
 
-  applyStylesheet(path, text, priority, skipDeprecatedSelectorsTransformation) {
+  applyStylesheet(path, text, priority, skipDeprecatedSelectorsTransformation, skipDeprecatedMathUsageTransformation) {
     this.styleSheetDisposablesBySourcePath[
       path
     ] = this.styleManager.addStyleSheet(text, {
       priority,
       skipDeprecatedSelectorsTransformation,
+      skipDeprecatedMathUsageTransformation,
       sourcePath: path
     });
 

--- a/static/atom-ui/styles/badges.less
+++ b/static/atom-ui/styles/badges.less
@@ -29,7 +29,6 @@
 
   // Size ----------------------
 
-  //.badge-size( @size: 12px ) {
   .badge-size( @size: @font-size; ) {
     @padding: round((@size/4));
     font-size: @size;

--- a/static/atom-ui/styles/badges.less
+++ b/static/atom-ui/styles/badges.less
@@ -29,11 +29,12 @@
 
   // Size ----------------------
 
+  //.badge-size( @size: 12px ) {
   .badge-size( @size: @font-size; ) {
-    @padding: round(@size/4);
+    @padding: round((@size/4));
     font-size: @size;
-    min-width: @size + @padding*2;
-    padding: @padding round(@padding*1.5);
+    min-width: (@size + @padding*2);
+    padding: @padding round((@padding*1.5));
   }
   .badge-size(); // default
 
@@ -47,18 +48,18 @@
   // Best used for larger sizes, since em's can cause rounding errors
   &.badge-flexible {
     @size: .8em;
-    @padding: @size/2;
+    @padding: (@size/2);
     font-size: @size;
-    min-width: @size + @padding*2;
-    padding: @padding @padding*1.5;
+    min-width: (@size + @padding*2);
+    padding: @padding (@padding*1.5);
   }
 
 
   // Icon ----------------------
 
   &.icon {
-    font-size: round(@component-icon-size*0.8);
-    padding: @component-icon-padding @component-icon-padding*2;
+    font-size: round((@component-icon-size*0.8));
+    padding: @component-icon-padding (@component-icon-padding*2);
   }
 
 }

--- a/static/atom-ui/styles/buttons.less
+++ b/static/atom-ui/styles/buttons.less
@@ -13,7 +13,7 @@
 .btn {
   display: inline-block;
   margin-bottom: 0; // For input.btn
-  height: @component-line-height + 2px;
+  height: (@component-line-height + 2px);
   padding: 0 @component-padding;
   font-size: @font-size;
   font-weight: normal;
@@ -154,31 +154,31 @@
 
 .btn-xs,
 .btn-group-xs > .btn {
-  padding: @component-padding/4 @component-padding/2;
-  font-size: @font-size - 2px;
+  padding: (@component-padding/4) (@component-padding/2);
+  font-size: (@font-size - 2px);
   height: auto;
   line-height: 1.3em;
   &.icon:before {
-    font-size: @font-size - 2px;
+    font-size: (@font-size - 2px);
   }
 }
 .btn-sm,
 .btn-group-sm > .btn {
-  padding: @component-padding/4 @component-padding/2;
+  padding: (@component-padding/4) (@component-padding/2);
   height: auto;
   line-height: 1.3em;
   &.icon:before {
-    font-size: @font-size + 1px;
+    font-size: (@font-size + 1px);
   }
 }
 .btn-lg,
 .btn-group-lg > .btn {
   font-size: @font-size + 2px;
-  padding: @component-padding - 2px  @component-padding + 2px;
+  padding: (@component-padding - 2px)  (@component-padding + 2px);
   height: auto;
   line-height: 1.3em;
   &.icon:before {
-    font-size: @font-size + 6px;
+    font-size: (@font-size + 6px);
   }
 }
 
@@ -266,7 +266,7 @@ input[type="button"] {
     margin-left: 0;
   }
   > * {
-    margin-right: @component-padding / 2;
+    margin-right: (@component-padding / 2);
   }
   > *:last-child {
     margin-right: 0;

--- a/static/atom-ui/styles/inputs.less
+++ b/static/atom-ui/styles/inputs.less
@@ -230,7 +230,7 @@ input.input-toggle {
       width: inherit;
       height: inherit;
       border-radius: inherit;
-      border: @component-size/3 solid transparent;
+      border: (@component-size/3) solid transparent;
       background-clip: content-box;
       background-color: @base-background-color;
       transform: scale(0);
@@ -347,7 +347,7 @@ input.input-toggle {
     display: inline-block;
     position: relative;
     font-size: inherit;
-    width: @component-size * 2;
+    width: (@component-size * 2);
     height: @component-size;
     vertical-align: middle;
     border-radius: 2em;
@@ -368,7 +368,7 @@ input.input-toggle {
       width: @component-size;
       height: @component-size;
       border-radius: inherit;
-      border: @component-size/4 solid transparent;
+      border: (@component-size/4) solid transparent;
       background-clip: content-box;
       background-color: @base-background-color;
       transition: transform .2s cubic-bezier(0.5, 0.15, 0.2, 1);

--- a/static/atom-ui/styles/layout.less
+++ b/static/atom-ui/styles/layout.less
@@ -34,7 +34,7 @@ div > div.block:last-child {
   margin-right: @component-padding;
 }
 .inline-block-tight {
-  margin-right: @component-padding/2;
+  margin-right: (@component-padding/2);
 }
 div > .inline-block:last-child,
 div > .inline-block-tight:last-child {
@@ -67,7 +67,7 @@ div > .inline-block-tight:last-child {
   }
   .inline-block-tight {
     margin-right: 0;
-    margin-left: @component-padding/2;
+    margin-left: (@component-padding/2);
   }
 
   > .inline-block:first-child,

--- a/static/atom-ui/styles/messages.less
+++ b/static/atom-ui/styles/messages.less
@@ -12,7 +12,7 @@
 }
 
 ul.background-message {
-  font-size: @font-size * 3;
+  font-size: (@font-size * 3);
 
   margin: 0;
   padding: 0;

--- a/static/atom-ui/styles/private/sections.less
+++ b/static/atom-ui/styles/private/sections.less
@@ -10,7 +10,7 @@ section, .section {
 
   &.bordered {
     margin: 0;
-    padding: @component-padding*2 0;
+    padding: (@component-padding*2) 0;
     border-top: 1px solid @background-color-highlight;
     border-bottom: 1px solid @tool-panel-border-color;
   }

--- a/static/core-ui/docks.less
+++ b/static/core-ui/docks.less
@@ -95,13 +95,13 @@ atom-dock {
 
   width: @atom-dock-toggle-button-size;
   height: @atom-dock-toggle-button-size;
-  &.bottom { height: @atom-dock-toggle-button-size / 2; }
-  &.left, &.right { width: @atom-dock-toggle-button-size / 2; }
+  &.bottom { height: (@atom-dock-toggle-button-size / 2); }
+  &.left, &.right { width: (@atom-dock-toggle-button-size / 2); }
 
   .atom-dock-toggle-button-inner {
     width: @atom-dock-toggle-button-size;
     height: @atom-dock-toggle-button-size;
-    border-radius: @atom-dock-toggle-button-size / 2;
+    border-radius: (@atom-dock-toggle-button-size / 2);
 
     position: absolute;
     display: flex;

--- a/static/core-ui/text-editor.less
+++ b/static/core-ui/text-editor.less
@@ -168,7 +168,7 @@ atom-text-editor[mini] {
   contain: @contain_except_size;
   font-size: @input-font-size;
   line-height: @component-line-height;
-  max-height: @component-line-height + 2; // +2 for borders
+  max-height: (@component-line-height + 2); // +2 for borders
   overflow: auto;
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1946,14 +1946,6 @@ ajv-keywords@^3.4.1:
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-3.5.2.tgz#31f29da5ab6e00d1c2d329acf7b5929614d5014d"
   integrity sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==
 
-ajv@^4.9.1:
-  version "4.11.8"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-4.11.8.tgz#82ffb02b29e662ae53bdc20af15947706739c536"
-  integrity sha512-I/bSHSNEcFFqXLf91nchoNB9D1Kie3QKcWdchYUaoIg1+1bdWDkdfdlvdIOJbi9U8xR0y+MWc5D+won9v95WlQ==
-  dependencies:
-    co "^4.6.0"
-    json-stable-stringify "^1.0.1"
-
 ajv@^6.10.0, ajv@^6.12.0, ajv@^6.12.3, ajv@^6.12.4:
   version "6.12.6"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.6.tgz#baf5a62e802b07d977034586f8c3baf5adf26df4"
@@ -2235,11 +2227,6 @@ assert-plus@1.0.0, assert-plus@^1.0.0:
   resolved "https://registry.yarnpkg.com/assert-plus/-/assert-plus-1.0.0.tgz#f12e0f3c5d77b0b1cdd9146942e4e96c1e4dd525"
   integrity sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==
 
-assert-plus@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/assert-plus/-/assert-plus-0.2.0.tgz#d74e1b87e7affc0db8aadb7021f3fe48101ab234"
-  integrity sha512-u1L0ZLywRziOVjUhRxI0Qg9G+4RnFB9H/Rq40YWn0dieDgO7vAYeJz6jKAO6t/aruzlDFLAPkQTT87e+f8Imaw==
-
 assertion-error@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/assertion-error/-/assertion-error-1.1.0.tgz#e60b6b0e8f301bd97e5375215bda406c85118c0b"
@@ -2380,17 +2367,12 @@ available-typed-arrays@^1.0.5:
   resolved "https://registry.yarnpkg.com/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz#92f95616501069d07d10edb2fc37d3e1c65123b7"
   integrity sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==
 
-aws-sign2@~0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/aws-sign2/-/aws-sign2-0.6.0.tgz#14342dd38dbcc94d0e5b87d763cd63612c0e794f"
-  integrity sha512-JnJpAS0p9RmixkOvW2XwDxxzs1bd4/VAGIl6Q0EC5YOo+p+hqIhtDhn/nmFnB/xUNXbLkpE2mOjgVIBRKD4xYw==
-
 aws-sign2@~0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/aws-sign2/-/aws-sign2-0.7.0.tgz#b46e890934a9591f2d2f6f86d7e6a9f1b3fe76a8"
   integrity sha512-08kcGqnYf/YmjoRhfxyu+CLxBjUtHLXLXX/vUfx9l2LYzG3c1m61nrpyFUZI6zeS+Li/wWMMidD9KgrqtGq3mA==
 
-aws4@^1.2.1, aws4@^1.8.0:
+aws4@^1.8.0:
   version "1.11.0"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.11.0.tgz#d61f46d83b2519250e2784daf5b09479a8b41c59"
   integrity sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==
@@ -2605,13 +2587,6 @@ boolean@^3.0.1:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/boolean/-/boolean-3.2.0.tgz#9e5294af4e98314494cbb17979fa54ca159f116b"
   integrity sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==
-
-boom@2.x.x:
-  version "2.10.1"
-  resolved "https://registry.yarnpkg.com/boom/-/boom-2.10.1.tgz#39c8918ceff5799f83f9492a848f625add0c766f"
-  integrity sha512-KbiZEa9/vofNcVJXGwdWWn25reQ3V3dHBWbS07FTF3/TOehLnm9GEhJV4T6ZvGPkShRpmUqYwnaCrkj0mRnP6Q==
-  dependencies:
-    hoek "2.x.x"
 
 boxen@^5.0.0:
   version "5.1.2"
@@ -3075,11 +3050,6 @@ clsx@^1.1.0:
   resolved "https://registry.yarnpkg.com/clsx/-/clsx-1.2.1.tgz#0ddc4a20a549b59c93a4116bb26f5294ca17dc12"
   integrity sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==
 
-co@^4.6.0:
-  version "4.6.0"
-  resolved "https://registry.yarnpkg.com/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"
-  integrity sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==
-
 code-point-at@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
@@ -3179,7 +3149,7 @@ colors@~0.6.2:
   resolved "https://registry.yarnpkg.com/colors/-/colors-0.6.2.tgz#2423fe6678ac0c5dae8852e5d0e5be08c997abcc"
   integrity sha512-OsSVtHK8Ir8r3+Fxw/b4jS1ZLPXkV6ZxDRJQzeD7qo0SqMXWrHDM71DgYzPMHY8SFJ0Ao+nNU2p1MmwdzKqPrw==
 
-combined-stream@^1.0.5, combined-stream@^1.0.6, combined-stream@^1.0.8, combined-stream@~1.0.5, combined-stream@~1.0.6:
+combined-stream@^1.0.6, combined-stream@^1.0.8, combined-stream@~1.0.6:
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
   integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
@@ -3329,6 +3299,13 @@ convert-source-map@^1.1.0, convert-source-map@^1.7.0:
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.9.0.tgz#7faae62353fb4213366d0ca98358d22e8368b05f"
   integrity sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==
 
+copy-anything@^2.0.1:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/copy-anything/-/copy-anything-2.0.6.tgz#092454ea9584a7b7ad5573062b2a87f5900fc480"
+  integrity sha512-1j20GZTsvKNkc4BY3NpMOM8tt///wY3FpIzozTOFO2ffuZcV61nojHXVKIy3WM+7ADCy5FVhdZYHYDdgTU0yJw==
+  dependencies:
+    is-what "^3.14.1"
+
 core-js-compat@^3.21.0, core-js-compat@^3.22.1, core-js-compat@^3.6.2:
   version "3.26.1"
   resolved "https://registry.yarnpkg.com/core-js-compat/-/core-js-compat-3.26.1.tgz#0e710b09ebf689d719545ac36e49041850f943df"
@@ -3413,13 +3390,6 @@ crypt@0.0.2:
   version "0.0.2"
   resolved "https://registry.yarnpkg.com/crypt/-/crypt-0.0.2.tgz#88d7ff7ec0dfb86f713dc87bbb42d044d3e6c41b"
   integrity sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==
-
-cryptiles@2.x.x:
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/cryptiles/-/cryptiles-2.0.5.tgz#3bdfecdc608147c1c67202fa291e7dca59eaa3b8"
-  integrity sha512-FFN5KwpvvQTTS5hWPxrU8/QE4kQUc6uwZcrnlMBN82t1MgAtq8mnoDwINBly9Tdr02seeIIhtdF+UH1feBYGog==
-  dependencies:
-    boom "2.x.x"
 
 crypto-random-string@^2.0.0:
   version "2.0.0"
@@ -3524,6 +3494,13 @@ debug@^2.2.0, debug@^2.6.8, debug@^2.6.9:
   integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
   dependencies:
     ms "2.0.0"
+
+debug@^3.2.6:
+  version "3.2.7"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.7.tgz#72580b7e9145fb39b6676f9c5e5fb100b934179a"
+  integrity sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==
+  dependencies:
+    ms "^2.1.1"
 
 decamelize@^1.1.1, decamelize@^1.2.0:
   version "1.2.0"
@@ -4420,7 +4397,7 @@ ext@^1.1.2:
   dependencies:
     type "^2.7.2"
 
-extend@~3.0.0, extend@~3.0.2:
+extend@~3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
   integrity sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==
@@ -4636,15 +4613,6 @@ form-data@^4.0.0:
   dependencies:
     asynckit "^0.4.0"
     combined-stream "^1.0.8"
-    mime-types "^2.1.12"
-
-form-data@~2.1.1:
-  version "2.1.4"
-  resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.1.4.tgz#33c183acf193276ecaa98143a69e94bfee1750d1"
-  integrity sha512-8HWGSLAPr+AG0hBpsqi5Ob8HrLStN/LWeqhpFl14d7FJgHK48TmgLoALPz69XSUR65YJzDfLUX/BM8+MLJLghQ==
-  dependencies:
-    asynckit "^0.4.0"
-    combined-stream "^1.0.5"
     mime-types "^2.1.12"
 
 form-data@~2.3.2:
@@ -4913,7 +4881,7 @@ getpass@^0.1.1:
 "git-diff@file:packages/git-diff":
   version "1.3.9"
   dependencies:
-    atom-select-list "^0.7.0"
+    atom-select-list "^0.8.1"
 
 git-utils@5.7.1:
   version "5.7.1"
@@ -5197,23 +5165,10 @@ handlebars@^4.7.7:
   optionalDependencies:
     uglify-js "^3.1.4"
 
-har-schema@^1.0.5:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/har-schema/-/har-schema-1.0.5.tgz#d263135f43307c02c602afc8fe95970c0151369e"
-  integrity sha512-f8xf2GOR6Rgwc9FPTLNzgwB+JQ2/zMauYXSWmX5YV5acex6VomT0ocSuwR7BfXo5MpHi+jL+saaux2fwsGJDKQ==
-
 har-schema@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/har-schema/-/har-schema-2.0.0.tgz#a94c2224ebcac04782a0d9035521f24735b7ec92"
   integrity sha512-Oqluz6zhGX8cyRaTQlFMPw80bSJVG2x/cFb8ZPhUILGgHka9SsokCCOQgpveePerqidZOrT14ipqfJb7ILcW5Q==
-
-har-validator@~4.2.1:
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/har-validator/-/har-validator-4.2.1.tgz#33481d0f1bbff600dd203d75812a6a5fba002e2a"
-  integrity sha512-5Gbp6RAftMYYV3UEI4c4Vv3+a4dQ7taVyvHt+/L6kRt+f4HX1GweAk5UDWN0SvdVnRBzGQ6OG89pGaD9uSFnVw==
-  dependencies:
-    ajv "^4.9.1"
-    har-schema "^1.0.5"
 
 har-validator@~5.1.3:
   version "5.1.5"
@@ -5274,25 +5229,10 @@ has@^1.0.3:
   dependencies:
     function-bind "^1.1.1"
 
-hawk@~3.1.3:
-  version "3.1.3"
-  resolved "https://registry.yarnpkg.com/hawk/-/hawk-3.1.3.tgz#078444bd7c1640b0fe540d2c9b73d59678e8e1c4"
-  integrity sha512-X8xbmTc1cbPXcQV4WkLcRMALuyoxhfpFATmyuCxJPOAvrDS4DNnsTAOmKUxMTOWU6TzrTOkxPKwIx5ZOpJVSrg==
-  dependencies:
-    boom "2.x.x"
-    cryptiles "2.x.x"
-    hoek "2.x.x"
-    sntp "1.x.x"
-
 he@1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
-
-hoek@2.x.x:
-  version "2.16.3"
-  resolved "https://registry.yarnpkg.com/hoek/-/hoek-2.16.3.tgz#20bb7403d3cea398e91dc4710a8ff1b8274a25ed"
-  integrity sha512-V6Yw1rIcYV/4JsnggjBU0l4Kr+EXhpwqXRusENU1Xx6ro00IHPHYNynCuBTOZAPlr3AAmLvchH9I7N/VUdvOwQ==
 
 hosted-git-info@^2.8.9:
   version "2.8.9"
@@ -5338,15 +5278,6 @@ http-proxy-agent@^5.0.0:
     "@tootallnate/once" "2"
     agent-base "6"
     debug "4"
-
-http-signature@~1.1.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/http-signature/-/http-signature-1.1.1.tgz#df72e267066cd0ac67fb76adf8e134a8fbcf91bf"
-  integrity sha512-iUn0NcRULlDGtqNLN1Jxmzayk8ogm7NToldASyZBpM2qggbphjXzNOiw3piN8tgz+e/DRs6X5gAzFwTI6BCRcg==
-  dependencies:
-    assert-plus "^0.2.0"
-    jsprim "^1.2.2"
-    sshpk "^1.7.0"
 
 http-signature@~1.2.0:
   version "1.2.0"
@@ -5408,7 +5339,7 @@ iconv-lite@^0.4.4, iconv-lite@~0.4.4:
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
 
-iconv-lite@^0.6.2:
+iconv-lite@^0.6.2, iconv-lite@^0.6.3:
   version "0.6.3"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.6.3.tgz#a52f80bf38da1952eb5c681790719871a1a72501"
   integrity sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==
@@ -5767,6 +5698,11 @@ is-weakset@^2.0.1:
   dependencies:
     call-bind "^1.0.2"
     get-intrinsic "^1.1.1"
+
+is-what@^3.14.1:
+  version "3.14.1"
+  resolved "https://registry.yarnpkg.com/is-what/-/is-what-3.14.1.tgz#e1222f46ddda85dead0fd1c9df131760e77755c1"
+  integrity sha512-sNxgpk9793nzSs7bA6JQJGeIuRBQhAaNGG77kzYQgMkrID+lS6SlK07K5LaptscDlSaIgH+GPFzf+d75FVxozA==
 
 is-wsl@^2.2.0:
   version "2.2.0"
@@ -6321,29 +6257,31 @@ lcid@^1.0.0:
   dependencies:
     invert-kv "^1.0.0"
 
-less-cache@1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/less-cache/-/less-cache-1.1.0.tgz#7e2f6b395fa5c7a974374905c858f2d3e9d15320"
-  integrity sha512-hFd0OdUMv2C4FoYVe6CfaGK2ydpT406wZiZP1h0I22hOkcdHvAvSrOsodB1OTe/FIis4NUog+7HsGdmfA3i1yg==
+less-cache@pulsar-edit/less-cache#v2.0.0:
+  version "2.0.0"
+  resolved "https://codeload.github.com/pulsar-edit/less-cache/tar.gz/6e01ff396df0055330e54e38fb4718807bc770f5"
   dependencies:
-    fs-plus "^3.0.0"
-    less "^2.7.1"
-    underscore-plus "1.x"
-    walkdir "0.0.11"
+    fs-plus "^3.1.1"
+    less "^4.1.3"
+    underscore-plus "^1.7.0"
+    walkdir "^0.4.1"
 
-less@^2.7.1:
-  version "2.7.3"
-  resolved "https://registry.yarnpkg.com/less/-/less-2.7.3.tgz#cc1260f51c900a9ec0d91fb6998139e02507b63b"
-  integrity sha512-KPdIJKWcEAb02TuJtaLrhue0krtRLoRoo7x6BNJIBelO00t/CCdJQUnHW5V34OnHMWzIktSalJxRO+FvytQlCQ==
+less@^4.1.3:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/less/-/less-4.1.3.tgz#175be9ddcbf9b250173e0a00b4d6920a5b770246"
+  integrity sha512-w16Xk/Ta9Hhyei0Gpz9m7VS8F28nieJaL/VyShID7cYvP6IL5oHeL6p4TXSDJqZE/lNv0oJ2pGVjJsRkfwm5FA==
+  dependencies:
+    copy-anything "^2.0.1"
+    parse-node-version "^1.0.1"
+    tslib "^2.3.0"
   optionalDependencies:
     errno "^0.1.1"
     graceful-fs "^4.1.2"
     image-size "~0.5.0"
-    mime "^1.2.11"
-    mkdirp "^0.5.0"
-    promise "^7.1.1"
-    request "2.81.0"
-    source-map "^0.5.3"
+    make-dir "^2.1.0"
+    mime "^1.4.1"
+    needle "^3.1.0"
+    source-map "~0.6.0"
 
 levn@^0.4.1:
   version "0.4.1"
@@ -6714,14 +6652,14 @@ mime-db@1.52.0:
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.52.0.tgz#bbabcdc02859f4987301c856e3387ce5ec43bf70"
   integrity sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
 
-mime-types@^2.1.12, mime-types@~2.1.19, mime-types@~2.1.7:
+mime-types@^2.1.12, mime-types@~2.1.19:
   version "2.1.35"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.35.tgz#381a871b62a734450660ae3deee44813f70d959a"
   integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==
   dependencies:
     mime-db "1.52.0"
 
-mime@^1.2.11:
+mime@^1.4.1:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.6.0.tgz#32cd9e5c64553bd58d19a568af452acff04981b1"
   integrity sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==
@@ -6906,7 +6844,7 @@ mkdirp@0.5.4:
   dependencies:
     minimist "^1.2.5"
 
-"mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@^0.5.4, mkdirp@^0.5.5, mkdirp@~0.5.1:
+"mkdirp@>=0.5 0", mkdirp@^0.5.1, mkdirp@^0.5.4, mkdirp@^0.5.5, mkdirp@~0.5.1:
   version "0.5.6"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.6.tgz#7def03d2432dcae4ba1d611445c48396062255f6"
   integrity sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==
@@ -7058,6 +6996,15 @@ natural@^0.6.3:
     json-stable-stringify "^1.0.1"
     sylvester "^0.0.12"
     underscore "^1.3.1"
+
+needle@^3.1.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/needle/-/needle-3.2.0.tgz#07d240ebcabfd65c76c03afae7f6defe6469df44"
+  integrity sha512-oUvzXnyLiVyVGoianLijF9O/RecZUf7TkBfimjGrLM4eQhXyeJwM6GeAWccwfQ9aa4gMCZKqhAOuLaMIcQxajQ==
+  dependencies:
+    debug "^3.2.6"
+    iconv-lite "^0.6.3"
+    sax "^1.2.4"
 
 negotiator@^0.6.2:
   version "0.6.3"
@@ -7281,11 +7228,6 @@ number-is-nan@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/number-is-nan/-/number-is-nan-1.0.1.tgz#097b602b53422a522c1afb8790318336941a011d"
   integrity sha512-4jbtZXNAsfZbAHiiqjLPBiCl16dES1zI4Hpzzxw61Tk+loF+sBDBKx1ICKKKwIqQ7M0mFn1TmkN7euSncWgHiQ==
-
-oauth-sign@~0.8.1:
-  version "0.8.2"
-  resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.8.2.tgz#46a6ab7f0aead8deae9ec0565780b7d4efeb9d43"
-  integrity sha512-VlF07iu3VV3+BTXj43Nmp6Irt/G7j/NgEctUS6IweH1RGhURjjCc2NWtzXFPXXWWfc7hgbXQdtiQu2LGp6MxUg==
 
 oauth-sign@~0.9.0:
   version "0.9.0"
@@ -7533,6 +7475,11 @@ parse-json@^5.0.0:
     json-parse-even-better-errors "^2.3.0"
     lines-and-columns "^1.1.6"
 
+parse-node-version@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/parse-node-version/-/parse-node-version-1.0.1.tgz#e2b5dbede00e7fa9bc363607f53327e8b073189b"
+  integrity sha512-3YHlOa/JgH6Mnpr05jP9eDG254US9ek25LyIxZlDItp2iJtwyaXQb57lBYLdT3MowkUFYEV2XXNAYIPlESvJlA==
+
 parse5-htmlparser2-tree-adapter@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-7.0.0.tgz#23c2cc233bcf09bb7beba8b8a69d46b08c62c2f1"
@@ -7620,11 +7567,6 @@ pend@~1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/pend/-/pend-1.2.0.tgz#7a57eb550a6783f9115331fcf4663d5c8e007a50"
   integrity sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==
-
-performance-now@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-0.2.0.tgz#33ef30c5c77d4ea21c5a53869d91b56d8f2555e5"
-  integrity sha512-YHk5ez1hmMR5LOkb9iJkLKqoBlL7WD5M8ljC75ZfzXriuBIVNuecaXuU7e+hOwyqf24Wxhh7Vxgt7Hnw9288Tg==
 
 performance-now@^2.1.0:
   version "2.1.0"
@@ -7869,11 +7811,6 @@ pump@^3.0.0:
     end-of-stream "^1.1.0"
     once "^1.3.1"
 
-punycode@^1.4.1:
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
-  integrity sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==
-
 punycode@^2.1.0, punycode@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
@@ -7903,11 +7840,6 @@ puppeteer-core@^13.1.3:
     tar-fs "2.1.1"
     unbzip2-stream "1.4.3"
     ws "8.5.0"
-
-qs@~6.4.0:
-  version "6.4.1"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-6.4.1.tgz#2bad97710a5b661c366b378b1e3a44a592ff45e6"
-  integrity sha512-LQy1Q1fcva/UsnP/6Iaa4lVeM49WiOitu2T4hZCyA/elLKu37L99qcBJk4VCCk+rdLvnMzfKyiN3SZTqdAZGSQ==
 
 qs@~6.5.2:
   version "6.5.3"
@@ -8168,34 +8100,6 @@ relay-runtime@5.0.0:
   dependencies:
     "@babel/runtime" "^7.0.0"
     fbjs "^1.0.0"
-
-request@2.81.0:
-  version "2.81.0"
-  resolved "https://registry.yarnpkg.com/request/-/request-2.81.0.tgz#c6928946a0e06c5f8d6f8a9333469ffda46298a0"
-  integrity sha512-IZnsR7voF0miGSu29EXPRgPTuEsI/+aibNSBbN1pplrfartF5wDYGADz3iD9vmBVf2r00rckWZf8BtS5kk7Niw==
-  dependencies:
-    aws-sign2 "~0.6.0"
-    aws4 "^1.2.1"
-    caseless "~0.12.0"
-    combined-stream "~1.0.5"
-    extend "~3.0.0"
-    forever-agent "~0.6.1"
-    form-data "~2.1.1"
-    har-validator "~4.2.1"
-    hawk "~3.1.3"
-    http-signature "~1.1.0"
-    is-typedarray "~1.0.0"
-    isstream "~0.1.2"
-    json-stringify-safe "~5.0.1"
-    mime-types "~2.1.7"
-    oauth-sign "~0.8.1"
-    performance-now "^0.2.0"
-    qs "~6.4.0"
-    safe-buffer "^5.0.1"
-    stringstream "~0.0.4"
-    tough-cookie "~2.3.0"
-    tunnel-agent "^0.6.0"
-    uuid "^3.0.0"
 
 request@^2.83.0:
   version "2.88.2"
@@ -8673,13 +8577,6 @@ smart-buffer@^4.0.2, smart-buffer@^4.2.0:
     temp "~0.8.0"
     underscore-plus "^1.0.0"
 
-sntp@1.x.x:
-  version "1.0.9"
-  resolved "https://registry.yarnpkg.com/sntp/-/sntp-1.0.9.tgz#6541184cc90aeea6c6e7b35e2659082443c66198"
-  integrity sha512-7bgVOAnPj3XjrKY577S+puCKGCRlUrcrEdsMeRXlg9Ghf5df/xNi6sONUa43WrHUd3TjJBF7O04jYoiY0FVa0A==
-  dependencies:
-    hoek "2.x.x"
-
 socks-proxy-agent@^6.0.0:
   version "6.2.1"
   resolved "https://registry.yarnpkg.com/socks-proxy-agent/-/socks-proxy-agent-6.2.1.tgz#2687a31f9d7185e38d530bef1944fe1f1496d6ce"
@@ -8726,12 +8623,12 @@ source-map@0.1.32:
   dependencies:
     amdefine ">=0.0.4"
 
-source-map@^0.5.0, source-map@^0.5.3:
+source-map@^0.5.0:
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
   integrity sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==
 
-source-map@^0.6.0, source-map@^0.6.1:
+source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.0:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
@@ -8967,11 +8864,6 @@ string_decoder@~1.1.1:
   integrity sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==
   dependencies:
     safe-buffer "~5.1.0"
-
-stringstream@~0.0.4:
-  version "0.0.6"
-  resolved "https://registry.yarnpkg.com/stringstream/-/stringstream-0.0.6.tgz#7880225b0d4ad10e30927d167a1d6f2fd3b33a72"
-  integrity sha512-87GEBAkegbBcweToUrdzf3eLhWNg06FJTebl4BVJz/JgWy8CvEr9dRtX5qWphiynMSQlxxi+QqN0z5T32SLlhA==
 
 strip-ansi@^3.0.0, strip-ansi@^3.0.1:
   version "3.0.1"
@@ -9318,13 +9210,6 @@ to-regex-range@^5.0.1:
   dependencies:
     is-number "^7.0.0"
 
-tough-cookie@~2.3.0:
-  version "2.3.4"
-  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.3.4.tgz#ec60cee38ac675063ffc97a5c18970578ee83655"
-  integrity sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==
-  dependencies:
-    punycode "^1.4.1"
-
 tough-cookie@~2.5.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.5.0.tgz#cd9fb2a0aa1d5a12b473bd9fb96fa3dcff65ade2"
@@ -9480,6 +9365,11 @@ truncate-utf8-bytes@^1.0.0:
   integrity sha512-95Pu1QXQvruGEhv62XCMO3Mm90GscOCClvrIUwCM0PYOXK3kaF3l3sIHxx71ThJfcbM2O5Au6SO3AWCSEfW4mQ==
   dependencies:
     utf8-byte-length "^1.0.1"
+
+tslib@^2.3.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.6.0.tgz#b295854684dbda164e181d259a22cd779dcd7bc3"
+  integrity sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==
 
 tunnel-agent@^0.6.0:
   version "0.6.0"
@@ -9737,7 +9627,7 @@ util-deprecate@^1.0.1, util-deprecate@^1.0.2, util-deprecate@~1.0.1:
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
   integrity sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==
 
-uuid@^3.0.0, uuid@^3.3.2:
+uuid@^3.3.2:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
@@ -9804,17 +9694,12 @@ walk-back@^5.1.0:
   resolved "https://registry.yarnpkg.com/walk-back/-/walk-back-5.1.0.tgz#486d6f29e67f56ab89b952d987028bbb1a4e956c"
   integrity sha512-Uhxps5yZcVNbLEAnb+xaEEMdgTXl9qAQDzKYejG2AZ7qPwRQ81lozY9ECDbjLPNWm7YsO1IK5rsP1KoQzXAcGA==
 
-walkdir@0.0.11:
-  version "0.0.11"
-  resolved "https://registry.yarnpkg.com/walkdir/-/walkdir-0.0.11.tgz#a16d025eb931bd03b52f308caed0f40fcebe9532"
-  integrity sha512-lMFYXGpf7eg+RInVL021ZbJJT4hqsvsBvq5sZBp874jfhs3IWlA7OPoG0ojQrYcXHuUSi+Nqp6qGN+pPGaMgPQ==
-
 walkdir@0.0.7:
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/walkdir/-/walkdir-0.0.7.tgz#04da0270a87a778540173cdbf0a2db499a8d9e29"
   integrity sha512-onj2wLVXrMWx/Ptvb1fobwLsoU/Aah+WHzcdu1iUXDKaJX12HWQsTF/41TwUBSULvNf+EjYMXoKePPt3x8FcXA==
 
-"walkdir@>= 0.0.1":
+"walkdir@>= 0.0.1", walkdir@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/walkdir/-/walkdir-0.4.1.tgz#dc119f83f4421df52e3061e514228a2db20afa39"
   integrity sha512-3eBwRyEln6E1MSzcxcVpQIhRG8Q1jLvEqRmCZqS3dsfXEDR/AhOF4d+jHg1qvDCpYaVRZjENPQyrVxAkQqxPgQ==


### PR DESCRIPTION
This PR brings us the newest changes within `less-cache`:

- Updating `less` from `3.12.2` -> `4.1.3`
- Normalizing all paths to use `/` on Linux, macOS, and Windows
- Decaffeinating the CoffeeScript source code

This now means we are using Less v4, which does come with some breaking changes to existing Less StyleSheets. For one of these breaking changes it's possible to set a flag within Less to remain using the older functionality, but on Discord it was determined to move forward with the new code, and instead apply fixes for all breakage to existing grammars. The biggest breaking changes can be read more about on the [`less-cache@2.0.0` release](https://github.com/pulsar-edit/less-cache/releases/tag/v2.0.0). I've also added a notice to the CHANGELOG of this breakage, and urge any and all users that see this to assist in possible with fixing syntax themes in the wild.

Because of these changes, some fixes had to be made within Pulsar itself, and our core packages/themes. Some of these were expected, such as wrapping math within `()` while others where surprising, such as failing to built a stylesheet on undefined variables, which made me discover long abandoned and unused styles within `settings-view` attempting to use variables, that as far as I can tell since their [inception](https://github.com/atom/settings-view/pull/277) have always been invalid. So offending blocks, where this invalid CSS was all that existed have been removed totally. 

Otherwise these changes have been tested with all of our core Themes and packages, and seems no other packages need any manual changes.

Additionally, this PR will nearly help us close #468 

## Curbing breaking Changes

After reading the above, which is unedited since my original creation of this PR, you can see the concerns of causing breaking changes in loads of community packages, but my latest comment details how I thought we could protect against this in community packages, by inspecting the CSS style sheets before applying them, much like we already do for the scope selectors themselves. 

Those changes have been completed, and will be pushed to this PR soon, after creating some tests.

But essentially, after we look for deprecated syntax selectors, we will also go ahead and search for any mathematical expressions contained within the source CSS that is not escaped properly.
This will not occur for bundled packages, much the same way we don't inspect bundled packages for deprecated selectors. Really much of the functionality choices have been taken directly from how we handle deprecated selectors. With that said, a quick proof of this functionality can be seen below:

As issue #612 shows, one of the breaking changes effected the `one-dark-ui` CSS for the status bar. Looking there for how this broke the status bar styling, if we again, leave our non-updated less style sheet containing the following:

```less
.inline-block {
    margin: 0; // override default
    padding: 0 @status-bar-padding/2; // TODO fix after testing
    vertical-align: top;

    &:hover {
      text-decoration: none;
      background-color: @level-3-color-hover;
    }
    &:active {
      background-color: @level-3-color-active;
    }

    // reset on child inline-block
    .inline-block {
      margin: 0;
      padding: 0;
    }
  }
```

Where we have our comment to fix this, before the our newest protections on reading the compiled CSS where created, would result in the following:

![image](https://github.com/pulsar-edit/pulsar/assets/26921489/a926051a-87b6-4e29-9b53-7a447ff3509a)

But now, with our protections, we can see the resulting CSS is as follows:

```css
.status-bar .inline-block {
  margin: 0;
  padding: 0 calc(1.5rem/2);
  vertical-align: top;
}
```

Which gives us the CSS we would expect to see here, styling the page as we would expect.

Additionally, since we had to manually restyle the CSS to work properly, we can now see this in our deprecations, where if we investigate the message via Deprecation Cop we get the following string:

```
[node_modules\one-dark-ui\index.less](file:///D:/pulsar-edit/pulsar/node_modules/one-dark-ui/index.less)

Starting from Pulsar v1.107.0, less v4.1.3 is used to transpile less style sheets. This means that Parens-division is now the default math setting, and all less style sheets must wrap division within parenthesis. To prevent breakage with existing style sheets, Pulsar will automatically wrap any mathematical expressions found unparsed by Less with calc(). Upgrading the values of the following properties:

* padding: 0 1.5em/2 => 0 calc(1.5em/2)

Please, make sure to upgrade usage of mathematical expressions within less style sheets.
```

So we can see, not only do these protections keep community packages less style sheets working in the vast majority of circumstances, it will also make users much more aware of this breakage, and hopefully let people fix these on their own time, rather than having things break immediately.  

Obviously, since we are using a long complex regex to check for these mathematical expressions, there will be edge cases where we won't be able to manually inject proper styling, but I hope that this is able to resolve enough of these issues, that the vast majority of users are unaffected.

---

Last but not least, for ease in writing the full changelog later, here are the full updates within `less-cache`.

## `less-cache`

- Added: Implement Repo Tests [@confused-Techie](https://github.com/pulsar-edit/less-cache/pull/1)
- Added: Manual decaf of source files [@confused-Techie](https://github.com/pulsar-edit/less-cache/pull/2)
- Fixed: Repository Cleanup + CoffeeScript Tool Removal [@confused-Techie](https://github.com/pulsar-edit/less-cache/pull/3)
- Bumped: Bump `less` `3.12.2` => `4.1.3` [@confused-Techie](https://github.com/pulsar-edit/less-cache/pull/4)
- Bumped: Bump `1.1.1` => `2.0.0` [@confused-Techie](https://github.com/pulsar-edit/less-cache/pull/5)