### PR TITLE
Cirrus: Don't update last good commit if CI skipped

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -263,3 +263,15 @@ silicon_mac_task:
 #       path: report.xml
 #       type: text/xml
 #       format: junit
+
+silently_mark_skipped_or_no_scheduled_tasks_builds_as_failed_task:
+  skip_notifications: true
+  only_if: $CIRRUS_CRON == "" && $CIRRUS_TAG == ""
+  ### !!! ^ Don't forget to update this appropriately if our `only_if:` or `skip:` logic changes for the other tasks! !!! ###
+  ### !!! ^ We want this task to run [only] if all other tasks would have skipped. !!! ###
+  container:
+    image: alpine:latest
+    cpu: 1
+  clone_script: exit 0 # Shortest possible script that succeeds. Saves time vs actually cloning. Failing here triggers an automatic re-run, so don't do that!
+  mark_task_as_failed_script: exit 1 # Shortest possible script to mark a build as "failed". This protects CIRRUS_LAST_GREEN_CHANGE from being updated by builds that actually just skipped CI.
+  timeout_in: 6s


### PR DESCRIPTION
### Identify the Bug

<!--

Link to the issue describing the bug that you're fixing.

If there is not yet an issue for your bug, please open a new issue and then link to that issue in your pull request.
Note: In some cases, one person's "bug" is another person's "feature." If the pull request does not address an existing issue with the "bug" label, the maintainers have the final say on whether the current behavior is a bug.

-->

The skipping logic from https://github.com/pulsar-edit/pulsar/pull/701 is slightly broken.

Cirrus updates `CIRRUS_LAST_GREEN_CHANGE` for all "successful builds". Unexpectedly, that var is updated _even if the build had no tasks, or had tasks that were all `SKIPPED`._

By the time the cron build rolled around, a branch push to `master` had already triggered, skipped, and been marked successful for that commit in Cirrus. So, the cron builds skipped as well, seeing that "the commit was already built once, nothing to do!".

So, we were effectively _skipping every build ever triggered on the Cirrus_, even the cron builds that were meant to, you know, build and publish Rolling binaries every few days (Mon+Wed+Fri).

### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

Run a task that does nothing other than report a failing status, so the overall build gets marked as failed.

(Conditionally running this task using the proper inverse of the `only_if:` logic for the other "real" tasks we want to run... So, if we were going to skip everything, run only this task that quickly/quietly fails the build. If we were going to run real tasks, do so us usual and don't fail the builds.)

Makes sure commits that have had CI "run-but-actually-skipped" on them don't report as "Successful", so the skipping logic doesn't _prevent/skip all builds ever in Cirrus_.

- Bonus implementation detail: I enabled a feature for this task that avoids reporting the failure to GitHub, so there will be less noise when checking the CI status of the skipped builds on the GitHub side. ✅

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

- We could just yeet/delete the skipping logic from https://github.com/pulsar-edit/pulsar/pull/701.
  - That logic is rarely used -- currently only really helps (as designed, if it was working properly) if a Cron build runs twice on the same commit. Basically only if we go two or three days between adding more commits to`master` branch.

Justification of why doing this instead of simplifying: I wanted to "skip repeat builds of the same commit (https://github.com/pulsar-edit/pulsar/pull/701) and do so properly (this PR)", because "engineers gonna engineer" and add more cool stuff... But also, skipping re-builds both theoretically saves us some credits, and theoretically saves us from pushing out new Rolling binaries in situations when nothing actually changed. (Makes it easier to reason about when/why the different Rolling versions were produced.)

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

- Unfortunately, this still shows up as extremely short failed builds on the Cirrus side. A bit noisy. ❌
- More complex than just yeeting/deleting the skipping logic from https://github.com/pulsar-edit/pulsar/pull/701.

### Verification Process

<!--

What process did you follow to verify that the change has not introduced any regressions? Describe the actions you performed (including buttons you clicked, text you typed, commands you ran, etc.), and describe the results you observed.

-->

- [x] If you look at the CI status of this PR **on Cirrus**, it should show one, ~2-3 second task that did nothing other than immediately fail
  - Yep, see the first/initial Cirrus run for this PR: https://cirrus-ci.com/build/5383988525662208
- [x] If you look at the Cirrus status of this PR **from the GitHub UI**, it should be clean or show no Cirrus info at all. This is because the failure is not reported to GitHub, to reduce the visual noise.
  - Update: This was true at this point as I was going down the checklist. There are genuine aborted tasks that are showing instead now, see below. But all is still as expected and intended.
- [x] If we schedule a Cron build of this PR's branch, it should _actually run!_
  - ~~(We might end up with binaries published to the Rolling releases repo if we do that, in which case we should probably track those down and delete them...)~~
  - [x] It did work. I cancelled the builds. So, now this PR shows with a cancelled (failed) build, but before it had nothing reported from Cirrus, for the record.

### Release Notes

<!--

Please describe the changes in a single line that explains this improvement in
terms that a user can understand. This text will be used in Atom's release notes.

If this change is not user-facing or notable enough to be included in release notes
you may use the strings "Not applicable" or "N/A" here.

Examples:

- The GitHub package now allows you to add co-authors to commits.
- Fixed an issue where multiple cursors did not work in a file with a single line.
- Increased the performance of searching and replacing across a whole project.

-->

Fixed skipping logic for Cirrus (but maybe don't add this in the actual Changelog, IDK, it's a CI-only change, so...???)