### PR TITLE
CI: Sign macOS binaries for branch pushes, not PRs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,9 +80,10 @@ jobs:
 
     # macOS Signing Stuff
     - name: Build Pulsar Binaries (macOS) (Signed)
-      if: ${{ runner.os == 'macOS' && github.event.pull_request.head.repo.full_name == 'pulsar-edit/pulsar' }}
-      # PRs generated from forks cannot access GitHub Secrets
-      # So if the PR is a fork, we will still build, but will not sign.
+      if: ${{ runner.os == 'macOS' && github.event_name == 'push' }}
+      # Note: PRs generated from forks cannot access GitHub Secrets.
+      # So if the PR is from a fork, we can still build, but cannot sign.
+      # Note: We aren't attempting to sign for *any* PRs anymore, though.
       env:
         CSC_LINK: ${{ secrets.CSC_LINK }}
         CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
@@ -97,7 +98,7 @@ jobs:
         command: yarn dist
 
     - name: Build Pulsar Binaries (macOS) (Unsigned)
-      if: ${{ runner.os == 'macOS' && github.event.pull_request.head.repo.full_name != 'pulsar-edit/pulsar' }}
+      if: ${{ runner.os == 'macOS' && github.event_name != 'push' }}
       uses: nick-fields/retry@943e742917ac94714d2f408a0e8320f2d1fcafcd
       with:
         timeout_minutes: 30


### PR DESCRIPTION
### Identify the Bug

<!--

Link to the issue describing the bug that you're fixing.

If there is not yet an issue for your bug, please open a new issue and then link to that issue in your pull request.
Note: In some cases, one person's "bug" is another person's "feature." If the pull request does not address an existing issue with the "bug" label, the maintainers have the final say on whether the current behavior is a bug.

-->

We have been unintentionally _not_ signing for branch pushes, and only signing for PRs.

Was discussed on Discord: https://discord.com/channels/992103415163396136/992109539346370661/1154927246830747668

### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

We definitely *do* want to sign for pushes, (specifically `master` branch), so that Rolling releases get signed, but we probably don't need (and probably don't want?) to sign for PRs. (Regardless of whether from a fork or not.)

So, this commit essentially reverses the situation from before:
- DO sign for branch pushes. (Note: the workflow currently only triggers for `master` branch pushes.)
- DON'T sign for any other events, such as for Pull Requests.

(This change is for GitHub Actions only, as the Cirrus config was already set up in a very particular way during the migration of most binary builds to GitHub Actions, which was quite recent, and doesn't need any changes at this time.)

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

- We could keep signing for _non-fork_ pull requests.

I started to realize, while contemplating this fix for the "not signing on `master`" thing, that it may be unnecessary and kinda weird to sign for PRs anyway. And we have to be careful about reading from the `github` context since any user-editable text like commit messages, fork names and PR titles could conceivably be used in script injection attacks (!). See: https://docs.github.com/en/actions/learn-github-actions/contexts#github-context

- Outdated/less-relevant comment?

Also, the comment about fork vs non-fork PRs is not super relevant if we stop signing for any PR, so we can _consider_ deleting the comment, but I kinda like more context rather than less, still worth pointing out for whoever comes next (Even if it's us in some weeks' time, when we may have forgotten some things.)

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

We're not signing for PRs anymore.

### Verification Process

<!--

What process did you follow to verify that the change has not introduced any regressions? Describe the actions you performed (including buttons you clicked, text you typed, commands you ran, etc.), and describe the results you observed.

-->

- [x] This PR should use the "(Unsigned)" code path in the workflow definition.
- [x] The logic checking `github.event_name == 'push'` is already in use lower in the workflow definition file, used for whether to try uploading binaries to the rolling release repo. Seems to be working just as intended.
  - [ ] So, hopefully this setup _does_ use the "(Signed)" code path once merged to `master` branch? Don't see why it wouldn't?

### Release Notes

<!--

Please describe the changes in a single line that explains this improvement in
terms that a user can understand. This text will be used in Atom's release notes.

If this change is not user-facing or notable enough to be included in release notes
you may use the strings "Not applicable" or "N/A" here.

Examples:

- The GitHub package now allows you to add co-authors to commits.
- Fixed an issue where multiple cursors did not work in a file with a single line.
- Increased the performance of searching and replacing across a whole project.

-->

Sign macOS binaries in GitHub Actions for branch pushes, not PRs (restore code-signing for intel macOS Rolling release binaries)