### PR TITLE
CI: Use commit date as the Rolling version number

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -28,7 +28,8 @@ env:
 #                 xvfb
 #     - git submodule init
 #     - git submodule update
-#     - sed -i -e "s/[0-9]*-dev/`date -u +%Y%m%d%H`/g" package.json
+#     - export COMMIT_DATE=`TZ=UTC0 git show --quiet --date='format-local:%Y%m%d%H' --format="%cd"`
+#     - sed -i -e "s/[0-9]*-dev/${COMMIT_DATE}/g" package.json
 #   install_script:
 #     - yarn install --ignore-engines || yarn install --ignore-engines
 #   build_script:
@@ -88,7 +89,8 @@ arm_linux_task:
     - gem install fpm
     - git submodule init
     - git submodule update
-    - sed -i -e "s/[0-9]*-dev/`date -u +%Y%m%d%H`/g" package.json
+    - export COMMIT_DATE=`TZ=UTC0 git show --quiet --date='format-local:%Y%m%d%H' --format="%cd"`
+    - sed -i -e "s/[0-9]*-dev/${COMMIT_DATE}/g" package.json
   install_script:
     - yarn install --ignore-engines || yarn install --ignore-engines
   build_script:
@@ -137,7 +139,8 @@ silicon_mac_task:
     - git submodule update
     - ln -s /opt/homebrew/bin/python$PYTHON_VERSION /opt/homebrew/bin/python
     - export PATH="/opt/homebrew/bin:/opt/homebrew/opt/node@16/bin:$PATH"
-    - sed -i -e "s/[0-9]*-dev/`date -u +%Y%m%d%H`/g" package.json
+    - export COMMIT_DATE=`TZ=UTC0 git show --quiet --date='format-local:%Y%m%d%H' --format="%cd"`
+    - sed -i -e "s/[0-9]*-dev/${COMMIT_DATE}/g" package.json
   install_script:
     - export PATH="/opt/homebrew/bin:/opt/homebrew/opt/node@16/bin:$PATH"
     - yarn install --ignore-engines || yarn install --ignore-engines
@@ -193,7 +196,8 @@ silicon_mac_task:
 #     - ln -s /usr/local/bin/python$PYTHON_VERSION /usr/local/bin/python
 #     - git submodule init
 #     - git submodule update
-#     - sed -i -e "s/[0-9]*-dev/`date -u +%Y%m%d%H`/g" package.json
+#     - export COMMIT_DATE=`TZ=UTC0 git show --quiet --date='format-local:%Y%m%d%H' --format="%cd"`
+#     - sed -i -e "s/[0-9]*-dev/${COMMIT_DATE}/g" package.json
 #   install_script:
 #     - export PATH="/usr/local/opt/node@16/bin:/usr/local/bin:$PATH"
 #     - arch -x86_64 npx yarn install --ignore-engines || arch -x86_64 npx yarn install --ignore-engines
@@ -246,7 +250,8 @@ silicon_mac_task:
 #     - npx yarn build:apm
 #     - npx yarn build || npx yarn build || npx yarn build
 #   build_binary_script:
-#     - sed -i -e "s/[0-9]*-dev/`date -u +%Y%m%d%H`/g" package.json
+#     - export COMMIT_DATE=`TZ=UTC0 git show --quiet --date='format-local:%Y%m%d%H' --format="%cd"`
+#     - sed -i -e "s/[0-9]*-dev/${COMMIT_DATE}/g" package.json
 #     - npx yarn dist || npx yarn dist || npx yarn dist
 #   rename_binary_script:
 #     - node script/rename.js "Windows"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,13 +45,11 @@ jobs:
         git submodule init
         git submodule update
 
-    - name: Check Pulsar Version
-      if: ${{ runner.os != 'Windows' }}
-      run: sed -i -e "s/[0-9]*-dev/`date -u +%Y%m%d%H`/g" package.json
-
-    - name: Check Pulsar Version - Windows
-      if: ${{ runner.os == 'Windows' }}
-      run: (Get-Content package.json) -replace '[0-9]*-dev', (date -u +%Y%m%d%H) | Set-Content -Path package.json
+    - name: Update Pulsar version number for Rolling
+      run: |
+        export COMMIT_DATE=`TZ=UTC0 git show --quiet --date='format-local:%Y%m%d%H' --format="%cd"`
+        sed -i -e "s/[0-9]*-dev/${COMMIT_DATE}/g" package.json
+      shell: bash
 
     - name: Install Pulsar Dependencies
       uses: nick-fields/retry@943e742917ac94714d2f408a0e8320f2d1fcafcd


### PR DESCRIPTION
### Issue or RFC Endorsed by ~~Atom's~~ Pulsar's Maintainers

<!--

Link to the issue or RFC that your change relates to. This must be one of the following:

* An open issue with the `help-wanted` label
* An open issue with the `triaged` label
* An RFC with "accepted" status

To contribute an enhancement that isn't covered by one of the items above, please follow our guide for suggesting an enhancement: https://github.com/atom/.github/blob/master/CONTRIBUTING.md#suggesting-enhancements

To contribute other changes, you must use a different template. You can see all templates at https://github.com/atom/.github/tree/master/.github/PULL_REQUEST_TEMPLATE.

-->

Was discussed on Discord somewhat extensively: https://discord.com/channels/992103415163396136/1110367202282057848/1146638376955543633

### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

Set the version numbers of Rolling releases to be the commit date, standardized to UTC.

We are considering doing this for a number of reasons:

### Rationale

- All OS/arch builds of Pulsar, across CI providers, will be able to share a version number if they are built from the same commit.
  - (Whereas before it would change based on the timing of re-running builds, or which build waited longer for a runner to be allocated to it so that the hour just rolled over to the next one for that OS/arch's job only. Maybe the build fails overnight for one OS, and has to be re-run, so the date and version number for that OS+arch is now the next day! And so on.)
- We can definitively tell which commit a Rolling version number corresponds to, by checking the commit dates of commits on `master` branch (so long as we convert those to UTC.)
- Binaries can be uploaded to the same-versioned Release over at the [Pulsar Rolling releases repo](https://github.com/pulsar-edit/pulsar-rolling-releases).

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

- We could try to incorporate \[a portion of\] the actual commit SHA into the version number
  - This would not be monotonically increasing on its own, so reasoning about newer vs older version numbers becomes hard without also keeping a date-based component as well, meaning the version number could start to get rather long
- Implementation style: we could generate the version number in a separate task/job and export the value for use in subsequent tasks/jobs
  - Decided against this, since it has no benefit for syncing the version number across all builds any further than the "commit date in UTC" strategy already does. Plus, separate tasks/jobs are slightly slower, and _slightly_ more expensive on paid tiers. Also, `git` commands are plenty fast, and the resulting version number can be written out to disk in `package.json` and persisted that way to later CI steps, making the version number "stateless" across all later CI steps, so that active coordination between jobs is unnecessary.

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

- If there are multiple commits posted to the default branch of pulsar-edit/pulsar repo within the same hour, newer ones will (if I understand correctly) overwrite the older ones at https://github.com/pulsar-edit/pulsar-rolling-releases?
  - In strangest scenario, such as merging multiple PR's back to back, if the first run is slower than the second or third run, then a binary from an older commit might overwrite a binary from a newer commit, probably only on one OS+arch, such that a binaries from a single GitHub Release are ambiguous as to what commit they derive from?
  - Counter-point: This can easily happen in essentially the same way with or without this PR. This change only _increases the chance_ we can reliably link a binary's version number to the commit it is based off of.
- This change might actually might make it _slightly less intuitive_ to manually browse for ARM binaries, since at the moment, those are likely to be the only ones with two to six binaries-ish, if just peeking at the assets count for each release?
  - But we do have a microservice to automatically find the latest one, so hopefully manual browsing isn't too much of a priority that this is seen as much of a downside? Whereas, if someone reports a bug on one OS/arch from a Rolling version number, it'll now be easier to find the corresponding binary on another OS/arch for testing and trying to reproduce their reported error.

### Verification Process

<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (including buttons you clicked, text you typed, commands you ran, etc.), and describe the results you observed.

-->

We should check that:
- [x] CI does not error out
- [x] The version number of the generated binaries matches the commit date for the corresponding commit as the tip of this PR's branch in UTC.
  - Yes, it worked, see below steps to confirm:

<details><summary>Steps to confirm version string is synced to commit date in UTC (click to expand):</summary>

```console
% TZ=UTC0 git show --quiet --date='format-local:%Y%m%d%H' --format="%cd" 06afb505d91d3a8965a09ad522d57865cf6c4c2c
2023091405
```
- [x] Downloaded macOS binaries match this version, for example `Pulsar-1.108.2023091405.dmg` -- "2023091405" matches the intended output from the script.
- [x] Windows binaries also match, such as `Pulsar-1.108.2023091405-win.zip` -- "2023091405" matches.
- [x] Linux binaries also match, such as `pulsar_1.108.2023091405_amd64.deb` -- "2023091405" matches.

---

</details>

- To Do: check that this all works in Cirrus as well? (Script is exactly the same, syntax and environment are different, but I'm reasonably confident it should work exactly the same in each CI provider.)

### Release Notes

<!--

Please describe the changes in a single line that explains this improvement in
terms that a user can understand. This text will be used in Atom's release notes.

If this change is not user-facing or notable enough to be included in release notes
you may use the strings "Not applicable" or "N/A" here.

Examples:

- The GitHub package now allows you to add co-authors to commits.
- Fixed an issue where multiple cursors did not work in a file with a single line.
- Increased the performance of searching and replacing across a whole project.

-->

Rolling version numbers are now derived from the commit date/hour in UTC, not the build date/hour in CI server time