### PR TITLE
[core] Handle invalid config on load

### DIFF
--- a/src/main-process/start.js
+++ b/src/main-process/start.js
@@ -126,7 +126,7 @@ function getConfig() {
       if (error) {
         console.log(error.message);
       } else {
-        config.resetUserSettings(configFileData);
+        config.resetUserSettings(data);
       }
     });
   }

--- a/src/main-process/start.js
+++ b/src/main-process/start.js
@@ -121,8 +121,14 @@ function getConfig() {
   let configFilePath = getConfigFilePath();
 
   if (configFilePath) {
-    const configFileData = CSON.readFileSync(configFilePath);
-    config.resetUserSettings(configFileData);
+    CSON.readFile(configFilePath, (error, data) => {
+      // Duplicated from `./src/config-file.js`.reload()
+      if (error) {
+        console.log(error.message);
+      } else {
+        config.resetUserSettings(configFileData);
+      }
+    });
   }
 
   return config;


### PR DESCRIPTION
When Pulsar loads a user's config while the application is open there is proper error handling to warn of an invalid config. But it seems that if Pulsar is first starting up and finds an invalid config, it'll crash silently, while reporting that it is still running.

While I would've much preferred to not have to duplicate this error checking at all, unfortunately the other error checking is mostly special by being attached to an emitter, which during initial startup we don't have that same feature. So it seemed simple enough otherwise to implement. 

You can view the live changes error handling below:

https://github.com/pulsar-edit/pulsar/blob/5f3e40a2f5369f8cedad9ee42c747709241e34a1/src/config-file.js#L112-L117

But as for here, we will add just a small bit of error handling, which if it fails, will load the default config, just like the config file doesn't exist, as well as log a message to the terminal. We can from here let the live reloading take care of alerting the user.

---

Resolves #409 