### PR TITLE
[spell-check]: Remove usage of reserved word

### DIFF
--- a/packages/spell-check/spec/spell-check-spec.js
+++ b/packages/spell-check/spec/spell-check-spec.js
@@ -27,8 +27,8 @@ describe('Spell check', function () {
         await atom.packages.activatePackage('language-text');
         await atom.packages.activatePackage('language-javascript');
         await atom.workspace.open(`${__dirname}${sep}sample.js`);
-        const package = await atom.packages.activatePackage('spell-check');
-        spellCheckModule = package.mainModule;
+        const pack = await atom.packages.activatePackage('spell-check');
+        spellCheckModule = pack.mainModule;
 
         // Disable the grammers so nothing is done until we turn it back on.
         atom.config.set('spell-check.grammars', []);


### PR DESCRIPTION
Currently our documentation CI is [failing to run](https://github.com/pulsar-edit/pulsar/actions/runs/5445766009/jobs/9905486497) since the newly bundled package `spell-check` uses a [reserved word](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#future_reserved_words) that causes the CI to stop executing.

Simply just changed the name to something shorter.