### PR TITLE
[language-toml] Add whitespace rule to values

### DIFF
--- a/packages/language-toml/grammars/toml.cson
+++ b/packages/language-toml/grammars/toml.cson
@@ -95,11 +95,11 @@
   'values':
     'patterns': [
       {
-        'begin': '\\[\\s*'
+        'begin': '\\['
         'beginCaptures':
           '0':
             'name': 'punctuation.definition.array.begin.toml'
-        'end': '\\s*\\]'
+        'end': '\\]'
         'endCaptures':
           '0':
             'name': 'punctuation.definition.array.end.toml'
@@ -108,7 +108,7 @@
             'include': '#comment'
           }
           {
-            'match': ',\\s*'
+            'match': ','
             'name': 'punctuation.definition.separator.comma.toml'
           }
           {
@@ -199,6 +199,9 @@
       }
       {
         'include': '#numbers'
+      }
+      {
+        'include': '#whitespace'
       }
       {
         'match': '.+'
@@ -293,3 +296,6 @@
         'name': 'constant.numeric.binary.toml'
       }
     ]
+  'whitespace':
+    'match': '\\s+'
+    'name': 'punctuation.whitespace.ignore.toml'


### PR DESCRIPTION
### Identify the Bug

Fixes #564

### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

Adds an additional rule for `whitespace` to `values` which matches before the `invalid.illegal.toml` rule.

For more details see here: [#564 comment](https://github.com/pulsar-edit/pulsar/issues/564#issuecomment-1637135580).

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

An alternative would be to remove the `invalid.illegal.toml` rule, however this would mean that invalid non-whitespace sequences may display as correct.

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

By allowing whitespace to be trated as a value it is possible that syntactically incorrect TOML will display as valid.

### Verification Process

<!--

What process did you follow to verify that the change has not introduced any regressions? Describe the actions you performed (including buttons you clicked, text you typed, commands you ran, etc.), and describe the results you observed.

-->

Compared the change using example TOML files containing multi-line arrays in Pulsar using the TextMate grammar with Atom v1.60.0. Also compared the change with the modern Tree-Sitter implementation.

### Release Notes

<!--

Please describe the changes in a single line that explains this improvement in
terms that a user can understand. This text will be used in Atom's release notes.

If this change is not user-facing or notable enough to be included in release notes
you may use the strings "Not applicable" or "N/A" here.

Examples:

- The GitHub package now allows you to add co-authors to commits.
- Fixed an issue where multiple cursors did not work in a file with a single line.
- Increased the performance of searching and replacing across a whole project.

-->

[language-toml] Add whitespace rule to values