### PR TITLE
[Time Sensitive] Update Cirrus Encrypted token for GitHub Access

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,6 +1,6 @@
 env:
   PYTHON_VERSION: 3.10
-  GITHUB_TOKEN: ENCRYPTED[13da504dc34d1608564d891fb7f456b546019d07d1abb059f9ab4296c56ccc0e6e32c7b313629776eda40ab74a54e95c]
+  GITHUB_TOKEN: ENCRYPTED[!b0ff4671044672be50914a3a10b49af642bd8e0e681a6f4e5855ec5230a5cf9afbc53d9e90239b8d2c79455f014f383f!]
   # The above token, is a GitHub API Token, that allows us to download RipGrep without concern of API limits
 
 linux_task:


### PR DESCRIPTION
This PR updates the Cirrus Encrypted token we use to have GitHub access.

Same as before, but the previous token expires today, and has no been regenerated. Without it, we see vastly increased build failures. So should be merged quickly to avoid unnecessary failures