### PR TITLE
Remove @ from example to fix Documentation CI

### DIFF
--- a/packages/tree-view/lib/tree-view.js
+++ b/packages/tree-view/lib/tree-view.js
@@ -1732,7 +1732,7 @@
      * @function selectedPaths
      * @desc Public: Return an array of paths from all selected items
      * @example
-     * @selectedPaths() => ['selected/path/one', 'selected/path/two', 'selected/path/three' ]
+     * selectedPaths() => [ 'selected/path/one', 'selected/path/two', 'selected/path/three' ]
      * @returns {array} Selected item paths
      */
     TreeView.prototype.selectedPaths = function() {


### PR DESCRIPTION
Coffeescript function calls are prefixed with an @, which is the same syntax that jsdoc uses for parsing - which meant that it thought the example was empty.