### PR TITLE
[pulsar-updater] Correct deb-get instructions (+ readme change)

### DIFF
--- a/packages/pulsar-updater/README.md
+++ b/packages/pulsar-updater/README.md
@@ -38,9 +38,9 @@ Since a major part of the functionality of this package is attempting to determi
 * Linux: Flatpak Installation
 * Linux: Deb-Get Installation
 * Linux: Nix Installation
-* Linux: Home Brew Installation
+* Linux: Homebrew Installation
 * Linux: Manual Installation
-* macOS: Home Brew Installation
+* macOS: Homebrew Installation
 * macOS: Manual Installation
 
 ## Known Issues

--- a/packages/pulsar-updater/src/main.js
+++ b/packages/pulsar-updater/src/main.js
@@ -171,7 +171,7 @@ class PulsarUpdater {
         break;
       case "Deb-Get Installation":
         returnText +=
-          "Install the latest version by running `sudo deb-get update`.";
+          "Install the latest version by running `deb-get update && deb-get install pulsar`.";
         break;
       case "Nix Installation":
         // TODO find nix update command


### PR DESCRIPTION
Instructions for deb-get were incorrect.
- `sudo` should never be used with deb-get as it breaks it (and generally I avoid ever putting `sudo` in any documentation or instructions as that should be up to the user to make that final decision for root access - stops any clipboard mishaps too)
- `deb-get update` will update the internal list but won't actually do anything to the packages.
- The correct instructions are either `deb-get update` followed by either `deb-get upgrade` or `deb-get install pulsar`
    - The former (upgrade) will upgrade *all* deb-get packages on the user's system (and apt packages too I think) so whilst it will update Pulsar I don't think this is the correct instruction.
    - The latter (install pulsar) is used for both the install of a single package as well as the upgrade of a single package
    - Therefore I've picked the latter one and I've put it in as a oneliner with `&&` but feel free to suggest it as two independent statements if needed. e.g:

> "Install the latest version by running `deb-get update` followed by `deb-get install pulsar`.";

deb-get help:
```
upgrade
    upgrade is used to install the newest versions of all packages currently
    installed on the system.

install
    install is followed by one package (or a space-separated list of packages)
    desired for installation or upgrading.
```

Example update:

```sh
$ deb-get install pulsar    
/var/cache/deb-get/Linux.pulsar_1.10 100%[======================================================================>] 133.13M  6.57MB/s    in 19s     
(Reading database ... 559918 files and directories currently installed.)
Preparing to unpack .../Linux.pulsar_1.107.1_amd64.deb ...
Unpacking pulsar (1.107.1) over (1.106.0) ...
```

The readme change is just updating "Home Brew" to "Homebrew" (which is actually how it is referred to elsewhere in the code as well as being the correct format).

