### PR TITLE
[styleguide] Fix error when styleguide is shown…

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -14,6 +14,11 @@ module.exports = {
     ecmaVersion: "latest"
   },
   rules: {
+    "space-before-function-paren": ["error", {
+      anonymous: "always",
+      asyncArrow: "always",
+      named: "never"
+    }],
     "node/no-unpublished-require": [
       "error",
       {

--- a/packages/styleguide/lib/code-block.js
+++ b/packages/styleguide/lib/code-block.js
@@ -1,17 +1,57 @@
 const {TextEditor} = require('atom')
 
+const PROMISES_BY_SCOPE_NAME = new Map();
+
 module.exports =
 class CodeBlock {
-  constructor (props) {
+  constructor(props) {
     this.editor = new TextEditor({readonly: true, keyboardInputEnabled: false})
     this.element = document.createElement('div')
     this.element.appendChild(this.editor.getElement())
-    atom.grammars.assignLanguageMode(this.editor, props.grammarScopeName)
     this.update(props)
+    this.whenGrammarAdded(props.grammarScopeName)
+      .then(() => {
+        // We don't use the returned grammar here; instead we trigger logic
+        // that matches up the grammars present right now with the user's
+        // stated preferences for language mode (TextMate vs Tree-sitter).
+        //
+        // In other words: “Once any grammar for language X loads, wait another
+        // second, then pick the language X grammar that best fits our needs.”
+        atom.grammars.assignLanguageMode(this.editor, props.grammarScopeName)
+      })
   }
 
-  update ({cssClass, code}) {
+  update({cssClass, code}) {
     this.editor.setText(code)
     this.element.classList.add(cssClass)
+  }
+
+  whenGrammarAdded(scopeName) {
+    // Lots of these will fire at once for the same scope name; we want them
+    // all to use the same promise.
+    if (PROMISES_BY_SCOPE_NAME.has(scopeName)) {
+      return PROMISES_BY_SCOPE_NAME.get(scopeName)
+    }
+
+    let grammar = atom.grammars.grammarForId(scopeName);
+    if (grammar) return Promise.resolve(grammar);
+
+    let promise = new Promise(resolve => {
+      let disposable = atom.grammars.onDidAddGrammar(grammar => {
+        if (grammar?.scopeName !== scopeName) return
+        disposable.dispose()
+
+        // If we resolve immediately, we might not get the right grammar for
+        // the user's preferred language mode setting. A short pause will allow
+        // all the grammars of a given language time to activate.
+        //
+        // This is how we balance assigning the grammar for the “wrong”
+        // language mode… versus waiting for another one that may never arrive.
+        setTimeout(resolve(grammar), 1000)
+      })
+    })
+
+    PROMISES_BY_SCOPE_NAME.set(scopeName, promise)
+    return promise
   }
 }

--- a/packages/styleguide/spec/styleguide-spec.js
+++ b/packages/styleguide/spec/styleguide-spec.js
@@ -16,7 +16,6 @@ describe('Style Guide', () => {
     })
 
     it('opens the style guide', () => {
-      console.log('OK', styleGuideView.element);
       expect(styleGuideView.element.textContent).toContain('Styleguide')
     })
 

--- a/packages/styleguide/spec/styleguide-spec.js
+++ b/packages/styleguide/spec/styleguide-spec.js
@@ -1,5 +1,9 @@
 const {it, fit, ffit, beforeEach, afterEach} = require('./async-spec-helpers') // eslint-disable-line no-unused-vars
 
+function wait(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
 describe('Style Guide', () => {
   beforeEach(async () => {
     await atom.packages.activatePackage('styleguide')
@@ -12,7 +16,21 @@ describe('Style Guide', () => {
     })
 
     it('opens the style guide', () => {
+      console.log('OK', styleGuideView.element);
       expect(styleGuideView.element.textContent).toContain('Styleguide')
+    })
+
+    it('assigns a grammar to its editors even if present before the correct grammar is added', async () => {
+      jasmine.useRealClock();
+      await wait(100);
+      let editor = styleGuideView.element.querySelector('atom-text-editor')
+      let te = editor.getModel();
+      expect(te.getGrammar()?.scopeName).toBe('text.plain.null-grammar');
+
+      await atom.packages.activatePackage('language-html')
+      await wait(100);
+
+      expect(te.getGrammar()?.scopeName).toBe('text.html.basic');
     })
   })
 })

--- a/spec/grammar-registry-spec.js
+++ b/spec/grammar-registry-spec.js
@@ -912,18 +912,20 @@ describe('GrammarRegistry', () => {
 
     it('adds an injection point to the grammar with the given id', async () => {
       await atom.packages.activatePackage('language-javascript');
-      atom.grammars.addInjectionPoint('javascript', injectionPoint);
-      const grammar = atom.grammars.grammarForId('javascript');
-      expect(grammar.injectionPoints).toContain(injectionPoint);
+      atom.grammars.addInjectionPoint('source.js', injectionPoint);
+      const grammar = atom.grammars.grammarForId('source.js');
+      expect(
+        grammar.injectionPointsByType['some_node_type']
+      ).toContain(injectionPoint);
     });
 
     it('fires the onDidUpdateGrammar callback', async () => {
+      await atom.packages.activatePackage('language-javascript');
       let callbackDisposable = atom.grammars.onDidUpdateGrammar((grammar) => {
         if (grammar.scopeName === 'source.js') {
           updateCallbackFired = true;
         }
       });
-      await atom.packages.activatePackage('language-javascript');
       atom.grammars.addInjectionPoint('source.js', injectionPoint);
       expect(updateCallbackFired).toBe(true);
     });
@@ -943,10 +945,12 @@ describe('GrammarRegistry', () => {
         addCallbackDisposable = atom.grammars.onDidAddGrammar((grammar) => {
           if (grammar.scopeName === 'source.js') addCallbackFired = true;
         });
-        atom.grammars.addInjectionPoint('javascript', injectionPoint);
+        atom.grammars.addInjectionPoint('source.js', injectionPoint);
         await atom.packages.activatePackage('language-javascript');
-        const grammar = atom.grammars.grammarForId('javascript');
-        expect(grammar.injectionPoints).toContain(injectionPoint);
+        const grammar = atom.grammars.grammarForId('source.js');
+        expect(
+          grammar.injectionPointsByType['some_node_type']
+        ).toContain(injectionPoint);
         expect(updateCallbackFired).toBe(false);
         expect(addCallbackFired).toBe(true);
       });

--- a/spec/grammar-registry-spec.js
+++ b/spec/grammar-registry-spec.js
@@ -137,6 +137,22 @@ describe('GrammarRegistry', () => {
         grammarRegistry.grammarForId('source.js') instanceof SecondMate.Grammar
       ).toBe(true);
     });
+
+    it('never returns a stub object before a grammar has loaded', () => {
+      grammarRegistry.addInjectionPoint('source.js', {
+        type: 'some_node_type',
+        language() {
+          return 'some_language_name';
+        },
+        content(node) {
+          return node;
+        }
+      });
+
+      expect(
+        grammarRegistry.grammarForId('source.js')
+      ).toBe(undefined);
+    });
   });
 
   describe('.autoAssignLanguageMode(buffer)', () => {
@@ -878,8 +894,20 @@ describe('GrammarRegistry', () => {
       }
     };
 
+    let addCallbackFired;
+    let updateCallbackFired;
+    let addCallbackDisposable;
+    let updateCallbackDisposable;
+
     beforeEach(() => {
+      addCallbackFired = false;
+      updateCallbackFired = false;
       setConfigForLanguageMode('node-tree-sitter');
+    });
+
+    afterEach(() => {
+      addCallbackDisposable?.dispose();
+      updateCallbackDisposable?.dispose();
     });
 
     it('adds an injection point to the grammar with the given id', async () => {
@@ -889,12 +917,38 @@ describe('GrammarRegistry', () => {
       expect(grammar.injectionPoints).toContain(injectionPoint);
     });
 
+    it('fires the onDidUpdateGrammar callback', async () => {
+      let callbackDisposable = atom.grammars.onDidUpdateGrammar((grammar) => {
+        if (grammar.scopeName === 'source.js') {
+          updateCallbackFired = true;
+        }
+      });
+      await atom.packages.activatePackage('language-javascript');
+      atom.grammars.addInjectionPoint('source.js', injectionPoint);
+      expect(updateCallbackFired).toBe(true);
+    });
+
     describe('when called before a grammar with the given id is loaded', () => {
       it('adds the injection point once the grammar is loaded', async () => {
+        // Adding an injection point before a grammar loads should not trigger
+        // onDidUpdateGrammar at any point.
+        updateCallbackDisposable = atom.grammars.onDidUpdateGrammar((grammar) => {
+          if (!grammar.scopeName) {
+            updateCallbackFired = true;
+          }
+        });
+
+        // But onDidAddGrammar should be triggered when the grammar eventually
+        // loads.
+        addCallbackDisposable = atom.grammars.onDidAddGrammar((grammar) => {
+          if (grammar.scopeName === 'source.js') addCallbackFired = true;
+        });
         atom.grammars.addInjectionPoint('javascript', injectionPoint);
         await atom.packages.activatePackage('language-javascript');
         const grammar = atom.grammars.grammarForId('javascript');
         expect(grammar.injectionPoints).toContain(injectionPoint);
+        expect(updateCallbackFired).toBe(false);
+        expect(addCallbackFired).toBe(true);
       });
     });
   });


### PR DESCRIPTION
…before certain grammars are loaded.

Fixes #560.

### Identify the Bug

When a user reloads a window that happens to have a `styleguide` tab open, it’ll usually throw an error during the load process. This happens because `styleguide` shows code samples for UI elements, and it expects to be initialized in an environment where the grammars it needs for syntax highlighting are already present.

In investigating this, I found a few other bugs and inconsistencies in `GrammarRegistry` that needed to be fixed.

### Description of the Change

1. `atom.grammars.addInjectionPoint` allows you to add injections for any grammar, even grammars that haven’t been seen or activated yet. It does this by creating a stub object at the given scope name. But some `GrammarRegistry` APIs weren’t aware that this was a stub, so they were trying to do things with it. Added some guards to fix this. `atom.grammars.grammarForId` should _never_ return one of these stubs; if the grammar for `source.foo` hasn’t yet been added, `atom.grammars.grammarForId('source.foo')` should always be `undefined`. Added a spec.
2. The `GrammarRegistry#onDidAddGrammar` and `GrammarRegistry#onDidUpdateGrammar` callbacks only ever worked for TM-style grammars. I added parallel paths for Tree-sitter grammars, both legacy and modern. The former callback is triggered when a grammar is first added, and the latter callback is triggered when something adds an injection point for a grammar that has already loaded. Added specs for these.
3. _Now_ we can finally write some code that waits for a specific grammar — that’s what `CodeBlock` needs to do here. But we don’t want it to wait for the first one to come along; we want to wait for the first one that matches the user’s settings around whether or not to use Tree-sitter. But we also don’t want it to wait forever for an ideal candidate!

I had envisioned a method called `GrammarRegistry#whenGrammarAdded` that would resolve a promise when a grammar of a given scope name was added. But how should it behave?

1. Wait, possibly forever, for (e.g.) a Tree-sitter language-X grammar, even though there’s a TextMate language-X grammar that has already been loaded, because it respects the user’s language mode settings.
2. Ignore all language mode settings and return the first language-X grammar it finds.
3. Balance these two strategies somehow, possibly with a timeout.

I think option 3 might be promising. But if I add this to `GrammarRegistry`, we have to support it, and I don’t want to support something half-baked that I dreamt up just to fix an issue with `styleguide`.

So I put a simplified version of `whenGrammarAdded` into `styleguide`’s `CodeBlock` class. It waits for the first `text.html.basic` grammar to be loaded, then waits another second, then tells `GrammarRegistry` to pick the best grammar that has already been loaded (taking language mode preferences into account).

### Alternate Designs

Described them above.

### Possible Drawbacks

The changes I made to `GrammarRegistry` could possibly have implications for other parts of the core. I verified all the `GrammarRegistry` specs are passing, but I’ll wait for CI to do the whole suite and tell me if anything else has failed.

I’m of the opinion that anything I touched in `GrammarRegistry` involved fixing behaviors that were flat-out wrong, so any code that would break as a result of those fixes is itself broken.

### Verification Process

Added a new spec to `styleguide`. Now it has two!

And, as mentioned above, I’ll find out whether anything new in the main test suite is broken.

### Release Notes

Fixed a syntax highlighting issue inside the `styleguide` package