### PR TITLE
CI: Tweak Cirrus build filter to allow tag pushes

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -56,7 +56,7 @@ env:
 
 arm_linux_task:
   alias: linux
-  only_if: $CIRRUS_CRON != "" || $CIRRUS_TAG == "regular_release"
+  only_if: $CIRRUS_CRON != "" || $CIRRUS_TAG != ""
   arm_container:
     image: node:16-slim
     memory: 8G
@@ -118,7 +118,7 @@ arm_linux_task:
 
 silicon_mac_task:
   alias: mac
-  only_if: $CIRRUS_CRON != "" || $CIRRUS_TAG == "regular_release"
+  only_if: $CIRRUS_CRON != "" || $CIRRUS_TAG != ""
   macos_instance:
     image: ghcr.io/cirruslabs/macos-monterey-xcode:14
     memory: 8G


### PR DESCRIPTION
### Short Summary / Purpose

This is a really long PR body for a very short change. This is trying to align our Cirrus build filters to do what we want them to do -- limit builds only to cron (for Rolling) builds, along with one build per release during our Regular release process.

### Identify the Bug

<!--

Link to the issue describing the bug that you're fixing.

If there is not yet an issue for your bug, please open a new issue and then link to that issue in your pull request.
Note: In some cases, one person's "bug" is another person's "feature." If the pull request does not address an existing issue with the "bug" label, the maintainers have the final say on whether the current behavior is a bug.

-->

See this comment thread: https://github.com/pulsar-edit/pulsar/pull/682#pullrequestreview-1603840898

To summarize: the build filtering logic in `.cirrus.yml` at the moment seems to be slightly different from what was intended.

(This filtering logic is the main mechanism we use to restrict what circumstances Cirrus tasks run in, now that the [free Cirrus usage has some significant upper limits placed on it per month](https://cirrus-ci.org/blog/2023/07/17/limiting-free-usage-of-cirrus-ci/).)

### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

In the `.cirrus.yml` CI config definition file, the part where we use `only_if:` to filter what conditions the tasks will run in... Check the Cirrus env var `CIRRUS_TAG` is non-empty, meaning the current build was triggered by a tag being pushed to this repo.

This, along with the existing cron build filter, would mean we only build for "cron builds or tag pushes." Which I think is about right.

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

See this whole thread for discussion: https://github.com/pulsar-edit/pulsar/pull/682#discussion_r1311049037

(This is a long section about  various alternatives that I don't think are worth it, given the approach I actually went with seems at minimum just slightly better, IMO. Feel free to skip this section, if you want!)

`CIRRUS_PR_LABELS == "regular_release"` was the approach proposed just before I stumbled upon this one. But I feel like having to set a PR label is a little more cumbersome than having Cirrus just automatically build for when the tag is pushed. I think that would also require conscious timing/order of operations -- setting the PR label _before_ publishing the PR or ideally _just before_ pushing the "change version to 1.X.0 (no -dev)" commit. Otherwise (I think), the build's tasks will skip and no binaries will be produced... Furthermore, there is the risk of multiple builds happening per release and using double credits unintentionally/undesirably, since we usually do push a "re-add the `-dev` to the version string" commit before merging the version bump PR's...

As another option, I believe `required_pr_labels: regular_release` would _wait for the label_ and _only then_ trigger the tasks, which fixes the "requires some timing/order of operations" concern. But still requires a PR label, whereas this PR currently just needs a tag to be pushed, adding no manual work to the release flow. And the "PR label" filtering approach still risks a wasteful second build when doing the "remove `-dev` from the version string" commit we usually do at the end of the version bump PR's.

We also have a bunch of other Cirrus env vars we may be able to check, but I stopped looking into them, since this PR's approach seemed to be a better match than any of those. But for example, `CIRRUS_RELEASE` happens _if you create a tag during the creation of a GitHub Release_, which if we make the tag manually, as we usually do, won't work. (But side note, if we _do_ start making the tag from, say the GitHub Releases web UI, the approach I took in this PR is still valid. And could enable us to automatically upload the binaries to the right raft release here at core repo!)

We could also look at `CIRRUS_PR_TITLE` or `CIRRUS_PR_BODY` and see if they include "Release" or something, but searching in arbitrary text is imprecise, and might risk running release-specific stuff where there wasn't actually an intent to do so, and risk wasting credits.

See: https://cirrus-ci.org/guide/writing-tasks/#environment-variables for all the various Cirrus env vars we could work with...

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

Building on every tag push means, if someone randomly pushed a tag without specifically intending to run a release, we would waste credits, and depending on how much automation is set up down the line, might automatically attempt to upload some binaries to a GitHub release. We should do a PSA for those with write access to please not push any random tags, but then again, people already don't do that, so... Also, we costed out our credit use very conservatively to stay within our limits. Chances are we could easily handle one or two, maybe even several branch pushes and still make it through the month in terms of credits.

But yeah, we should avoid pushing random tags if we go with this simple "on tag pushed" approach.

### Verification Process

<!--

What process did you follow to verify that the change has not introduced any regressions? Describe the actions you performed (including buttons you clicked, text you typed, commands you ran, etc.), and describe the results you observed.

-->

Admittedly not tested, but this aligns with the docs at https://cirrus-ci.org/guide/writing-tasks/#environment-variables.

It's also used in a real-world example Cirrus team pointed us to: https://github.com/cirruslabs/macos-image-templates/blob/59624221fec15db250bfcad9e68d0e8931d2ccdc/.cirrus.yml#L33 (From this discussion where @confused-Techie got some valuable info on how we could start limiting the builds: https://github.com/cirruslabs/cirrus-ci-docs/discussions/1223#discussioncomment-6843012)

We will want to test this down the line, but testing it requires this config change being present on a tag that's pushed, so... I suppose I can push a tag off this branch to test it??? (And then delete said tag.)

TODO.

### Release Notes

<!--

Please describe the changes in a single line that explains this improvement in
terms that a user can understand. This text will be used in Atom's release notes.

If this change is not user-facing or notable enough to be included in release notes
you may use the strings "Not applicable" or "N/A" here.

Examples:

- The GitHub package now allows you to add co-authors to commits.
- Fixed an issue where multiple cursors did not work in a file with a single line.
- Increased the performance of searching and replacing across a whole project.

-->

N/A

(Do we do Changelog entries for CI stuff???? I don't think we do. I dunno.)