### PR TITLE
settings-view: Don't fix repository for core themes

### DIFF
--- a/packages/settings-view/lib/themes-panel.js
+++ b/packages/settings-view/lib/themes-panel.js
@@ -200,12 +200,6 @@ export default class ThemesPanel extends CollapsibleSectionPanel {
     packages.core = packages.core.filter(({theme}) => theme)
     packages.git = (packages.git || []).filter(({theme}) => theme)
 
-    for (let pack of packages.core) {
-      if (pack.repository == null) {
-        pack.repository = `https://github.com/pulsar-edit/${pack.name}`
-      }
-    }
-
     for (let packageType of ['dev', 'core', 'user', 'git']) {
       for (let pack of packages[packageType]) {
         pack.owner = ownerFromRepository(pack.repository)


### PR DESCRIPTION
Stop inserting a best-guess `repository` field for built-in themes' package.json data if they lack one in their actual package.json file.

Follow-up to https://github.com/pulsar-edit/pulsar/pull/264.

Doing this for the themes panel as well, since we just did it for the installed-packages panel in https://github.com/pulsar-edit/pulsar/pull/264, and since it's good to be consistent.

This was apparently being done to fix the Atom org icon (at the time) not being displayed for certain core packages that lacked the `repository` field in their package.json files. See: https://github.com/pulsar-edit/settings-view/commit/3b74b350a10d0cc59786003a01376ac259cc56f8

But I agree with the discussion in #264 to just remove this bit of code "fixing" the `repository` field and ensure we have the real data correctly entered in core packages' package.json files. Because the "fixed" value the code automatically inserted was often not where the package actually lived (it was incorrect data being auto-inserted, bot great).

But expect if a bundled package or theme has a broken or bugged author icon, that probably means we need to add a `repository` URL in that package's package.json file.