### PR TITLE
[wrap-guide] Make the automatic modification of `editor.preferredLineLength` configurable

### DIFF
--- a/packages/wrap-guide/lib/wrap-guide-element.js
+++ b/packages/wrap-guide/lib/wrap-guide-element.js
@@ -90,8 +90,10 @@ module.exports = class WrapGuideElement {
       const columns = uniqueAscending(args.newValue);
       if (columns != null ? columns.length : undefined) {
         atom.config.set('wrap-guide.columns', columns);
-        atom.config.set('editor.preferredLineLength', columns[columns.length - 1],
-          {scopeSelector: `.${this.editor.getGrammar().scopeName}`});
+        if (atom.config.get('wrap-guide.modifyPreferredLineLength')) {
+          atom.config.set('editor.preferredLineLength', columns[columns.length - 1],
+            {scopeSelector: `.${this.editor.getGrammar().scopeName}`});
+        }
         return this.updateGuide();
       }
     };

--- a/packages/wrap-guide/package.json
+++ b/packages/wrap-guide/package.json
@@ -17,6 +17,11 @@
       },
       "description": "Display guides at each of the listed character widths. Leave blank for one guide at your `editor.preferredLineLength`."
     },
+    "modifyPreferredLineLength": {
+      "default": true,
+      "type": "boolean",
+      "description": "Modify the Editor's Preferred Line Length when changing Wrap Guide's Columns setting."
+    },
     "enabled": {
       "default": true,
       "type": "boolean"

--- a/packages/wrap-guide/spec/wrap-guide-element-spec.js
+++ b/packages/wrap-guide/spec/wrap-guide-element-spec.js
@@ -105,7 +105,7 @@ describe("WrapGuideElement", function() {
       for (let i = 0; i < columnCount; i++) {
         columns.push(i * 10);
       }
-      
+
       atom.config.set("wrap-guide.columns", columns);
       waitsForPromise(() => editorElement.getComponent().getNextUpdatePromise());
 
@@ -243,6 +243,19 @@ describe("WrapGuideElement", function() {
         expect(positions[1]).toBeGreaterThan(positions[0]);
         expect(positions[2]).toBeGreaterThan(positions[1]);
         expect(wrapGuide).toBeVisible();
+      });
+    });
+
+    it("leaves alone preferredLineLength if modifyPreferredLineLength is false", () => {
+      const initial = atom.config.get("editor.preferredLineLength", { scope: editor.getRootScopeDescriptor() });
+      atom.config.set("wrap-guide.modifyPreferredLineLength", false);
+
+      atom.config.set("wrap-guide.columns", [ initial, initial + 10]);
+      waitsForPromise(() => editorElement.getComponent().getNextUpdatePromise());
+
+      runs(() => {
+        const length = atom.config.get("editor.preferredLineLength", { scope: editor.getRootScopeDescriptor() });
+        expect(length).toBe(initial);
       });
     });
   });


### PR DESCRIPTION
In short, the `wrap-guide` package will automatically sync the setting of `editor.preferredLineLength` whenever it's own settings are changed. Except it will only set the `editor.preferredLineLength` to that of the currently open syntax. Which can be confusing and downright unhelpful depending on your use case. Much more information is available on #697 

But this PR takes the simpler approach to this, in case anybody has come to rely on this behavior, where we make this behavior configurable within `wrap-guide` introducing a new setting `wrap-guide.modifyPreferredLineLength` which by default is `true` (So that we don't change behavior on anyone) but does mean this function can be turned off to stop the unexpected behavior.

---

Resolves #697 
Resolves #696 