### PR TITLE
[about] Link release notes to `CHANGELOG.md` instead of tagged release of Pulsar

### DIFF
--- a/packages/about/lib/update-manager.js
+++ b/packages/about/lib/update-manager.js
@@ -18,7 +18,7 @@ let UpdateManager = class UpdateManager {
       appVersion = appVersion.replace("v", "");
     }
 
-    return `https://github.com/pulsar-edit/pulsar/blob/master/CHANGELOG.md#${appVersion.replace(".", "")}`;
+    return `https://github.com/pulsar-edit/pulsar/blob/master/CHANGELOG.md#${appVersion.replace(/\./g, "")}`;
   }
 };
 

--- a/packages/about/lib/update-manager.js
+++ b/packages/about/lib/update-manager.js
@@ -9,11 +9,6 @@ let UpdateManager = class UpdateManager {
   }
 
   getReleaseNotesURLForVersion(appVersion) {
-    // Dev versions will not have a releases page
-    if (appVersion.indexOf('dev') > -1) {
-      return 'https://pulsar-edit.dev/download.html';
-    }
-
     if (appVersion.startsWith('v')) {
       appVersion = appVersion.replace("v", "");
     }

--- a/packages/about/lib/update-manager.js
+++ b/packages/about/lib/update-manager.js
@@ -14,13 +14,11 @@ let UpdateManager = class UpdateManager {
       return 'https://pulsar-edit.dev/download.html';
     }
 
-    if (!appVersion.startsWith('v')) {
-      appVersion = `v${appVersion}`;
+    if (appVersion.startsWith('v')) {
+      appVersion = appVersion.replace("v", "");
     }
 
-    const releaseRepo =
-      appVersion.indexOf('nightly') > -1 ? 'pulsar-nightly-releases' : 'pulsar';
-    return `https://github.com/pulsar-edit/${releaseRepo}/releases/tag/${appVersion}`;
+    return `https://github.com/pulsar-edit/pulsar/blob/master/CHANGELOG.md#${appVersion.replace(".", "")}`;
   }
 };
 

--- a/packages/about/spec/update-manager-spec.js
+++ b/packages/about/spec/update-manager-spec.js
@@ -8,7 +8,15 @@ describe('UpdateManager', () => {
   });
 
   describe('::getReleaseNotesURLForVersion', () => {
+    it('returns the page for the release even when a dev version', () => {
+      expect(updateManager.getReleaseNotesURLForVersion('1.100.0-dev')).toContain(
+        'pulsar-edit/pulsar/blob/master/CHANGELOG.md#11000-dev'
+      );
+    });
     it('returns the page for the release when not a dev version', () => {
+      expect(updateManager.getReleaseNotesURLForVersion('1.108.2023090322')).toContain(
+        'pulsar-edit/pulsar/blob/master/CHANGELOG.md#11082023090322'
+      );
       expect(updateManager.getReleaseNotesURLForVersion('1.100.0')).toContain(
         'pulsar-edit/pulsar/blob/master/CHANGELOG.md#11000'
       );

--- a/packages/about/spec/update-manager-spec.js
+++ b/packages/about/spec/update-manager-spec.js
@@ -16,19 +16,10 @@ describe('UpdateManager', () => {
 
     it('returns the page for the release when not a dev version', () => {
       expect(updateManager.getReleaseNotesURLForVersion('1.100.0')).toContain(
-        'pulsar-edit/pulsar/releases/tag/v1.100.0'
+        'pulsar-edit/pulsar/blob/master/CHANGELOG.md#11000'
       );
       expect(updateManager.getReleaseNotesURLForVersion('v1.100.0')).toContain(
-        'pulsar-edit/pulsar/releases/tag/v1.100.0'
-      );
-      // TODO: Since we no longer follow release channels, is it useful to continue testing their state?
-      expect(
-        updateManager.getReleaseNotesURLForVersion('1.100.0-beta10')
-      ).toContain('pulsar-edit/pulsar/releases/tag/v1.100.0-beta10');
-      expect(
-        updateManager.getReleaseNotesURLForVersion('1.100.0-nightly10')
-      ).toContain(
-        'pulsar-edit/pulsar-nightly-releases/releases/tag/v1.100.0-nightly10'
+        'pulsar-edit/pulsar/blob/master/CHANGELOG.md#11000'
       );
     });
   });

--- a/packages/about/spec/update-manager-spec.js
+++ b/packages/about/spec/update-manager-spec.js
@@ -8,12 +8,6 @@ describe('UpdateManager', () => {
   });
 
   describe('::getReleaseNotesURLForVersion', () => {
-    it('returns pulsar-edit download page when dev version', () => {
-      expect(
-        updateManager.getReleaseNotesURLForVersion('1.7.0-dev-e44b57d')
-      ).toContain('pulsar-edit.dev/download');
-    });
-
     it('returns the page for the release when not a dev version', () => {
       expect(updateManager.getReleaseNotesURLForVersion('1.100.0')).toContain(
         'pulsar-edit/pulsar/blob/master/CHANGELOG.md#11000'


### PR DESCRIPTION
Currently the release notes returned by the `about` package attempt to link to a tagged release of Pulsar. This works fine for the regular release of Pulsar, but will link to a non-existent page when used in a Rolling Release.

While there was talks of other methods of fixing this issue, especially now that we do have the `pulsar-rolling-release` repo (although that repo has no release notes on each published version).

The simplest answer was to return the link to Pulsar's `CHANGELOG.md`. The biggest benefit of using this and using an anchor tag to link to a specific version, means it will work on all regular releases, and in the event someone on a rolling release uses this link, the anchor tag will not resolve, and instead will link to the top of the page, thus showing the user the `[Unreleased]` notes, which should mostly be applicable to their rolling release details.

Additionally on this PR, since I had the chance, I removed the logic of finding a `nightly` release repo, since we do not use that logic at all. And since we are now linking via an anchor tag, I've removed the logic of appending a `v` to the version, and instead we now remove it if present, since this character is not present in our changelog notes.

Resolves #283 