### PR TITLE
[meta] Create Workflow to validate WASM Grammar Changes

### DIFF
--- a/.github/workflows/validate-wasm-grammar-prs.yml
+++ b/.github/workflows/validate-wasm-grammar-prs.yml
@@ -1,0 +1,21 @@
+name: Validate WASM Grammar PR Changes
+# Since we now want to enforce the rule that any changes to a WASM grammar binary
+# file, is accompanied by a change to the `parserSource` key within the
+# `grammar.cson` file. This GHA will preform this check for us.
+
+on:
+  pull_request:
+    paths:
+      - '**.wasm'
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout the Latest Code
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 2
+
+    - name: Run Validation Script
+      run: node ./script/validate-wasm-grammar-prs.js

--- a/.github/workflows/validate-wasm-grammar-prs.yml
+++ b/.github/workflows/validate-wasm-grammar-prs.yml
@@ -15,7 +15,16 @@ jobs:
     - name: Checkout the Latest Code
       uses: actions/checkout@v3
       with:
-        fetch-depth: 2
+        fetch-depth: 0
+        # Make sure we get all commits, so that we can compare to early commits
+
+    - name: Setup Node
+      uses: actions/setup-node@v3
+      with:
+        node-version: 16
+
+    - name: Install dependencies
+      run: yarn install
 
     - name: Run Validation Script
       run: node ./script/validate-wasm-grammar-prs.js

--- a/script/validate-wasm-grammar-prs.js
+++ b/script/validate-wasm-grammar-prs.js
@@ -13,7 +13,7 @@ const fs = require("node:fs");
 const CSON = require("season");
 
 // Change this if you want more logs
-let verbose = false;
+let verbose = true;
 
 // Lets first find our common ancestor commit
 // This lets us determine the commit where the branch or fork departed from
@@ -99,12 +99,15 @@ for (const wasmFile of wasmFilesChanged) {
 
         if (getPrevFile.status !== 0 || getPrevFile.stderr.toString().length > 0) {
           // This can fail for two major reasons
-          // 1. It actually failed
-          // 2. This is a new file, and it failed to find an earlier one that didn't exist
+          // 1. The `git show` command has returned an error code other than `0`, failing.
+          // 2. This is a new file, and it failed to find an earlier copy (which didn't exist)
           // So that we don't fail brand new TreeSitter grammars, we manually check for number 2
 
           if (getPrevFile.stderr.toString().includes("exists on disk, but not in")) {
             // Looks like this file is new. Skip this check
+            if (verbose) {
+              console.log("Looks like this file is new. Skipping...");
+            }
             continue;
           }
 
@@ -135,6 +138,10 @@ for (const wasmFile of wasmFilesChanged) {
 
         // Else it looks like it has been updated properly
         console.log(`Validated \`parserSource\` has been updated within '${filePath}' properly.`);
+      } else {
+        if (verbose) {
+          console.log("This grammar file doesn't use a WASM file that's changed (On the current interation)");
+        }
       }
     }
   }

--- a/script/validate-wasm-grammar-prs.js
+++ b/script/validate-wasm-grammar-prs.js
@@ -17,7 +17,7 @@ let verbose = false;
 
 // Lets first find our common ancestor commit
 // This lets us determine the commit where the branch or fork departed from
-const commonAncestorCmd = cp.spawnSync("git", [ "merge-base", "master", "HEAD^" ]);
+const commonAncestorCmd = cp.spawnSync("git", [ "merge-base", "origin/master", "HEAD^" ]);
 
 if (commonAncestorCmd.status !== 0 || commonAncestorCmd.stderr.toString().length > 0) {
   console.error("Git Command has failed!");

--- a/script/validate-wasm-grammar-prs.js
+++ b/script/validate-wasm-grammar-prs.js
@@ -123,14 +123,14 @@ for (const wasmFile of wasmFilesChanged) {
         if (newParserSource.length === 0) {
           console.error(`Failed to find the new \`parserSource\` within: '${filePath}'`);
           console.error(contents.treeSitter);
-          process.exit(0);
+          process.exit(1);
         }
 
         if (oldParserSource == newParserSource) {
           // The repo and commit is identical! This means it hasn't been updated
           console.error(`The \`parserSource\` key of '${filePath}' has not been updated!`);
           console.error(`Current key: ${newParserSource} - Old key: ${oldParserSource}`);
-          process.exit(0);
+          process.exit(1);
         }
 
         // Else it looks like it has been updated properly

--- a/script/validate-wasm-grammar-prs.js
+++ b/script/validate-wasm-grammar-prs.js
@@ -45,6 +45,11 @@ const changedFiles = cmd.stdout.toString().split("\n");
 // This gives us an array of the name and path of every single changed file from the last two commits
 // Now to check if there's any changes we care about.
 
+if (verbose) {
+  console.log("Array of changed files between commits:");
+  console.log(changedFiles);
+}
+
 const wasmFilesChanged = changedFiles.filter(element => element.endsWith(".wasm"));
 
 if (wasmFilesChanged.length === 0) {

--- a/script/validate-wasm-grammar-prs.js
+++ b/script/validate-wasm-grammar-prs.js
@@ -21,7 +21,7 @@ const commonAncestorCmd = cp.spawnSync("git", [ "merge-base", "origin/master", "
 
 if (commonAncestorCmd.status !== 0 || commonAncestorCmd.stderr.toString().length > 0) {
   console.error("Git Command has failed!");
-  console.error("'git merge-base master HEAD^'");
+  console.error("'git merge-base origin/master HEAD^'");
   console.error(commonAncestorCmd.stderr.toString());
   process.exit(1);
 }
@@ -32,11 +32,11 @@ if (verbose) {
   console.log(`Common Ancestor Commit: '${commit}'`);
 }
 
-const cmd = cp.spawnSync("git", [ "diff", "--name-only", "-r", "HEAD^", commit])
+const cmd = cp.spawnSync("git", [ "diff", "--name-only", "-r", "HEAD", commit])
 
 if (cmd.status !== 0 || cmd.stderr.toString().length > 0) {
   console.error("Git Command has failed!");
-  console.error(`'git diff --name-only -r HEAD^ ${commit}'`);
+  console.error(`'git diff --name-only -r HEAD ${commit}'`);
   console.error(cmd.stderr.toString());
   process.exit(1);
 }

--- a/script/validate-wasm-grammar-prs.js
+++ b/script/validate-wasm-grammar-prs.js
@@ -1,0 +1,136 @@
+/*
+ * This script is called via `validate-wasm-grammar-prs.yml`
+ * It's purpose is to ensure that everytime a `.wasm` file is changed in a PR
+ * That the `parserSource` key of the grammar that uses that specific `.wasm`
+ * file is also updated.
+ * This way we can ensure that the `parserSource` is always accurate, and is
+ * never forgotten about.
+ */
+
+const cp = require("node:child_process");
+const path = require("node:path");
+const fs = require("node:fs");
+const CSON = require("season");
+
+// Change this if you want more logs
+let verbose = false;
+
+// Lets first find our common ancestor commit
+// This lets us determine the commit where the branch or fork departed from
+const commonAncestorCmd = cp.spawnSync("git", [ "merge-base", "master", "HEAD" ]);
+
+if (commonAncestorCmd.status !== 0 || commonAncestorCmd.stderr.toString().length > 0) {
+  console.error("Git Command has failed!");
+  console.error("'git merge-base master HEAD'");
+  console.error(commonAncestorCmd.stderr.toString());
+  process.exit(1);
+}
+
+const commit = commonAncestorCmd.stdout.toString().trim();
+
+if (verbose) {
+  console.log(`Common Ancestor Commit: '${commit}'`);
+}
+
+const cmd = cp.spawnSync("git", [ "diff", "--name-only", "-r", "HEAD", commit])
+
+if (cmd.status !== 0 || cmd.stderr.toString().length > 0) {
+  console.error("Git Command has failed!");
+  console.error(`'git diff --name-only -r HEAD ${commit}'`);
+  console.error(cmd.stderr.toString());
+  process.exit(1);
+}
+
+const changedFiles = cmd.stdout.toString().split("\n");
+// This gives us an array of the name and path of every single changed file from the last two commits
+// Now to check if there's any changes we care about.
+
+const wasmFilesChanged = changedFiles.filter(element => element.endsWith(".wasm"));
+
+if (wasmFilesChanged.length === 0) {
+  // No WASM files have been modified. Return success
+  console.log("No WASM files have been changed.");
+  process.exit(0);
+}
+
+// Now for every single wasm file that's been changed, we must validate those changes
+// are also accompanied by a change in the `parserSource` key
+
+for (const wasmFile of wasmFilesChanged) {
+  const wasmPath = path.dirname(wasmFile);
+
+  const files = fs.readdirSync(path.join(wasmPath, ".."));
+  console.log(`Detected changes to: ${wasmFile}`);
+
+  if (verbose) {
+    console.log("Verbose file check details:");
+    console.log(wasmFile);
+    console.log(wasmPath);
+    console.log(files);
+    console.log("\n");
+  }
+
+  for (const file of files) {
+    const filePath = path.join(wasmPath, "..", file);
+    console.log(`Checking: ${filePath}`);
+
+    if (fs.lstatSync(filePath).isFile()) {
+      const contents = CSON.readFileSync(filePath);
+
+      // We now have the contents of one of the grammar files for this specific grammar.
+      // Since each grammar may contain multiple grammar files, we need to ensure
+      // that this particular one is using the tree-sitter wasm file that was
+      // actually changed.
+      const grammarFile = contents.treeSitter?.grammar ?? "";
+
+      if (path.basename(grammarFile) === path.basename(wasmFile)) {
+        // This grammar uses the WASM file that's changed. So we must ensure our key has also changed
+        // Sidenote we use `basename` here, since the `wasmFile` will be
+        // a path relative from the root of the repo, meanwhile `grammarFile`
+        // will be relative from the file itself
+
+        // In order to check the previous state of what the key is, we first must retreive the file prior to this PR
+        const getPrevFile = cp.spawnSync("git", [ "show", `${commit}:./${filePath}` ]);
+
+        if (getPrevFile.status !== 0 || getPrevFile.stderr.toString().length > 0) {
+          // This can fail for two major reasons
+          // 1. It actually failed
+          // 2. This is a new file, and it failed to find an earlier one that didn't exist
+          // So that we don't faile brand new TreeSitter grammars, we manually check for number 2
+
+          if (getPrevFile.stderr.toString().includes("exists on disk, but not in")) {
+            // Looks like this file is new. Skip this check
+            continue;
+          }
+
+          console.error("Git command failed!");
+          console.error(`'git show ${commit}:./${filePath}'`);
+          console.error(getPrevFile.stderr.toString());
+          process.exit(1);
+        }
+
+        fs.writeFileSync(path.join(wasmPath, "..", `OLD-${file}`), getPrevFile.stdout.toString());
+
+        const oldContents = CSON.readFileSync(path.join(wasmPath, "..", `OLD-${file}`));
+        const oldParserSource = oldContents.treeSitter?.parserSource ?? "";
+        const newParserSource = contents.treeSitter?.parserSource ?? "";
+
+        if (newParserSource.length === 0) {
+          console.error(`Failed to find the new \`parserSource\` within: '${filePath}'`);
+          console.error(contents.treeSitter);
+          process.exit(0);
+        }
+
+        if (oldParserSource == newParserSource) {
+          // The repo and commit is identical! This means it hasn't been updated
+          console.error(`The \`parserSource\` key of '${filePath}' has not been updated!`);
+          console.error(`Current key: ${newParserSource} - Old key: ${oldParserSource}`);
+          process.exit(0);
+        }
+
+        // Else it looks like it has been updated properly
+        console.log(`Validated \`parserSource\` has been updated within '${filePath}' properly.`);
+      }
+    }
+  }
+}

--- a/script/validate-wasm-grammar-prs.js
+++ b/script/validate-wasm-grammar-prs.js
@@ -17,11 +17,11 @@ let verbose = false;
 
 // Lets first find our common ancestor commit
 // This lets us determine the commit where the branch or fork departed from
-const commonAncestorCmd = cp.spawnSync("git", [ "merge-base", "master", "HEAD" ]);
+const commonAncestorCmd = cp.spawnSync("git", [ "merge-base", "master", "HEAD^" ]);
 
 if (commonAncestorCmd.status !== 0 || commonAncestorCmd.stderr.toString().length > 0) {
   console.error("Git Command has failed!");
-  console.error("'git merge-base master HEAD'");
+  console.error("'git merge-base master HEAD^'");
   console.error(commonAncestorCmd.stderr.toString());
   process.exit(1);
 }
@@ -32,11 +32,11 @@ if (verbose) {
   console.log(`Common Ancestor Commit: '${commit}'`);
 }
 
-const cmd = cp.spawnSync("git", [ "diff", "--name-only", "-r", "HEAD", commit])
+const cmd = cp.spawnSync("git", [ "diff", "--name-only", "-r", "HEAD^", commit])
 
 if (cmd.status !== 0 || cmd.stderr.toString().length > 0) {
   console.error("Git Command has failed!");
-  console.error(`'git diff --name-only -r HEAD ${commit}'`);
+  console.error(`'git diff --name-only -r HEAD^ ${commit}'`);
   console.error(cmd.stderr.toString());
   process.exit(1);
 }

--- a/script/validate-wasm-grammar-prs.js
+++ b/script/validate-wasm-grammar-prs.js
@@ -101,7 +101,7 @@ for (const wasmFile of wasmFilesChanged) {
           // This can fail for two major reasons
           // 1. It actually failed
           // 2. This is a new file, and it failed to find an earlier one that didn't exist
-          // So that we don't faile brand new TreeSitter grammars, we manually check for number 2
+          // So that we don't fail brand new TreeSitter grammars, we manually check for number 2
 
           if (getPrevFile.stderr.toString().includes("exists on disk, but not in")) {
             // Looks like this file is new. Skip this check

--- a/script/validate-wasm-grammar-prs.js
+++ b/script/validate-wasm-grammar-prs.js
@@ -140,7 +140,7 @@ for (const wasmFile of wasmFilesChanged) {
         console.log(`Validated \`parserSource\` has been updated within '${filePath}' properly.`);
       } else {
         if (verbose) {
-          console.log("This grammar file doesn't use a WASM file that's changed (On the current interation)");
+          console.log("This grammar file doesn't use a WASM file that's changed (On the current iteration)");
         }
       }
     }


### PR DESCRIPTION
This was discussed over on #736.

Essentially, we thought it'd be a good idea to start adding `parserSource` as a key to WASM grammars, so that we could always determine the source repository used to generate a WASM binary. Even further, @savetheclocktower and I thought it'd be a good idea to enforce this new standard, and ensure this value is always being updated every time the WASM binary changes. Since it'd be pointless to keep around if we can't 100% rely on it's value.

So to that end, we discussed two possibilities:

1. Generate a WASM binary from the `parserSource` listed, and make sure this new one matches what was put in by maintainers.
2. Just make sure that `parserSource` has changed, if the WASM binary has changed.

We opted for the second choice, as option 1 would mean having to setup the entire WASM generation toolkit, which can be quite complex.

So that's exactly what this PR does, ensures that if the WASM binary has changed at all, it'll make sure the `parserSource` has also changed.

A quick summary of the logic included:

1. Uses `git merge-base master HEAD` to find the common ancestor commit SHA from wherever this branch or fork originated. This is the SHA that will be used as the "before" picture, whereas the current changes will be seen as the "after".
2. We use `git diff --name-only -r HEAD ${SHA}` to check what files have been changed. 
3. We look for any `.wasm` files in this list, exiting cleanly if none are found.
4. Once any are found we then look though all grammar files within that directory, and check if the `treeSitter.grammar` key of a checked grammar file uses the same file that has changed
5. If it has we then use `git show ${SHA}:./${file}` to get the contents of the file before the branch or fork was created, saving this content to disk.
6. We then can compare the `treeSitter.parserSource` key between these two files to know if they have changed.
7. We exit cleanly if these values are in any way different from each other, even accounting for if one has it and the other doesn't.