### PR TITLE
[autocomplete-html] Wrap completions in `try/catch` handler

### DIFF
--- a/packages/autocomplete-html/lib/main.js
+++ b/packages/autocomplete-html/lib/main.js
@@ -8,10 +8,19 @@ const provider = {
   filterSuggestions: true,
 
   getSuggestions (request) {
-    if (request.editor.getBuffer().getLanguageMode().tree) {
-      return getSuggestionsWithTreeSitter(request)
-    } else {
-      return getSuggestionsWithTextMate(request)
+    try {
+      if (request.editor.getBuffer().getLanguageMode().tree) {
+        return getSuggestionsWithTreeSitter(request)
+      } else {
+        return getSuggestionsWithTextMate(request)
+      }
+    } catch(err) {
+      // We avoid creating any actual error messages, as this is intended to fix
+      // the case when providing completions for EJS that multiple continious
+      // errors are created rapidly.
+      // https://github.com/pulsar-edit/pulsar/issues/649
+      console.error(err);
+      return [];
     }
   },
 


### PR DESCRIPTION
When completing some EJS snippets, `autocomplete-html` may fail to properly expect the exact tree that exists for EJS.

Meaning that in some situations multiple, continuous errors will be thrown, which an error thrown for every key stroke in an improperly parsed syntax tree is obviously not ideal.

While I'm sure there's a much better solution here, such as something suggested by @savetheclocktower over on #649, this solution takes the much simpler route.

In this PR I simply wrap all instances of `autocomplete-html`s `getSuggestions()` in a `try/catch` block to avoid any errors being generated.

I do see how this could potentially make things harder, with the fact that errors are semi hidden now (they are logged here, but no notification is created), so if someone wants to take a shot at one of the proper fixes, feel free and we can close this. But otherwise to prevent the error, this seems better to me than disabling `autocomplete-ejs` when programming with EJS.

---

Closes #649 