### PR TITLE
[core & settings-view] Avoid network requests for bundled packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "main": "./src/main-process/main.js",
   "repository": {
     "type": "git",
-    "url": "https://github.com/pulsar-edit/pulsar.git"
+    "url": "https://github.com/pulsar-edit/pulsar"
   },
   "bugs": {
     "url": "https://github.com/pulsar-edit/pulsar/issues"

--- a/packages/settings-view/lib/package-card.js
+++ b/packages/settings-view/lib/package-card.js
@@ -280,31 +280,39 @@ export default class PackageCard {
   }
 
   loadCachedMetadata () {
-    this.client.avatar(ownerFromRepository(this.pack.repository), (err, avatarPath) => {
-      if (!err && avatarPath) {
-        this.refs.avatar.src = `file://${avatarPath}`
-      }
-    })
-
-    this.client.package(this.pack.name, (err, data) => {
-      // We don't need to actually handle the error here, we can just skip
-      // showing the download count if there's a problem.
-      if (!err) {
-        if (data == null) {
-          data = {}
+    if (this.pack.repository === atom.branding.urlCoreRepo) {
+      // Don't hit the web for our bundled packages. Just use the local image.
+      this.refs.avatar.src = `file://${path.join(process.execPath, "..", "resources", "pulsar.png")}`;
+    } else {
+      this.client.avatar(ownerFromRepository(this.pack.repository), (err, avatarPath) => {
+        if (!err && avatarPath) {
+          this.refs.avatar.src = `file://${avatarPath}`
         }
+      })
+    }
 
-        if (this.pack.apmInstallSource && this.pack.apmInstallSource.type === 'git') {
-          this.refs.downloadIcon.classList.remove('icon-cloud-download')
-          this.refs.downloadIcon.classList.add('icon-git-branch')
-          this.refs.downloadCount.textContent = this.pack.apmInstallSource.sha.substr(0, 8)
-        } else {
+    // We don't want to hit the API for this data, if it's a bundled package
+    if (this.pack.repository !== atom.branding.urlCoreRepo) {
+      this.client.package(this.pack.name, (err, data) => {
+        // We don't need to actually handle the error here, we can just skip
+        // showing the download count if there's a problem.
+        if (!err) {
+          if (data == null) {
+            data = {}
+          }
 
-          this.refs.stargazerCount.textContent = data.stargazers_count ? parseInt(data.stargazers_count).toLocaleString() : ''
-          this.refs.downloadCount.textContent = data.downloads ? parseInt(data.downloads).toLocaleString() : ''
+          if (this.pack.apmInstallSource && this.pack.apmInstallSource.type === 'git') {
+            this.refs.downloadIcon.classList.remove('icon-cloud-download')
+            this.refs.downloadIcon.classList.add('icon-git-branch')
+            this.refs.downloadCount.textContent = this.pack.apmInstallSource.sha.substr(0, 8)
+          } else {
+
+            this.refs.stargazerCount.textContent = data.stargazers_count ? parseInt(data.stargazers_count).toLocaleString() : ''
+            this.refs.downloadCount.textContent = data.downloads ? parseInt(data.downloads).toLocaleString() : ''
+          }
         }
-      }
-    })
+      })
+    }
   }
 
   updateInterfaceState () {

--- a/packages/settings-view/lib/package-card.js
+++ b/packages/settings-view/lib/package-card.js
@@ -5,6 +5,7 @@ import {CompositeDisposable, Disposable} from 'atom'
 import {shell} from 'electron'
 import etch from 'etch'
 import BadgeView from './badge-view'
+import path from 'path'
 
 import {ownerFromRepository} from './utils'
 

--- a/packages/settings-view/lib/package-card.js
+++ b/packages/settings-view/lib/package-card.js
@@ -283,7 +283,7 @@ export default class PackageCard {
   loadCachedMetadata () {
     if (this.pack.repository === atom.branding.urlCoreRepo) {
       // Don't hit the web for our bundled packages. Just use the local image.
-      this.refs.avatar.src = `file://${path.join(process.execPath, "..", "resources", "pulsar.png")}`;
+      this.refs.avatar.src = `file://${path.join(process.resourcesPath, "pulsar.png")}`;
     } else {
       this.client.avatar(ownerFromRepository(this.pack.repository), (err, avatarPath) => {
         if (!err && avatarPath) {

--- a/packages/settings-view/lib/package-card.js
+++ b/packages/settings-view/lib/package-card.js
@@ -7,7 +7,7 @@ import etch from 'etch'
 import BadgeView from './badge-view'
 import path from 'path'
 
-import {ownerFromRepository} from './utils'
+import {ownerFromRepository, repoUrlFromRepository} from './utils'
 
 let marked = null
 
@@ -281,7 +281,7 @@ export default class PackageCard {
   }
 
   loadCachedMetadata () {
-    if (this.pack.repository === atom.branding.urlCoreRepo) {
+    if (repoUrlFromRepository(this.pack.repository) === atom.branding.urlCoreRepo) {
       // Don't hit the web for our bundled packages. Just use the local image.
       this.refs.avatar.src = `file://${path.join(process.resourcesPath, "pulsar.png")}`;
     } else {

--- a/packages/settings-view/lib/utils.js
+++ b/packages/settings-view/lib/utils.js
@@ -22,13 +22,21 @@ const ownerFromRepository = repository => {
 const repoUrlFromRepository = repository => {
   if (!repository) return ''
 
+  let repo = repository
+
   if (typeof repository === 'string') {
-    return repository
+    repo = repository
   } else if (typeof repository === 'object' && typeof repository.url === 'string') {
-    return repository.url
+    repo = repository.url
   } else {
-    return ''
+    repo = ''
   }
+
+  if (repo.endsWith('.git')) {
+    repo = repo.replace('.git', '')
+  }
+
+  return repo
 }
 
 const packageComparatorAscending = (left, right) => {

--- a/packages/settings-view/lib/utils.js
+++ b/packages/settings-view/lib/utils.js
@@ -19,6 +19,18 @@ const ownerFromRepository = repository => {
   return match ? match[1] : ''
 }
 
+const repoUrlFromRepository = repository => {
+  if (!repository) return ''
+
+  if (typeof repository === 'string') {
+    return repository
+  } else if (typeof repository === 'object' && typeof repository.url === 'string') {
+    return repository.url
+  } else {
+    return ''
+  }
+}
+
 const packageComparatorAscending = (left, right) => {
   const leftStatus = atom.packages.isPackageDisabled(left.name)
   const rightStatus = atom.packages.isPackageDisabled(right.name)
@@ -37,4 +49,4 @@ const packageComparatorAscending = (left, right) => {
   }
 }
 
-module.exports = {ownerFromRepository, packageComparatorAscending}
+module.exports = {ownerFromRepository, repoUrlFromRepository, packageComparatorAscending}

--- a/src/atom-environment.js
+++ b/src/atom-environment.js
@@ -222,7 +222,8 @@ class AtomEnvironment {
       name: packagejson.branding.name,
       urlWeb: packagejson.branding.urlWeb,
       urlGH: packagejson.branding.urlGH,
-      urlForum: packagejson.branding.urlForum
+      urlForum: packagejson.branding.urlForum,
+      urlCoreRepo: packagejson.repository.url
     };
 
     // Keep instances of HistoryManager in sync


### PR DESCRIPTION
In this PR I've made three changes:

* Added `atom.branding.urlCoreRepo` to equal the value of our `package.json`s `repository.url`
* Don't hit the GitHub API for getting our org picture for `settings-view`, instead just load the `pulsar.png` that comes with every installation
* Don't hit the backend API for getting download counts and star counts, instead just skip loading them totally

These changes are all focused on reducing the amount of times we hit the backend unnecessarily. As nobody is really installing our bundled packages, it doesn't make much sense to show download counts or stargazer counts for them. Additionally, loading a locally stored image reduces the amount of network requests needed for every user.