### PR TITLE
[markdown-preview]: Support for nested table objects in Yaml Frontmatter

### DIFF
--- a/packages/markdown-preview/lib/renderer.js
+++ b/packages/markdown-preview/lib/renderer.js
@@ -108,7 +108,7 @@ function renderYamlTable (variables) {
     entries.map(entry => entry[0]),
     entries.map(entry => '--'),
     entries.map((entry) => {
-      if (typeof entry[1] === "object") {
+      if (typeof entry[1] === "object" && !Array.isArray(entry[1])) {
         // Remove all newlines, or they ruin formatting of parent table
         return marked.parse(renderYamlTable(entry[1])).replace(/\n/g,"");
       } else {

--- a/packages/markdown-preview/lib/renderer.js
+++ b/packages/markdown-preview/lib/renderer.js
@@ -107,7 +107,14 @@ function renderYamlTable (variables) {
   const markdownRows = [
     entries.map(entry => entry[0]),
     entries.map(entry => '--'),
-    entries.map(entry => entry[1])
+    entries.map((entry) => {
+      if (typeof entry[1] === "object") {
+        // Remove all newlines, or they ruin formatting of parent table
+        return marked.parse(renderYamlTable(entry[1])).replace(/\n/g,"");
+      } else {
+        return entry[1];
+      }
+    })
   ]
 
   return (

--- a/packages/markdown-preview/package.json
+++ b/packages/markdown-preview/package.json
@@ -15,7 +15,7 @@
     "fs-plus": "^3.0.0",
     "marked": "5.0.3",
     "underscore-plus": "^1.0.0",
-    "yaml-front-matter": "^4.0.0"
+    "yaml-front-matter": "^4.1.1"
   },
   "devDependencies": {
     "temp": "^0.8.1"

--- a/packages/markdown-preview/spec/fixtures/subdir/file.markdown
+++ b/packages/markdown-preview/spec/fixtures/subdir/file.markdown
@@ -3,6 +3,8 @@ variable1: value1
 array:
   - foo
   - bar
+object:
+  key: value2
 ---
 
 ## File.markdown

--- a/packages/markdown-preview/spec/markdown-preview-view-spec.js
+++ b/packages/markdown-preview/spec/markdown-preview-view-spec.js
@@ -338,12 +338,12 @@ end\
           [...preview.element.querySelectorAll('table th')].map(
             el => el.textContent
           )
-        ).toEqual(['variable1', 'array'])
+        ).toEqual(['variable1', 'array', 'object', 'key'])
         expect(
           [...preview.element.querySelectorAll('table td')].map(
             el => el.textContent
           )
-        ).toEqual(['value1', 'foo,bar'])
+        ).toEqual(['value1', 'foo,bar', 'keyvalue2', 'value2'])
       })
     })
   })


### PR DESCRIPTION
Resolves #628 

This PR adds the ability to insert nested objects as nested tables from the  yaml frontmatter into Markdown preview.

This behave matches what GitHub does with nested objects in yaml frontmatter.

Since Markdown itself cannot support nested tables, any child tables within a markdown table must themselves be proper HTML. So if the frontmatter table builder encounters a value that is an object, it'll create the table for it, then go ahead and pass that table through marked, only then returning the new HTML table.

## Before PR

![image](https://github.com/pulsar-edit/pulsar/assets/26921489/ec543af3-666c-47ab-bf65-e899dc2c9826)


## After PR

![image](https://github.com/pulsar-edit/pulsar/assets/26921489/df38a6f3-1c96-4c13-942b-1c7eabd0db6f)
