### PR TITLE
fix(arm): use rubygems from APT

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -66,7 +66,7 @@ arm_linux_task:
                 gnupg2
                 procps
                 curl
-                ruby-rubygems
+                ruby
                 rpm
                 build-essential
                 git

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -90,7 +90,6 @@ arm_linux_task:
     - yarn build
     - yarn run build:apm
   build_binary_script:
-    - source /etc/profile.d/rvm.sh
     - yarn dist || yarn dist
   binary_artifacts:
     path: ./binaries/*

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -66,6 +66,7 @@ arm_linux_task:
                 gnupg2
                 procps
                 curl
+                ruby-rubygems
                 rpm
                 build-essential
                 git
@@ -79,10 +80,6 @@ arm_linux_task:
                 libasound2-dev
                 libnss3
                 xvfb
-    - gpg2 --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
-    - \curl -sSL https://get.rvm.io | bash -s stable
-    - source /etc/profile.d/rvm.sh
-    - rvm install ruby
     - gem install fpm
     - git submodule init
     - git submodule update


### PR DESCRIPTION
### Identify the Bug

Currently sometimes the AMR linux workflow fails due to some issues with downloading Ruby.

### Description of the Change

Instead of using RVM to install ruby, it can be done directly from APT. This version isn't that old and FPM which is what is being installed hasn't been updated in such a long time.

### Alternate Designs

Perhaps the installer could be fixed or a repository could be added (Launchpad) with a more recent version if needed.

### Verification Process

The arm linux workflow succeeds.

### Release Notes

- Fixed an issue with rubygems timing out on ARM Linux workflow