### PR TITLE
Bump `less-cache` to 2.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -122,7 +122,7 @@
     "language-typescript": "file:packages/language-typescript",
     "language-xml": "file:packages/language-xml",
     "language-yaml": "file:packages/language-yaml",
-    "less-cache": "pulsar-edit/less-cache#v2.0.0",
+    "less-cache": "pulsar-edit/less-cache#v2.0.1",
     "line-ending-selector": "file:packages/line-ending-selector",
     "line-top-index": "0.3.1",
     "link": "file:packages/link",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6257,9 +6257,9 @@ lcid@^1.0.0:
   dependencies:
     invert-kv "^1.0.0"
 
-less-cache@pulsar-edit/less-cache#v2.0.0:
-  version "2.0.0"
-  resolved "https://codeload.github.com/pulsar-edit/less-cache/tar.gz/6e01ff396df0055330e54e38fb4718807bc770f5"
+less-cache@pulsar-edit/less-cache#v2.0.1:
+  version "2.0.1"
+  resolved "https://codeload.github.com/pulsar-edit/less-cache/tar.gz/40bf113d57aa29d93f7a0d7d575c72045467f016"
   dependencies:
     fs-plus "^3.1.1"
     less "^4.1.3"


### PR DESCRIPTION
### Identify the Bug

Fixes the bug that was addressed in [less-cache#6](https://github.com/pulsar-edit/less-cache/pull/6).

### Description of the Change

Inline JavaScript (within backticks) will once again be tolerated within certain LESS constructs. This is a feature I was using so that I could write

```less
.s('string.quoted.double', { color: green; });
```

instead of

```css
.syntax--string.syntax--quoted.syntax--double {
  color: green;
}
```

Less.js has deprecated this behavior, but we haven’t, and it’s good not to break stuff.

### Alternate Designs

There is an alternative way of pulling this off with `@plugin` rules, but it only works in Less v4, and there’s no simple way to offer up the right solution for the user’s Pulsar version, so I’ll hold off on adopting that approach in my syntax theme until I’m certain it won’t break for the entirely fictional other people who are also using `vibrant-ink-redux` as their syntax theme.

### Possible Drawbacks

I can’t think of any. This is no less secure than what we were already doing, and I don’t think it’s a security problem at all, since the JS inside a `less` file is ultimately no less sandboxed than the JS we allow a package to run otherwise.

### Verification Process

Wrote a unit test in `less-cache` to demonstrate the fix. If CI passes, we should be good.

### Release Notes

Restored ability for `less` files in packages to use inline JavaScript inside backticks
