### PR TITLE
[autocomplete-plus] Suppress `marked` warnings

### DIFF
--- a/packages/autocomplete-plus/lib/suggestion-list-element.js
+++ b/packages/autocomplete-plus/lib/suggestion-list-element.js
@@ -141,7 +141,9 @@ module.exports = class SuggestionListElement {
         marked(item.descriptionMarkdown, {
           gfm: true,
           breaks: true,
-          sanitize: false
+          sanitize: false,
+          mangle: false,
+          headerIds: false
         })
       )
       this.setDescriptionMoreLink(item)


### PR DESCRIPTION
### Identify the Bug

When `autocomplete-plus` shows results, [some warnings appear in the console](https://github.com/pulsar-edit/pulsar/pull/680#issuecomment-1687656688) about `marked` deprecations.

### Description of the Change

This PR just makes the changes recommended in the warnings. The features in question aren’t features we need in this context.

### Alternate Designs

One of them — adding IDs to headings — is something that we’ll probably need for `markdown-preview`, so we might consider installing the extra package for that. But we’ll never need the ability to mangle email addresses, so I’m looking forward to the next version of `marked` that’ll just remove that feature altogether and stop making us explicitly opt out of it.

### Possible Drawbacks

Two extra lines of code? That’s all I can think of.

### Verification Process

No real way to verify via a spec that a warning _wasn’t_ emitted, but I’ve confirmed that the warnings don’t appear in the console now that I’ve added these settings.

### Release Notes

* Prevented warnings in the developer console from appearing when autocomplete suggestions are shown
