### PR TITLE
Cirrus: Skip builds if same commit was previously built

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -57,6 +57,7 @@ env:
 arm_linux_task:
   alias: linux
   only_if: $CIRRUS_CRON != "" || $CIRRUS_TAG != ""
+  skip: $CIRRUS_CHANGE_IN_REPO == $CIRRUS_LAST_GREEN_CHANGE
   arm_container:
     image: node:16-slim
     memory: 8G
@@ -119,6 +120,7 @@ arm_linux_task:
 silicon_mac_task:
   alias: mac
   only_if: $CIRRUS_CRON != "" || $CIRRUS_TAG != ""
+  skip: $CIRRUS_CHANGE_IN_REPO == $CIRRUS_LAST_GREEN_CHANGE
   macos_instance:
     image: ghcr.io/cirruslabs/macos-monterey-xcode:14
     memory: 8G


### PR DESCRIPTION
### Issue or RFC Endorsed by Atom's Maintainers

<!--

Link to the issue or RFC that your change relates to. This must be one of the following:

* An open issue with the `help-wanted` label
* An open issue with the `triaged` label
* An RFC with "accepted" status

To contribute an enhancement that isn't covered by one of the items above, please follow our guide for suggesting an enhancement: https://github.com/atom/.github/blob/master/CONTRIBUTING.md#suggesting-enhancements

To contribute other changes, you must use a different template. You can see all templates at https://github.com/atom/.github/tree/master/.github/PULL_REQUEST_TEMPLATE.

-->

None, but we discussed it on Discord (https://discord.com/channels/992103415163396136/1110367202282057848/1145964110962503772) and possibly in some of the other PR's/issues?

### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

In the Cirrus CI config definition, compare `$CIRRUS_CHANGE_IN_REPO`(the git SHA being built) and `$CIRRUS_LAST_GREEN_CHANGE` (the git SHA of the last successful Cirrus build on the same branch). If they match, it means we already built this commit, so we can skip it.

See these resources that document the env vars, and the task-skipping functionality, respectively: 
- https://cirrus-ci.org/guide/writing-tasks/#environment-variables
- https://cirrus-ci.org/guide/writing-tasks/#conditional-task-execution

Save some credits, and avoid putting out new Rolling releases and additional Apple Silicon macOS and ARM Linux binaries when we've already built the same state of the repo.

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

I could have shoved all this logic into `only_if: ` instead of putting this part in `skip: `, but I wanted to break up the long line first and foremost, and I suppose having a slightly different status of the build can help indicate at a glance why it didn't run (Namely, a build with all "skipped" task means the same git commit was already built! A build where no tasks were scheduled means one of the other filters caused the build not to run any tasks.)

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

None anticipated, unless I implemented it wrong??

### Verification Process

<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (including buttons you clicked, text you typed, commands you ran, etc.), and describe the results you observed.

-->

~~Gonna be a little hard to test this one, I suppose I can schedule two Cirrus cron builds on this branch. Yeah, that's not too bad, I'll do that...~~

~~TO BE TESTED YET~~

UPDATE: It works. See the Cirrus runs for this branch: https://cirrus-ci.com/github/pulsar-edit/pulsar/Cirrus-Rolling-dont-build-same-commit-multiple-times

<details><summary><b>Screenshots</b> (click to expand):</summary>

![Cirrus CI view of the builds for branch "Cirrus-Rolling-dont-build-same-commit-multiple-times", showing five completed runs -- three "branch push" or "PR" builds with no runtime, one "cron" build with 55,03 runtime, and one "cron" build with no runtime](https://github.com/pulsar-edit/pulsar/assets/20157115/df2abeca-00f1-4ec1-ab9e-6825411680f4)
![An ARM Linux build for the second "cron" build of this branch, showing that the task was skipped](https://github.com/pulsar-edit/pulsar/assets/20157115/ceeb8b3d-28ac-4ef2-a654-153545ac80e1)

</details>


### Release Notes

<!--

Please describe the changes in a single line that explains this improvement in
terms that a user can understand. This text will be used in Atom's release notes.

If this change is not user-facing or notable enough to be included in release notes
you may use the strings "Not applicable" or "N/A" here.

Examples:

- The GitHub package now allows you to add co-authors to commits.
- Fixed an issue where multiple cursors did not work in a file with a single line.
- Increased the performance of searching and replacing across a whole project.

-->

N/A

As much work as all this CI stuff is, I reckon we don't _usually_ put CI stuff in the Changelogs?