### PR TITLE
[meta] GitHub Actions: Don't sign macOS builds from forked repo PRs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,7 +76,6 @@ jobs:
     - name: Build Pulsar Binaries (macOS) (Signed)
       if: ${{ runner.os == 'macOS' && github.event.pull_request.head.repo.full_name == 'pulsar-edit/pulsar' }}
       # PRs generated from forks cannot access GitHub Secrets
-      # The empty string assignment of these values will cause macOS builds to fail
       # So if the PR is a fork, we will still build, but will not sign.
       env:
         CSC_LINK: ${{ secrets.CSC_LINK }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,14 +73,20 @@ jobs:
           yarn run build:apm
 
     # macOS Signing Stuff
-    - name: Build Pulsar Binaries (macOS)
-      if: ${{ runner.os == 'macOS' }}
+    - name: Setup macOS Signing Env Vars
+      if: ${{ github.event.pull_request.head.repo.full_name == 'pulsar-edit/pulsar' }}
+      # PRs generated from forks cannot access GitHub Secrets
+      # The empty string assignment of these values will cause macOS builds to fail
+      # So if the PR is a fork, we will still build, but will not sign.
       env:
         CSC_LINK: ${{ secrets.CSC_LINK }}
         CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
         APPLEID: ${{ secrets.APPLEID }}
         APPLEID_PASSWORD: ${{ secrets.APPLEID_PASSWORD }}
         TEAM_ID: ${{ secrets.TEAM_ID }}
+
+    - name: Build Pulsar Binaries (macOS)
+      if: ${{ runner.os == 'macOS' }}
       uses: nick-fields/retry@943e742917ac94714d2f408a0e8320f2d1fcafcd
       with:
         timeout_minutes: 30

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,8 +73,8 @@ jobs:
           yarn run build:apm
 
     # macOS Signing Stuff
-    - name: Setup macOS Signing Env Vars
-      if: ${{ github.event.pull_request.head.repo.full_name == 'pulsar-edit/pulsar' }}
+    - name: Build Pulsar Binaries (macOS) (Signed)
+      if: ${{ runner.os == 'macOS' && github.event.pull_request.head.repo.full_name == 'pulsar-edit/pulsar' }}
       # PRs generated from forks cannot access GitHub Secrets
       # The empty string assignment of these values will cause macOS builds to fail
       # So if the PR is a fork, we will still build, but will not sign.
@@ -84,9 +84,15 @@ jobs:
         APPLEID: ${{ secrets.APPLEID }}
         APPLEID_PASSWORD: ${{ secrets.APPLEID_PASSWORD }}
         TEAM_ID: ${{ secrets.TEAM_ID }}
+      uses: nick-fields/retry@943e742917ac94714d2f408a0e8320f2d1fcafcd
+      with:
+        timeout_minutes: 30
+        max_attempts: 3
+        retry_on: error
+        command: yarn dist
 
-    - name: Build Pulsar Binaries (macOS)
-      if: ${{ runner.os == 'macOS' }}
+    - name: Build Pulsar Binaries (macOS) (Unsigned)
+      if: ${{ runner.os == 'macOS' && github.event.pull_request.head.repo.full_name != 'pulsar-edit/pulsar' }}
       uses: nick-fields/retry@943e742917ac94714d2f408a0e8320f2d1fcafcd
       with:
         timeout_minutes: 30


### PR DESCRIPTION
According to the [docs](https://docs.github.com/en/actions/security-guides/encrypted-secrets#using-encrypted-secrets-in-a-workflow) a GitHub Action triggered from a forked repository, will be unable to access the `secrets` of the target repository, and instead will return an empty string, when asking for a secret.

What this means, is if a forked repo creates a PR to our repo, they will be unable to access the secrets of our repo, specifically the new macOS signing secrets. And instead the macOS signing secrets will be set with empty strings, which will cause Electron Builder to fail.

Resulting in logs like so:

```
empty password will be used for code signing  reason=CSC_KEY_PASSWORD is not defined
```

Which can be seen on #170 and #160 

To avoid this, we will create a single step in GitHub Actions that can conditionally assign the env vars for macOS signing, only if the PR created stems from this exact repository.

It does mean that PRs generated from a forked repo will not be signed, and comes with the headaches involved there, but this is a necessary change if we want to achieve green CI, while still ensuring builds can be built on macOS properly.