### PR TITLE
[meta] Build x86 Linux binaries on Ubuntu 20.04, for older (more compatible) glibc

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ ubuntu-latest, windows-latest, macos-latest ]
+        os: [ ubuntu-20.04, windows-latest, macos-latest ]
       fail-fast: false
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
Based on the information [here](https://github.com/arduino/arduino-ide/pull/1983#pullrequestreview-1378812825) it seems possible such a simple change can properly fix this issue for Linux users above Ubuntu 18.04.

This is a partial solution to the reported issues like this, as it won't fix issues running on RHEL8, but should hopefully fix the issue for at least the latest builds.

This can always been seen as an intermediary step, if we would like to bring support for older versions as well.

Relates to #733 