### PR TITLE
[meta] Ensure Actions can upload Rolling Releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,7 @@ env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   PYTHON_VERSION: '3.10'
   NODE_VERSION: 16
+  ROLLING_UPLOAD_TOKEN: ${{ secrets.ROLLING_RELEASE_UPLOAD_TOKEN }}
   # Below variables allow us to quickly control visual tests for each platform
   RUN_WINDOWS_VT: false
   RUN_LINUX_VT: true
@@ -24,8 +25,6 @@ jobs:
         os: [ ubuntu-latest, windows-latest, macos-latest ]
       fail-fast: false
     runs-on: ${{ matrix.os }}
-    permissions:
-      contents: write
 
     steps:
     - name: Checkout the latest code

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,6 +24,8 @@ jobs:
         os: [ ubuntu-latest, windows-latest, macos-latest ]
       fail-fast: false
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: write
 
     steps:
     - name: Checkout the latest code

--- a/script/rolling-release-scripts/rolling-release-binary-upload.js
+++ b/script/rolling-release-scripts/rolling-release-binary-upload.js
@@ -48,6 +48,10 @@ if (cirrusFlag === "cirrus") {
 
   console.log(`Uploading local binaries to rolling release repo: ${binaryAssets.join(",")}`);
 
+  // ROLLING_UPLOAD_TOKEN:
+  // - Assigned within Cirrus via encrypted variables
+  // - Assigned within GitHub Actions via secrets API
+  // - GITHUB_TOKEN as fallback
   publish({
     token: process.env.ROLLING_UPLOAD_TOKEN || process.env.GITHUB_TOKEN,
     owner: "pulsar-edit",


### PR DESCRIPTION
This PR increases the permissions of the actions to ensure it can write the new release for rolling releases