### PR TITLE
[core]: Make showing tab title in window title optional

### DIFF
--- a/spec/workspace-spec.js
+++ b/spec/workspace-spec.js
@@ -2079,7 +2079,7 @@ describe('Workspace', () => {
           escapeStringRegex(path.dirname(item.getPath()))
         );
         expect(document.title).toMatch(
-          new RegExp(`^${pathEscaped} \\u2014`)
+          new RegExp(`^${pathEscaped}`)
         );
         atom.config.unset("core.addCurrentTabToWindowTitle");
         // Now with the config changed, the title should automatically update

--- a/spec/workspace-spec.js
+++ b/spec/workspace-spec.js
@@ -2072,6 +2072,22 @@ describe('Workspace', () => {
         );
       });
 
+      it("sets the title to the item's path if addCurrentTabToWindowTitle is disabled", () => {
+        atom.config.set("core.addCurrentTabToWindowTitle", false);
+        const item = atom.workspace.getActivePaneItem();
+        const pathEscaped = fs.tildify(
+          escapeStringRegex(path.dirname(item.getPath()))
+        );
+        expect(document.title).toMatch(
+          new RegExp(`^${pathEscaped} \\u2014`)
+        );
+        atom.config.unset("core.addCurrentTabToWindowTitle");
+        // Now with the config changed, the title should automatically update
+        expect(document.title).toMatch(
+          new RegExp(`^${item.getTitle()} \\u2014 ${pathEscaped}`)
+        );
+      });
+
       describe('when the title of the active pane item changes', () => {
         it("updates the window title based on the item's new title", () => {
           const editor = atom.workspace.getActivePaneItem();

--- a/src/config-schema.js
+++ b/src/config-schema.js
@@ -393,6 +393,11 @@ const configSchema = {
         description: 'Whether Pulsar should transform deprecated Mathematical Expressions in community package style sheets. Increases compatibility, as well as startup time.',
         type: 'boolean',
         default: true
+      },
+      addCurrentTabToWindowTitle: {
+        description: 'Add the current tab title to the Pulsar Window title.',
+        type: 'boolean',
+        default: true
       }
     }
   },

--- a/src/workspace.js
+++ b/src/workspace.js
@@ -684,7 +684,10 @@ module.exports = class Workspace extends Model {
   // open.
   updateWindowTitle() {
     let itemPath, itemTitle, projectPath, representedPath;
-    const appName = atom.getAppName();
+    // We have to use optional chaining on `atom` here, as the observe callback in
+    // init, may call this function prior to the world being spun up during test runs
+    // Should not have any effect in production
+    const appName = atom?.getAppName() ?? "";
     const left = this.project.getPaths();
     const projectPaths = left != null ? left : [];
     const item = this.getActivePaneItem();
@@ -721,10 +724,10 @@ module.exports = class Workspace extends Model {
     }
 
     const titleParts = [];
-    if (item != null && projectPath != null && atom.config.get('core.addCurrentTabToWindowTitle')) {
+    if (item != null && projectPath != null && this.config.get('core.addCurrentTabToWindowTitle')) {
       titleParts.push(itemTitle, projectPath);
       representedPath = itemPath != null ? itemPath : projectPath;
-    } else if (item != null && projectPath != null && !atom.config.get('core.addCurrentTabToWindowTitle')) {
+    } else if (item != null && projectPath != null && !this.config.get('core.addCurrentTabToWindowTitle')) {
       titleParts.push(projectPath);
       representedPath = itemPath != null ? itemPath : projectPath;
     } else if (projectPath != null) {

--- a/src/workspace.js
+++ b/src/workspace.js
@@ -381,7 +381,8 @@ module.exports = class Workspace extends Model {
     this.subscribeToMovedItems();
     this.subscribeToDockToggling();
 
-    atom.config.observe('core.addCurrentTabToWindowTitle', () => {
+    // We use `this.config` since `atom.config` isn't declared globally yet during test runs
+    this.config.observe('core.addCurrentTabToWindowTitle', () => {
       this.updateWindowTitle();
     });
   }

--- a/src/workspace.js
+++ b/src/workspace.js
@@ -380,6 +380,10 @@ module.exports = class Workspace extends Model {
     this.subscribeToAddedItems();
     this.subscribeToMovedItems();
     this.subscribeToDockToggling();
+
+    atom.config.observe('core.addCurrentTabToWindowTitle', () => {
+      this.updateWindowTitle();
+    });
   }
 
   consumeServices({ serviceHub }) {
@@ -716,8 +720,11 @@ module.exports = class Workspace extends Model {
     }
 
     const titleParts = [];
-    if (item != null && projectPath != null) {
+    if (item != null && projectPath != null && atom.config.get('core.addCurrentTabToWindowTitle')) {
       titleParts.push(itemTitle, projectPath);
+      representedPath = itemPath != null ? itemPath : projectPath;
+    } else if (item != null && projectPath != null && !atom.config.get('core.addCurrentTabToWindowTitle')) {
+      titleParts.push(projectPath);
       representedPath = itemPath != null ? itemPath : projectPath;
     } else if (projectPath != null) {
       titleParts.push(projectPath);


### PR DESCRIPTION
This PR allows a simple bit of configuration of the Window title of Pulsar. 

Whereas currently the window title will generally always show: `Tab Title -- Project Folder -- App Name`

This PR allows the tab title to be togglable, such as: `Project Folder -- App Name` instead.

This new behavior is controlled via `core.addCurrentTabToWindowTitle`, with the default value of `true` resulting in zero change in behavior.

## "Add Current Tab to Window Title" Enabled (Default)

![image](https://github.com/pulsar-edit/pulsar/assets/26921489/a9fe2648-8692-43d5-861a-818d2c5ccd2f)

## "Add Current Tab to Window Title" Disabled

![image](https://github.com/pulsar-edit/pulsar/assets/26921489/897fbb44-04af-4239-8190-f9075a34ff1a)

---

Resolves #670 