### PR TITLE
[core] Fix the icon used when registering Pulsar as a file handler in Windows

### DIFF
--- a/src/main-process/win-shell.js
+++ b/src/main-process/win-shell.js
@@ -10,8 +10,7 @@ const fileIconPath = `"${Path.join(
   process.execPath,
   '..',
   'resources',
-  'cli',
-  'file.ico'
+  'pulsar.ico'
 )}"`;
 
 class ShellOption {


### PR DESCRIPTION
Currently if Pulsar is registered as a file handler in Windows, the icon used no longer exists since our rewriting of the `electron-builder` process.

This means that if Pulsar is then set as the application to open a specific file, after enabling `Register as file handler` in Pulsar's settings, that file will receive a blank icon, instead of the Pulsar logo.

This PR resolves the icon path to one that we know exists on Windows, and should resolve this issue.

Resolves #662 