### PR TITLE
CI: Check for forks in a more semantic way for macOS signing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,7 +74,7 @@ jobs:
 
     # macOS Signing Stuff
     - name: Build Pulsar Binaries (macOS) (Signed)
-      if: ${{ runner.os == 'macOS' && github.event.pull_request.head.repo.full_name == 'pulsar-edit/pulsar' }}
+      if: ${{ runner.os == 'macOS' && ! github.event.pull_request.head.repo.fork }}
       # PRs generated from forks cannot access GitHub Secrets
       # So if the PR is a fork, we will still build, but will not sign.
       env:
@@ -91,7 +91,7 @@ jobs:
         command: yarn dist
 
     - name: Build Pulsar Binaries (macOS) (Unsigned)
-      if: ${{ runner.os == 'macOS' && github.event.pull_request.head.repo.full_name != 'pulsar-edit/pulsar' }}
+      if: ${{ runner.os == 'macOS' && github.event.pull_request.head.repo.fork }}
       uses: nick-fields/retry@943e742917ac94714d2f408a0e8320f2d1fcafcd
       with:
         timeout_minutes: 30


### PR DESCRIPTION
### Issue or RFC Endorsed by Pulsar's Maintainers

<!--

Link to the issue or RFC that your change relates to. This must be one of the following:

* An open issue with the `help-wanted` label
* An open issue with the `triaged` label
* An RFC with "accepted" status

To contribute an enhancement that isn't covered by one of the items above, please follow our guide for suggesting an enhancement: https://github.com/atom/.github/blob/master/CONTRIBUTING.md#suggesting-enhancements

To contribute other changes, you must use a different template. You can see all templates at https://github.com/atom/.github/tree/master/.github/PULL_REQUEST_TEMPLATE.

-->

Was discussed on the Discord: https://discord.com/channels/992103415163396136/992109539346370661/1146710576286928906

### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

Check the value of `github.event.pull_request.head.repo.fork` (can be `true` or `false`), rather than checking if the repo that the pull request originates from is `pulsar-edit/pulsar` as a hard-coded string.

Slightly more fork friendly if anyone forks Pulsar core and expects to run the CI and field pull requests at said fork.

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

We could also check `github.event.pull_request.head.repo.full_name == github.repository`, which is semantically: "check if pull request comes from the very repo/fork currently running the workflow."

_OR_, we could check that one or more of the env vars' contents is non-empty in length? So, try to sign if (in bash) `[[ -nz "$CSC_LINK" ]]`??

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

Forks of the repo are unlikely to have valid macOS signing certificates ready to go, so in that hypothetical scenario, "try to sign if not a PR from a fork" may actually cause them more trouble than help, I suppose... Hmm.

Actually having second thoughts if this is helpful to forks.

(I still think it's nice to have shorter lines in the workflow file, but eh. Maybe not worth it, IDK.)

### Verification Process

<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (including buttons you clicked, text you typed, commands you ran, etc.), and describe the results you observed.

-->

Checked that this value is real in the docs.

Events that can trigger GitHub Actions Worfklows, section on `pull_request` event: https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows

Links to the REST API definition of the `pull_request` event, where you can see in the example JSON responses that it has `pull_request.head.repo.fork` as a boolean `true`/`false`: https://docs.github.com/en/webhooks/webhook-events-and-payloads?actionType=opened#pull_request

**If real-world testing is desired,** I can run a PR of the same change, but from my personal fork `DeeDeeG/pulsar`.

### Release Notes

<!--

Please describe the changes in a single line that explains this improvement in
terms that a user can understand. This text will be used in Atom's release notes.

If this change is not user-facing or notable enough to be included in release notes
you may use the strings "Not applicable" or "N/A" here.

Examples:

- The GitHub package now allows you to add co-authors to commits.
- Fixed an issue where multiple cursors did not work in a file with a single line.
- Increased the performance of searching and replacing across a whole project.

-->

N/A (not important enough for release notes??)