### PR TITLE
[settings-view] Don't let project-specific settings pollute the UI

### DIFF
--- a/packages/settings-view/lib/settings-panel.js
+++ b/packages/settings-view/lib/settings-panel.js
@@ -116,7 +116,6 @@ export default class SettingsPanel extends CollapsibleSectionPanel {
       let name = type === 'radio' ? input.name : input.id
 
       this.observe(name, (value) => {
-        console.log('change:', name, value)
         this.updateOverrideMessage(name)
         if (type === 'checkbox') {
           input.checked = value

--- a/packages/settings-view/lib/settings-panel.js
+++ b/packages/settings-view/lib/settings-panel.js
@@ -36,7 +36,7 @@ export default class SettingsPanel extends CollapsibleSectionPanel {
       namespace = 'editor'
       settings = {}
       for (const name of SCOPED_SETTINGS) {
-        settings[name] = atom.config.get(name, {scope: [this.options.scopeName]})
+        settings[name] = getWithoutProjectOverride(name, {scope: [this.options.scopeName]})
       }
     } else {
       settings = getWithoutProjectOverride(namespace)
@@ -174,8 +174,12 @@ export default class SettingsPanel extends CollapsibleSectionPanel {
     // reflected in the settings panel. We use `observe` to hook into any
     // possible changes to our value, but we double-check it by looking up the
     // value ourselves.
-    let wrappedCallback = () => {
-      callback(getWithoutProjectOverride(name))
+    let wrappedCallback = (nv) => {
+      let params = {}
+      if (this.options.scopeName != null) {
+        params.scope = [this.options.scopeName]
+      }
+      callback(getWithoutProjectOverride(name, params))
     }
 
     this.disposables.add(atom.config.observe(name, params, wrappedCallback))
@@ -404,8 +408,7 @@ function sortSettings (namespace, settings) {
     .value()
 }
 
-function getWithoutProjectOverride (name) {
-  let options = {}
+function getWithoutProjectOverride (name, options = {}) {
   if (atom.config.projectFile) {
     options.excludeSources = [atom.config.projectFile]
   }

--- a/packages/settings-view/spec/settings-panel-spec.coffee
+++ b/packages/settings-view/spec/settings-panel-spec.coffee
@@ -137,6 +137,16 @@ describe "SettingsPanel", ->
       expect(settingsPanel.isDefault('foo.haz')).toBe false
       expect(atom.config.get('foo.haz')).toBe 'newhaz'
 
+    it "ignores project-specific overrides", ->
+      atom.project.replace(
+        originPath: 'TEST'
+        config:
+          foo:
+            haz: 'newhaz'
+      )
+      expect(settingsPanel.isDefault('foo.haz')).toBe true
+      expect(atom.config.get('foo.haz')).toBe 'newhaz'
+
     it 'has a tooltip showing the default value', ->
       hazEditor = settingsPanel.element.querySelector('[id="foo.haz"]')
       tooltips = atom.tooltips.findTooltips(hazEditor)

--- a/packages/settings-view/styles/settings-view.less
+++ b/packages/settings-view/styles/settings-view.less
@@ -421,6 +421,10 @@
       color: @text-color;
     }
 
+    .setting-override-warning {
+      margin-top: 0.75em;
+    }
+
     .control-group + .control-group {
       margin-top:  1.5em;
     }

--- a/spec/config-spec.js
+++ b/spec/config-spec.js
@@ -1,4 +1,4 @@
-fdescribe('Config', () => {
+describe('Config', () => {
   let savedSettings;
 
   beforeEach(() => {

--- a/spec/config-spec.js
+++ b/spec/config-spec.js
@@ -1,4 +1,4 @@
-describe('Config', () => {
+fdescribe('Config', () => {
   let savedSettings;
 
   beforeEach(() => {
@@ -6,7 +6,7 @@ describe('Config', () => {
     atom.config.settingsLoaded = true;
 
     savedSettings = [];
-    atom.config.saveCallback = function(settings) {
+    atom.config.saveCallback = function (settings) {
       savedSettings.push(settings);
     };
   });
@@ -40,7 +40,11 @@ describe('Config', () => {
       expect(atom.config.get('bar.baz')).toEqual({ a: 3 });
     });
 
-    describe("when a 'sources' option is specified", () =>
+    describe("when a 'sources' option is specified", () => {
+      afterEach(() => {
+        atom.project.replace(null);
+      });
+
       it('only retrieves values from the specified sources', () => {
         atom.config.set('x.y', 1, { scopeSelector: '.foo', source: 'a' });
         atom.config.set('x.y', 2, { scopeSelector: '.foo', source: 'b' });
@@ -64,9 +68,50 @@ describe('Config', () => {
         expect(
           atom.config.get(null, { sources: ['a'], scope: ['.foo'] }).x.y
         ).toBe(1);
-      }));
+      })
 
-    describe("when an 'excludeSources' option is specified", () =>
+      it(`ignores project-specific settings unless specified in the "sources" option`, () => {
+        atom.config.set('x.y', 1);
+        atom.config.set('u.v', 5);
+
+        atom.project.replace({
+          originPath: 'TEST',
+          paths: atom.project.getPaths(),
+          config: {
+            "*": {
+              "x": {
+                "y": 4
+              }
+            }
+          }
+        });
+
+        expect(
+          atom.config.get('x.y', { sources: [atom.config.mainSource] })
+        ).toBe(1);
+        expect(
+          atom.config.get('x.y', { sources: [atom.config.mainSource, atom.config.projectFile] })
+        ).toBe(4);
+
+        expect(
+          atom.config.get('x.y', { sources: [atom.config.projectFile] })
+        ).toBe(4);
+
+        expect(
+          atom.config.get('u.v', {
+            sources: [atom.config.projectFile],
+            excludeSources: [atom.config.mainSource]
+          })
+        ).toBeUndefined();
+      });
+    });
+
+
+    describe("when an 'excludeSources' option is specified", () => {
+      afterEach(() => {
+        atom.project.replace(null);
+      });
+
       it('only retrieves values from the specified sources', () => {
         atom.config.set('x.y', 0);
         atom.config.set('x.y', 1, { scopeSelector: '.foo', source: 'a' });
@@ -103,7 +148,29 @@ describe('Config', () => {
             excludeSources: [atom.config.getUserConfigPath()]
           })
         ).toBe(4);
-      }));
+      });
+
+      it("ignores the project-specific source when 'excludeSources' tells it to", () => {
+        atom.config.set('x.y', 1);
+
+        atom.project.replace({
+          originPath: 'TEST',
+          paths: atom.project.getPaths(),
+          config: {
+            "*": {
+              "x": {
+                "y": 4
+              }
+            }
+          }
+        });
+
+        expect( atom.config.get('x.y') ).toBe(4);
+        expect(
+          atom.config.get('x.y', { excludeSources: [atom.config.projectFile] })
+        ).toBe(1);
+      });
+    });
 
     describe("when a 'scope' option is given", () => {
       it('returns the property with the most specific scope selector', () => {
@@ -590,7 +657,7 @@ describe('Config', () => {
         ).toBe(55);
 
         advanceClock(150);
-        
+
         savedSettings.length = 0;
 
         atom.config.unset('foo.bar.baz', { scopeSelector: '.source.coffee' });


### PR DESCRIPTION
### Identify the Bug

Come with me on a journey of underdocumented features!

Atom has an interface without a UI: a way to overlay settings so that they apply in only one project rather than globally. It can be used at [atom.project.replace](https://github.com/pulsar-edit/pulsar/blob/master/src/project.js#L91).

This was [one of the last major features added to Atom](https://github.com/atom/atom/pull/16845) before Microsoft bought GitHub. Progress seemed to slow _way the hell down_ after that, so this feature never got a proper first-party UI.

But I’m aware of two packages built on this feature: [atomic-management](https://github.com/harmsk/atomic-management) and [project-config](https://github.com/steelbrain/project-config).

This abstraction works beautifully for ordinary usage, but can go quite wrong if the user opens a settings page. This isn’t a package bug; this is a bug in how Pulsar handles project-specific settings overrides.

#### Example

This is the real example I just used to discover this bug. I used `project-config` to define a file at `.atom/config.json` that would disable the ESNode linter for the one project I happened to be working in:

```json
{
  "linter": {
    "disabledProviders": ["ESLint (Node)"]
  }
}
```

Here’s the relevant part of my global `config.cson`:

```coffeescript
"*":
  linter:
    disabledProviders: []
    lintOnChange: false
```

Once I’ve loaded my project window, I can verify that the config is what I want it to be via the console:

```js
atom.config.get('linter.disabledProviders');
// -> ["ESLint (Node)"]
```

My `config.cson` has not changed.

But suppose I open the `linter` package settings:

<img width="458" alt="Screenshot 2023-07-22 at 9 04 19 PM" src="https://github.com/pulsar-edit/pulsar/assets/3450/abe21803-aebe-4278-aea2-ca76567b46e9">

The GUI shows **my project-specific settings**, and it’s not clear what will happen if I try to change them. Will the change apply globally?

In fact, the damage is already done in my `config.cson`, and I haven’t touched anything:

```coffeescript
"*":
  linter:
    disabledProviders: [
      "ESLint (Node)"
    ]
    lintOnChange: false
```

Does this happen with everything, or just with arrays? Let’s start over. I’ll manually restore my global `config.cson` to the empty array that it used to be. Now I’ll put another setting in `.atom/config.json`:

```json
{
  "linter": {
    "disabledProviders": ["ESLint (Node)"],
    "lintOnChange": true
  }
}
```

Now we open up the `linter` package settings again. Does the new setting automatically get inherited by `config.cson` just because we opened the package settings?

```coffeescript
"*":
  linter:
    disabledProviders: [
      "ESLint (Node)"
    ]
    lintOnChange: false
```

No, it doesn’t. What happens if I uncheck the “Lint on Change” box and then check it again?

```coffeescript
"*":
  linter:
    disabledProviders: [
      "ESLint (Node)"
    ]
    lintOnChange: true
```

That much seems to make sense.

#### The underlying cause

`atom.config` is a thicket of settings. Every setting can be applied for an arbitrary scope context or globally (a scope of `*`). And settings don’t just come from the user's `config.cson`; they can come from a CSON file in the `settings` folder of any package. And that’s not even talking about the _default_ configuration values as described in various schemas in `package.json` files.

Luckily, `atom.config` keeps track of where each of its settings comes from, and keeps them organized by source. Project-specific overrides are treated as just another source, and the name of that source (if present) will always live at `atom.config.projectFile`. And the main source is also easy to reference; it’s creatively named `atom.config.mainSource`, and (I think) will always be equal to `atom.config.getUserConfigPath()`.

`atom.config.get` lets us specify `sources` and `excludeSources` keys in its options. So, in theory, we should be able to look up what a setting would be _if we ignored project-specific overrides_ by doing something like this:

```js
atom.config.get('linter.disabledProviders', {
  excludeSources: [atom.config.projectFile]
});
```

But this wasn’t working; the project-specific value was still being returned. This attempt returned the same wrong value:


```js
atom.config.get('linter.disabledProviders', {
  source: [atom.config.mainSource]
});
```

### Description of the Change

I’ve changed the lookup logic in `atom.config.getRawValue` so that it never considers the project-specific override if we either (a) exclude it via `excludeSources` or (b) fail to include it if we specify `sources`.

This is the beginning of the fix.

The second half of the fix is to make it so that `settings-view` tries very hard never to show project-specific overrides in its UI. It relies heavily on `atom.config.observe` to do a sort of poor-man’s two-way-binding, so it’d be great if I could update `atom.config.observe` (and `atom.config.onDidChange`) so that they treat `sources` and `excludeSources` identically to how they’re now treated in `atom.config.get`.

I went down that road, but ended up backing those changes out because they’d end up breaking things that people rely on. (For instance: when you do `atom.config.observe('foo', { sources: [atom.config.mainSource] })`, your callback is immediately invoked with the current value of `foo`, but it’s the current _global_ value of `foo` — it ignored your `sources` option. But _future_ updates in the value of `foo` work the way they ought to!)

So I went for something hackier but less likely to break things. I changed `settings-view` so that it still uses the `observe` lifecycle but manually looks up the right value in the callback so that it can be sure it’s not seeing a value from a project-specific override.

The other part is something I’m rather fond of.

The settings GUI can only write to the user’s `config.cson`, so a user might be confused if they try to change a setting that’s been overridden in the project and find that it seems to have no effect.

So I’ve added a message in the GUI for settings that happen to be overridden:

<img width="1226" alt="Screenshot 2023-07-22 at 8 56 20 PM" src="https://github.com/pulsar-edit/pulsar/assets/3450/f9e384e5-bc77-44e9-ba1c-f18d74ddc5df">

These messages update dynamically. If I edit the `config.json` on the left to remove one of the overrides and then save it, the corresponding warning message in the UI disappears.

### Alternate Designs

It’d be great to have it so that the settings page magically does the right thing in all cases. When you change a setting in the GUI, it somehow knows whether you mean to make that change just for the project or globally, and changes the right file accordingly.

But that’s pretty much impossible, so I view this as the next best thing.

### Possible Drawbacks

I tried my best to make this code change have zero drawbacks when compared to the status quo. It’d be great to untangle all the complexity of `atom.config`, but it’s probably too late to do that without major disruption.

### Verification Process

A few new specs test both the `atom.config` behavior change and the `settings-view` behavior change.

### Release Notes

Ensure that project-specific setting overrides don’t leak to the user’s config file when the settings UI is visited.