### PR TITLE
[pulsar-updater] Don't notify if Pulsar is running via `yarn start`

### DIFF
--- a/packages/pulsar-updater/README.md
+++ b/packages/pulsar-updater/README.md
@@ -30,6 +30,7 @@ Since a major part of the functionality of this package is attempting to determi
 * Universal: Developer Mode
 * Universal: Safe Mode
 * Universal: Spec Mode
+* Universal: Developer Instance
 * Windows: Chocolatey Installation
 * Windows: winget Installation
 * Windows: User Installation

--- a/packages/pulsar-updater/spec/find-install-method-spec.js
+++ b/packages/pulsar-updater/spec/find-install-method-spec.js
@@ -5,13 +5,13 @@ describe("find-install-method main", async () => {
   const platform = process.platform;
   const arch = process.arch;
 
-  it("Returns spec mode if applicable", async () => {
+  it("Returns developer instance if applicable", async () => {
     // We can't mock the atom api return from a package,
     // So we will just know that if tests are running, it's in the Atom SpecMode
 
     let method = await findInstallMethod();
 
-    expect(method.installMethod).toBe("Spec Mode");
+    expect(method.installMethod).toBe("Developer Instance");
     expect(method.platform).toBe(platform);
     expect(method.arch).toBe(arch);
   });

--- a/packages/pulsar-updater/src/find-install-method.js
+++ b/packages/pulsar-updater/src/find-install-method.js
@@ -77,6 +77,13 @@ async function main() {
     returnValue = "Spec Mode";
   }
 
+  if (atom.getVersion().endsWith("-dev")) {
+    // This would only be the case if
+    // 1. `yarn start` was used by a developer
+    // 2. Someone built a local binary without removing `-dev` from the version
+    returnValue = "Developer Instance";
+  }
+
   if (returnValue.length > 0) {
     // Return early
     return {

--- a/packages/pulsar-updater/src/main.js
+++ b/packages/pulsar-updater/src/main.js
@@ -166,6 +166,9 @@ class PulsarUpdater {
       case "Spec Mode":
         return null;
         break;
+      case "Developer Instance":
+        return null;
+        break;
       case "Flatpak Installation":
         returnText += "Install the latest version by running `flatpak update`.";
         break;


### PR DESCRIPTION
When a developer of Pulsar is running Pulsar locally, such as using `yarn start` the version of Pulsar would be reported as ending with `-dev`, which according to semver is a prerelease channel and would always be lower than the same version without the `-dev`.

For example:

* We have just published `1.108.0`.
* A developer then starts working on Pulsar with the version of `1.108.0-dev`
* `pulsar-updater` sees `1.108.0-dev` and uses semver to compare it to the latest GitHub release of `1.108.0`
* Then semver sees the prerelease and assumes it's out of date compared to GitHub
* `pulsar-updater` prompts for an Update

What this means, is that almost always when a developer is working on Pulsar they will be notified to update via `pulsar-updater`.

This PR includes a manual check within `pulsar-updater` to see if `atom.getVersion()` ends with `-dev` and if so will not emit a notification for an update.