### PR TITLE
[autocomplete-plus] Detect when menu state gets out of sync with DOM

### DIFF
--- a/packages/autocomplete-plus/lib/suggestion-list.js
+++ b/packages/autocomplete-plus/lib/suggestion-list.js
@@ -4,7 +4,7 @@ const SuggestionListElement = require('./suggestion-list-element')
 
 module.exports =
 class SuggestionList {
-  constructor () {
+  constructor() {
     this.wordPrefixRegex = null
     this.cancel = this.cancel.bind(this)
     this.confirm = this.confirm.bind(this)
@@ -16,9 +16,10 @@ class SuggestionList {
     this.hide = this.hide.bind(this)
     this.destroyOverlay = this.destroyOverlay.bind(this)
     this.activeEditor = null
+    this.lastActiveAt = 0
   }
 
-  initialize () {
+  initialize() {
     this.emitter = new Emitter()
     this.subscriptions = new CompositeDisposable()
 
@@ -37,7 +38,7 @@ class SuggestionList {
     }))
   }
 
-  get suggestionListElement () {
+  get suggestionListElement() {
     if (!this._suggestionListElement) {
       this._suggestionListElement = new SuggestionListElement(this)
     }
@@ -45,7 +46,7 @@ class SuggestionList {
     return this._suggestionListElement
   }
 
-  addBindings (editor) {
+  addBindings(editor) {
     if (this.bindings && this.bindings.dispose) {
       this.bindings.dispose()
     }
@@ -124,47 +125,47 @@ class SuggestionList {
   Section: Event Triggers
   */
 
-  cancel () {
+  cancel() {
     return this.emitter.emit('did-cancel')
   }
 
-  confirm (match) {
+  confirm(match) {
     return this.emitter.emit('did-confirm', match)
   }
 
-  confirmSelection () {
+  confirmSelection() {
     return this.emitter.emit('did-confirm-selection')
   }
 
-  confirmSelectionIfNonDefault (event) {
+  confirmSelectionIfNonDefault(event) {
     return this.emitter.emit('did-confirm-selection-if-non-default', event)
   }
 
-  select (suggestion) {
+  select(suggestion) {
     return this.emitter.emit('did-select', suggestion)
   }
 
-  selectNext () {
+  selectNext() {
     return this.emitter.emit('did-select-next')
   }
 
-  selectPrevious () {
+  selectPrevious() {
     return this.emitter.emit('did-select-previous')
   }
 
-  selectPageUp () {
+  selectPageUp() {
     return this.emitter.emit('did-select-page-up')
   }
 
-  selectPageDown () {
+  selectPageDown() {
     return this.emitter.emit('did-select-page-down')
   }
 
-  selectTop () {
+  selectTop() {
     return this.emitter.emit('did-select-top')
   }
 
-  selectBottom () {
+  selectBottom() {
     return this.emitter.emit('did-select-bottom')
   }
 
@@ -172,67 +173,67 @@ class SuggestionList {
   Section: Events
   */
 
-  onDidConfirmSelection (fn) {
+  onDidConfirmSelection(fn) {
     return this.emitter.on('did-confirm-selection', fn)
   }
 
-  onDidconfirmSelectionIfNonDefault (fn) {
+  onDidconfirmSelectionIfNonDefault(fn) {
     return this.emitter.on('did-confirm-selection-if-non-default', fn)
   }
 
-  onDidConfirm (fn) {
+  onDidConfirm(fn) {
     return this.emitter.on('did-confirm', fn)
   }
 
-  onDidSelect (fn) {
+  onDidSelect(fn) {
     return this.emitter.on('did-select', fn)
   }
 
-  onDidSelectNext (fn) {
+  onDidSelectNext(fn) {
     return this.emitter.on('did-select-next', fn)
   }
 
-  onDidSelectPrevious (fn) {
+  onDidSelectPrevious(fn) {
     return this.emitter.on('did-select-previous', fn)
   }
 
-  onDidSelectPageUp (fn) {
+  onDidSelectPageUp(fn) {
     return this.emitter.on('did-select-page-up', fn)
   }
 
-  onDidSelectPageDown (fn) {
+  onDidSelectPageDown(fn) {
     return this.emitter.on('did-select-page-down', fn)
   }
 
-  onDidSelectTop (fn) {
+  onDidSelectTop(fn) {
     return this.emitter.on('did-select-top', fn)
   }
 
-  onDidSelectBottom (fn) {
+  onDidSelectBottom(fn) {
     return this.emitter.on('did-select-bottom', fn)
   }
 
-  onDidCancel (fn) {
+  onDidCancel(fn) {
     return this.emitter.on('did-cancel', fn)
   }
 
-  onDidDispose (fn) {
+  onDidDispose(fn) {
     return this.emitter.on('did-dispose', fn)
   }
 
-  onDidChangeItems (fn) {
+  onDidChangeItems(fn) {
     return this.emitter.on('did-change-items', fn)
   }
 
-  onDidChangeItem (fn) {
+  onDidChangeItem(fn) {
     return this.emitter.on('did-change-item', fn)
   }
 
-  isActive () {
+  isActive() {
     return (this.activeEditor != null)
   }
 
-  show (editor, options) {
+  show(editor, options) {
     if (atom.config.get('autocomplete-plus.suggestionListFollows') === 'Cursor') {
       return this.showAtCursorPosition(editor, options)
     } else {
@@ -250,7 +251,7 @@ class SuggestionList {
     }
   }
 
-  showAtBeginningOfPrefix (editor, prefix, followRawPrefix = false) {
+  showAtBeginningOfPrefix(editor, prefix, followRawPrefix = false) {
     let bufferPosition
     if (editor) {
       bufferPosition = editor.getCursorBufferPosition()
@@ -275,6 +276,7 @@ class SuggestionList {
         this.overlayDecoration = editor.decorateMarker(marker, {type: 'overlay', item: this.suggestionListElement, position: 'tail', class: 'autocomplete-plus'})
         const editorElement = atom.views.getView(this.activeEditor)
         if (editorElement && editorElement.classList) {
+          this.lastActiveAt = performance.now()
           editorElement.classList.add('autocomplete-active')
         }
 
@@ -283,7 +285,7 @@ class SuggestionList {
     }
   }
 
-  showAtCursorPosition (editor) {
+  showAtCursorPosition(editor) {
     if (this.activeEditor === editor || (editor == null)) { return }
     this.destroyOverlay()
 
@@ -295,6 +297,7 @@ class SuggestionList {
       this.activeEditor = editor
       const editorElement = atom.views.getView(this.activeEditor)
       if (editorElement && editorElement.classList) {
+        this.lastActiveAt = performance.now()
         editorElement.classList.add('autocomplete-active')
       }
 
@@ -303,7 +306,7 @@ class SuggestionList {
     }
   }
 
-  hide () {
+  hide() {
     this.destroyOverlay()
     if (this.activeEditor === null) {
       return
@@ -317,7 +320,7 @@ class SuggestionList {
     return this.activeEditor
   }
 
-  destroyOverlay () {
+  destroyOverlay() {
     if (this.suggestionMarker && this.suggestionMarker.destroy) {
       this.suggestionMarker.destroy()
     } else if (this.overlayDecoration && this.overlayDecoration.destroy) {
@@ -325,7 +328,11 @@ class SuggestionList {
     }
     const editorElement = atom.views.getView(this.activeEditor)
     if (editorElement && editorElement.classList) {
+      let timestamp = this.lastActiveAt
       atom.views.updateDocument(() => {
+        // A newer timestamp here means that the menu is open again and we
+        // shouldn't remove this class name anymore.
+        if (this.lastActiveAt > timestamp) return
         editorElement.classList.remove('autocomplete-active')
       })
     }
@@ -334,12 +341,12 @@ class SuggestionList {
     return this.overlayDecoration
   }
 
-  changeItems (items) {
+  changeItems(items) {
     this.items = items
     return this.emitter.emit('did-change-items', this.items)
   }
 
-  replaceItem (oldSuggestion, newSuggestion) {
+  replaceItem(oldSuggestion, newSuggestion) {
     if (newSuggestion == null) {
       return
     }
@@ -368,7 +375,7 @@ class SuggestionList {
   }
 
   // Public: Clean up, stop listening to events
-  dispose () {
+  dispose() {
     if (this.subscriptions) {
       this.subscriptions.dispose()
     }


### PR DESCRIPTION
_(Apologies for the diff — I've been doing incremental style harmonization by setting some theoretically uncontroversial ESLint rules, and I forgot it would fix this file upon save. Lines 19, 279, 300, and 331 point to the only logic changes.)_

### Identify the Bug

#583 describes either one or two bugs in `autocomplete-plus` — it’s not clear yet if they’ve got the same root cause. This is certain to fix one of them.

This screencast illustrates a scenario where an autocomplete suggestion list closes, then immediately opens again:

https://github.com/pulsar-edit/pulsar/assets/3450/ed58d756-0a89-47e8-a04a-31d0ff46c762



`autocomplete-plus` tries to add and remove a class name from the appropriate `atom-text-editor` in sync with this menu’s life cycle — the presence of `.autocomplete-active` on `atom-text-editor` is how it knows it should be consuming a <kbd>Tab</kbd> or <kbd>Return</kbd> keystroke.

But if a menu disappears and then reappears immediately, the scheduled removal of `.autocomplete-active` may not run until after the menu has already reappeared — in which case it shouldn’t remove that class name. Instead, it removes `.autocomplete-active` anyway, dooming the next attempted choice confirmation to be handled by the editor instead of `autocomplete-plus` — thus inserting a tab character or newline instead.

### Description of the Change

I choose to fix this by introducing a sanity check inside the scheduled removal. When we open a menu, we now update a `lastActiveAt` property with a timestamp. When we schedule the class name removal, we capture the value of that property. Later, when the DOM task runs, we check on `lastActiveAt`: if the value has changed, that means the menu has reopened, and our task is stale.

### Alternate Designs

A simpler fix would’ve been to perform the class name removal _immediately_ instead of scheduling it, and that’s almost what I did. But I decided to believe that the original decision to use `atom.views.updateDocument` had a good reason behind it, even if I don’t know exactly what it is.

### Possible Drawbacks

I can’t think of any.

### Verification Process

Do what I’m doing in that screencast, but be sure to try it at least two dozen times to make sure that the bug isn’t still present. For whatever reason, I found it much easier to replicate the issue on my first completion attempt after a window reload.

### Release Notes

Fixed a race condition that could cause `autocomplete-plus` to ignore user input.
