### PR TITLE
ppm: Update submodule to 49c8ced8f9552bb4aeb279130

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@
 
 ## [Unreleased]
 
+- Added `ppm` and `ppm.cmd` binaries/launchers within ppm. This allows easier integration of correctly named binaries on more systems in more contexts (especially Windows). Existing `apm` and `apm.cmd` binaries/launchers are still there for the time being.
+
+### Pulsar
+
+Bumped: ppm: Update submodule to 49c8ced8f9552bb4aeb279130 [@DeeDeeG](https://github.com/pulsar-edit/pulsar/pull/654)
+
+### ppm
+
+- Added: Add 'ppm' bins to complement existing 'apm' bins [@DeeDeeG](https://github.com/pulsar-edit/ppm/pull/80)
+- Fixed: Replace "apm" by "ppm" in help messages. [@azuledu](https://github.com/pulsar-edit/ppm/pull/62)
+- Bumped: Update OS, actions, node [@Spiker985](https://github.com/pulsar-edit/ppm/pull/57)
+
 ## 1.107.1
 
 - Updated the `github` package to resolve incompatibility in Style Sheets against Less v4


### PR DESCRIPTION
## Updating the ppm submodule

Updating the ppm submodule from 915cbf6e5f9ea1141ef5dcaf86343237e17bf380 to 49c8ced8f9552bb4aeb279130e20a491e653ab75. [Comparison view on GitHub of the changes.](https://github.com/pulsar-edit/ppm/compare/915cbf6e5f9ea1141ef5dcaf86343237e17bf380...49c8ced8f9552bb4aeb279130e20a491e653ab75)

- Adds `ppm` and `ppm.cmd` bins to complement existing `apm` and `apm.cmd` bins. Should help integrating a correctly named `ppm` binary/launcher onto the user's PATH for CLI usage in Windows, maybe it will make a meaningful difference in some other contexts as well.
- Also updates some help text to correctly refer to or demonstrate 'ppm' commands, not 'apm' commands.
- Some CI-only bumps of two GitHub Actions and adding testing on Node 18 (to complement existing testing on Node 14 and 16).

## CHANGELOG

I added this stuff to the `CHANGELOG.md` as well, at least as pertains to this first step. There will probably be a lot of follow-up work making use of the new `ppm` and `ppm.cmd` bins in core repo that will be worth mentioning in the CHANGELOGs, but that stuff isn't done yet, so. We can decide what to write about it when more is said and done and/or when release time rolls around again.

## Includes the following PRs from ppm repo:

- https://github.com/pulsar-edit/ppm/pull/57
- https://github.com/pulsar-edit/ppm/pull/62
- https://github.com/pulsar-edit/ppm/pull/80