### PR TITLE
about: Make the About page's CSS responsive for narrow panes

### DIFF
--- a/packages/about/lib/components/about-view.js
+++ b/packages/about/lib/components/about-view.js
@@ -83,7 +83,7 @@ module.exports = class AboutView extends EtchComponent {
     return $.div(
       { className: 'pane-item native-key-bindings about' },
       $.div(
-        { className: 'about-container' },
+        { className: 'about-container min-width-min-content' },
         $.header(
           { className: 'about-header' },
           $.a(
@@ -94,7 +94,7 @@ module.exports = class AboutView extends EtchComponent {
             { className: 'about-header-info' },
             $.span(
               {
-                className: 'about-version-container inline-block atom',
+                className: 'about-version-container atom',
                 onclick: this.handleAtomVersionClick.bind(this)
               },
               $.span(
@@ -114,7 +114,7 @@ module.exports = class AboutView extends EtchComponent {
           $.span(
             {
               className:
-                'about-version-container inline-block show-more-expand',
+                'about-version-container show-more-expand',
               onclick: this.handleShowMoreClick.bind(this)
             },
             $.span({ className: 'about-more-expand' }, 'Show more')
@@ -168,7 +168,7 @@ module.exports = class AboutView extends EtchComponent {
       ),
 
       $.div(
-        { className: 'about-updates group-start' },
+        { className: 'about-updates group-start min-width-min-content' },
         $.div(
           { className: 'about-updates-box' },
           $.div(
@@ -177,7 +177,7 @@ module.exports = class AboutView extends EtchComponent {
               { className: 'about-updates-item app-unsupported' },
               $.span(
                 { className: 'about-updates-label is-strong' },
-                'Updates have been moved to the package ', $.code({}, 'pulsar-updater'), '.',
+                'Updates have been moved to the package ', $.code({style: {'white-space': 'nowrap'}}, 'pulsar-updater'), '.',
                 $.br()
               ),
               $.a(
@@ -242,7 +242,8 @@ module.exports = class AboutView extends EtchComponent {
           className: 'btn about-update-action-button',
           onclick: this.executeUpdateAction.bind(this),
           style: {
-            display: 'block'
+            display: 'block',
+            margin: '0 .5em'
           }
         },
         'Check Now'

--- a/packages/about/styles/about.less
+++ b/packages/about/styles/about.less
@@ -78,10 +78,8 @@
   flex-wrap: wrap;
   justify-content: center;
   align-items: center;
-  column-gap: .8em;
   column-gap: 30px;
 }
-
 .about-version-container {
   vertical-align: middle;
   white-space: nowrap;

--- a/packages/about/styles/about.less
+++ b/packages/about/styles/about.less
@@ -33,6 +33,10 @@
     margin-top: -.2em;
   }
 
+  .min-width-min-content {
+    min-width: min-content;
+  }
+
   // used to group different elements
   .group-start {
     margin-top: 4em;
@@ -45,7 +49,12 @@
 .about-container {
   width: 100%;
   max-width: 500px;
+
+  .icon::before {
+    margin-right: 0;
+  }
 }
+
 
 // Header --------------------------------
 
@@ -64,7 +73,18 @@
   transition: color 0.2s;
 }
 
+.about-header-info {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  align-items: center;
+  column-gap: .8em;
+  column-gap: 30px;
+}
+
 .about-version-container {
+  vertical-align: middle;
+  white-space: nowrap;
   &:hover {
     color: lighten(@text-color, 15%);
   }
@@ -84,17 +104,19 @@
   font-size: .9em;
 }
 
+/*
 .about-header-release-notes {
   vertical-align: middle;
   margin-left: 1em;
 }
+*/
 
 
 // Updates --------------------------------
 
 .about-updates {
   width: 100%;
-  //max-width: 510px;
+  max-width: 39em;
 }
 
 .about-updates-box {
@@ -130,7 +152,7 @@
 
 .about-updates-release-notes,
 .about-updates-instructions {
-  margin: 0 1em 0 1.5em;
+  // margin: 0 1em 0 1.5em;
 }
 
 .about-auto-updates {
@@ -144,6 +166,8 @@
 // Love --------------------------------
 
 .about-love {
+  min-width: max-content;
+
   .icon::before {
     // Make these octicons look good inlined with text
     position: relative;

--- a/packages/about/styles/about.less
+++ b/packages/about/styles/about.less
@@ -102,13 +102,6 @@
   font-size: .9em;
 }
 
-/*
-.about-header-release-notes {
-  vertical-align: middle;
-  margin-left: 1em;
-}
-*/
-
 
 // Updates --------------------------------
 
@@ -146,11 +139,6 @@
 
 .about-updates-version {
   margin: 0 .4em;
-}
-
-.about-updates-release-notes,
-.about-updates-instructions {
-  // margin: 0 1em 0 1.5em;
 }
 
 .about-auto-updates {


### PR DESCRIPTION
### Issue or RFC Endorsed by ~~Atom's~~ Pulsar's Maintainers

<!--

Link to the issue or RFC that your change relates to. This must be one of the following:

* An open issue with the `help-wanted` label
* An open issue with the `triaged` label
* An RFC with "accepted" status

To contribute an enhancement that isn't covered by one of the items above, please follow our guide for suggesting an enhancement: https://github.com/atom/.github/blob/master/CONTRIBUTING.md#suggesting-enhancements

To contribute other changes, you must use a different template. You can see all templates at https://github.com/atom/.github/tree/master/.github/PULL_REQUEST_TEMPLATE.

-->

Mentioned it on the Discord and got some initial positive feedback there: https://discord.com/channels/992103415163396136/992109539346370661/1143393453498179594

### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

Adjust the CSS/styling of the About view to be a little cleaner-looking when its pane is shrunk horizontally. (It already overflow-scrolls vertically in a totally reasonable way, when needed, IMO.)

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

- Wasn't 100% sure about when to add a new class, vs inline adding a `style` attribute/rule directly on an element.
- `white-space: nowrap` and `min-width: max-content` have, for all intents and purpose, the same effect. I mixed and matched these slightly, so I suppose I could standardize on just one?
- There are an infinite amount of ways to style something, and CSS is extremely flexible even for different ways to express 100% equivalent styles. I think you could get stuck in the minutiae here forever.

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

_Might look too fresh and clean._

<details><summary>Being serious:</summary>

I _guess_ these very minimal changes to the styling might not work perfectly on all themes, but from the default-installed themes plus to the extent I could test Dracula theme, it looks fine?)

</details>

### Verification Process

<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (including buttons you clicked, text you typed, commands you ran, etc.), and describe the results you observed.

-->

_Looks fresh to me 😎._

In all seriousness, I tested this locally with the built-in themes Atom Dark/Atom Light, and One Dark/One Light. Looked reasonable in either... (other than that, subjectively, the One themes (default theme) are much nicer than the Atom Dark/Atom Light theme, and text and several elements looks small to me _everywhere_ when using that theme, not just on the _About_ page.)

- [x] About package tests pass in CI.
- [x] All other tests pass in CI as well.

### Screen Recordings

<details><summary>Screen recordings of before/after, click to expand:</summary>

#### Before:

https://github.com/pulsar-edit/pulsar/assets/20157115/6dd70c9a-dc54-4a3f-9d56-faca084277c6

#### After:

https://github.com/pulsar-edit/pulsar/assets/20157115/6829e3f4-27df-4756-bd2e-bb9155aa2323

</details>

### Release Notes

<!--

Please describe the changes in a single line that explains this improvement in
terms that a user can understand. This text will be used in Atom's release notes.

If this change is not user-facing or notable enough to be included in release notes
you may use the strings "Not applicable" or "N/A" here.

Examples:

- The GitHub package now allows you to add co-authors to commits.
- Fixed an issue where multiple cursors did not work in a file with a single line.
- Increased the performance of searching and replacing across a whole project.

-->

Make the About page's CSS responsive for narrow panes