### PR TITLE
[meta] Fix Windows Builds in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,8 +54,11 @@ jobs:
       run: (Get-Content package.json) -replace '[0-9]*-dev', (date -u +%Y%m%d%H) | Set-Content -Path package.json
 
     - name: Reinstall Current Node-GYP NodeJS Headers
+      # Overwrite bad headers that get downloaded.
+      # NodeJS versions above 16 should come with `node-gyp@9.4.0` that has a fix
+      # for this issue. At that point this additional step can be removed.
       run: npx node-gyp install ${{ env.NODE_VERSION }}
-      
+
     - name: Install Pulsar Dependencies
       uses: nick-fields/retry@943e742917ac94714d2f408a0e8320f2d1fcafcd
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,6 +53,9 @@ jobs:
       if: ${{ runner.os == 'Windows' }}
       run: (Get-Content package.json) -replace '[0-9]*-dev', (date -u +%Y%m%d%H) | Set-Content -Path package.json
 
+    - name: Reinstall Current Node-GYP NodeJS Headers
+      run: npx node-gyp install ${{ env.NODE_VERSION }}
+      
     - name: Install Pulsar Dependencies
       uses: nick-fields/retry@943e742917ac94714d2f408a0e8320f2d1fcafcd
       with:


### PR DESCRIPTION
I've noticed that our Windows builds are consistently failing in CI. This PR attempts to track down the cause of this issue.

- [X] Node v16.20.0 has been confirmed to work locally. Does the CI using v16.20.2 cause this breakage? :: No it does not. 16.20.0 still fails in CI
- [X] Python 3.10.10 has been confirmed to work locally. Does the CI using 3.10.11 cause this breakage? :: No it does not. 3.10.10 still fails in CI
- [X] Visual Studio 2019 has been confirmed to work locally. Does the CI using 2022 cause this breakage? :: Not it does not. Visual Studio 2019 still fails in CI
- [X] Is it somehow a mix of all of the above?? :: No. Using `windows-2019` and pinning Python and Node still have breakage.
- [X] Is this somehow related to the only recently merged PR? The one bumping PPM :: No. Even reverting that PR still has things breaking.

---

I'll leave in my troubleshooting steps here. But this issue is now resolved. The fix comes from @DeeDeeG's [helpful comment](https://github.com/nodejs/node-gyp/issues/2714#issuecomment-1309376926) detailing the exact command needed to fix this issue.

To put it in someone that's more familiar with `node-gyp`s words:

> The fix comes from overwriting a copy of the cached headers that got improperly extracted / bonked somehow the first go-around.

So we should be good to go with this fix for the time being.

Although, once we move past NodeJS 16, there was a fix in `node-gyp@9.4.0` that should resolve this issue in the future. So at that point we could very likely remove this new step in our build action, although it shouldn't do any harm if left in.