### PR TITLE
[meta] Add `ignorePaths` to renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -5,6 +5,13 @@
   },
   "labels": ["dependencies"],
   "separateMajorMinor": "false",
+  "ignorePaths": [
+    "packages/autocomplete-atom-api/spec/fixtures/",
+    "packages/dev-live-reload/spec/fixtures/",
+    "packages/incompatible-packages/spec/fixtures/",
+    "packages/settings-view/spec/fixtures/",
+    "spec/fixtures/"
+  ],
   "packageRules": [
     {
       "description": "Group all DevDependencies for the Core Editor",


### PR DESCRIPTION
This PR adds the `ignorePaths` option to our renovate config.

It seems some of our suggested dependencies to bump are coming from fixtures in some of our specs.

So this PR just ensures those are no longer recommended, and don't distract away from real dependencies we need to worry about.