### PR TITLE
CI: Use Python 3.11 to fix macOS signing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ on:
 env:
   # Variables needed for build information
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  PYTHON_VERSION: '3.10'
+  PYTHON_VERSION: '3.11'
   NODE_VERSION: 16
   ROLLING_UPLOAD_TOKEN: ${{ secrets.ROLLING_RELEASE_UPLOAD_TOKEN }}
   # Below variables allow us to quickly control visual tests for each platform


### PR DESCRIPTION
### Background and context for this Pull Request...

<details><summary>It's a long story, click to expand if you want:</summary>

Not sure why exactly, but our GitHub Actions workflow is producing *signed* macOS binaries that pass spctl "acceptance" on the CLI, and various other signing/notarization checks on the CLI, such as stapler, but nevertheless warn they can't be verified when opening the signed Pulsar.app in Finder or using `open` on the CLI, and so on.

Through investigating what changes we can make to better-match the Cirrus environment, which has been producing signed binaries that open just fine without the warning for months now, we have tried many things.

Eventually, disabling actions/setup-node and actions/setup-python was tried, which incidentally got us Python 3.11 instead of our manually pinned older Python 3.10. That worked, the signed binaries open as they should, sans verification warning.

Further narrowing it down resulted in, any way we get Python other than 3.10 from actions/setup-python seems to be working.

Given that, this commit starts using Python 3.11 in GitHub Actions, to fix the "macOS is signed but is still not making Gatekeeper happy" situation we have been having with GitHub Actions.

</details>

#### Credit where due

By the way, co-credit for this goes to @confused-Techie for the idea to try and replicate our steps for setting up for the build in the Cirrus CI environment, re-creating them here in GitHub Actions. This was the big inspiration for trying to test every possible difference in the things we control that might be different in how the Cirrus and GitHub Actions were set up, and led directly toward the final stretch "process of elimination" testing efforts that culminated in this PR. (See https://github.com/pulsar-edit/pulsar/pull/742). And for discussing back and forth throughout all this. Felt a lot less daunting tackling this with two+ people working on it.

Also thanks to @Meadowsys for helping with the debugging and answering some questions about the signing process, which helped to narrow down where the problem _wasn't_, so we could focus with more confidence on what else it could be.

### Identify the Bug

<!--

Link to the issue describing the bug that you're fixing.

If there is not yet an issue for your bug, please open a new issue and then link to that issue in your pull request.
Note: In some cases, one person's "bug" is another person's "feature." If the pull request does not address an existing issue with the "bug" label, the maintainers have the final say on whether the current behavior is a bug.

-->

Well, macOS binaries from GitHub Actions have been _signed_ (as can be verified with `spctl` or `stapler`, and so on) but still warning that they can't be verified, just like any not signed binary usually would.

This is since we started building any binaries on GitHub Actions. (https://github.com/pulsar-edit/pulsar/pull/682)

_(This is another shot at what https://github.com/pulsar-edit/pulsar/pull/742 was getting at. Hopefully we've got it solved now (see "Verification Process" below).)_

### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

Start using Python 3.11 in GitHub Actions.

Before anyone asks: No, I don't know why this fixes the problem, I don't know why there was a problem in the first place.

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

We could just delete the `actions/setup-python` step, but then we'd eventually auto-update to Python 3.12 at some point, which I'd like to avoid the surprise of that.

There may be other ways of getting Python (some as elaborate as installing an entire new package manager like Homebrew), but I don't see the point in any alternatives, so long as this works.

(If Python 3.11 from actions/setup-python stops working, then sure we can try either of these alternative options.)

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

Should be **none**, since we should have new enough node-gyp now to handle Python 3.11. Being stuck on old node-gyp was the reason we pinned to Python 3.10 in the first place, not an issue now.

(Fixed in https://github.com/pulsar-edit/ppm/pull/79 and https://github.com/pulsar-edit/ppm/pull/94 in ppm repo, --> https://github.com/pulsar-edit/pulsar/pull/725 at this core editor repo.)

To be clear, this may require the CI environment to have relatively recent npm, which it apparently does, since it worked in a test run of this change in CI already before I opened this PR (see "Verification Process" just below).

### Verification Process

<!--

What process did you follow to verify that the change has not introduced any regressions? Describe the actions you performed (including buttons you clicked, text you typed, commands you ran, etc.), and describe the results you observed.

-->

- [x] ~~NOT YET VERIFIED~~: CI assets for _this PR_ should open without a Gatekeeper warning saying it couldn't be verified (only the usual "this was downloaded from the internet" warning that always shows, even for signed packages, when downloaded from the internet.) (UPDATE: Verified, it works. ✅ )
  - [x] A test CI run outside of any PR already passed this check (https://github.com/pulsar-edit/pulsar/actions/runs/6320738698), just want to double-check it works here in this PR as well, to be sure.

### Release Notes

<!--

Please describe the changes in a single line that explains this improvement in
terms that a user can understand. This text will be used in Atom's release notes.

If this change is not user-facing or notable enough to be included in release notes
you may use the strings "Not applicable" or "N/A" here.

Examples:

- The GitHub package now allows you to add co-authors to commits.
- Fixed an issue where multiple cursors did not work in a file with a single line.
- Increased the performance of searching and replacing across a whole project.

-->

Fixed signing for intel macOS binaries in GitHub Actions