### PR TITLE
Fixed filtering of suggestions with ranges

### DIFF
--- a/packages/autocomplete-plus/lib/autocomplete-manager.js
+++ b/packages/autocomplete-plus/lib/autocomplete-manager.js
@@ -377,14 +377,15 @@ class AutocompleteManager {
       const text = (suggestion.snippet || suggestion.text)
       const suggestionPrefix = suggestion.replacementPrefix != null ? suggestion.replacementPrefix : prefix
       const prefixIsEmpty = !suggestionPrefix || suggestionPrefix === ' '
-      const firstCharIsMatch = !prefixIsEmpty && suggestionPrefix[0].toLowerCase() === text[0].toLowerCase()
 
       if (prefixIsEmpty) {
         results.push(suggestion)
-      }
-      if (firstCharIsMatch && (score = fuzzaldrinProvider.score(text, suggestionPrefix)) > 0) {
-        suggestion.score = score * suggestion.sortScore
-        results.push(suggestion)
+      } else {
+        const keepMatching = suggestion.ranges || suggestionPrefix[0].toLowerCase() === text[0].toLowerCase()
+        if (keepMatching && (score = fuzzaldrinProvider.score(text, suggestionPrefix)) > 0) {
+          suggestion.score = score * suggestion.sortScore
+          results.push(suggestion)
+        }
       }
     }
 

--- a/packages/autocomplete-plus/spec/provider-api-spec.js
+++ b/packages/autocomplete-plus/spec/provider-api-spec.js
@@ -327,5 +327,25 @@ describe('Provider API', () => {
 
       expect(editor.getText()).toEqual("ohai, world\n")
     })
+
+    it('ignores `prefix` if `range` is present', async () => {
+      testProvider = {
+        scopeSelector: '.source.js',
+        filterSuggestions: true,
+        getSuggestions (options) {
+          return [
+            {text: 'notmatch/foololohairange', ranges: [[[0, 0], [0, 5]]]},
+            {text: 'notmatch/foololohaiprefix'},
+            {text: 'foololohaiprefix2'}
+          ]
+        }
+      }
+      registration = atom.packages.serviceHub.provide('autocomplete.provider', '5.0.0', testProvider)
+      editor.insertText('foololohai')
+      await triggerAutocompletion()
+      expect(document.querySelector('autocomplete-suggestion-list').innerText).toMatch(/notmatch\/foololohairange/)
+      expect(document.querySelector('autocomplete-suggestion-list').innerText).toMatch(/foololohaiprefix2/)
+      expect(document.querySelector('autocomplete-suggestion-list').innerText).toNotMatch(/notmatch\/foololohaiprefix/)
+    })
   })
 })


### PR DESCRIPTION
Previously, autocomplete suggestions with `.ranges` property was being filtered by the same rules as previous autocomplete - basically, by matching the first character.

Unfortunately, that might not be the case anymore - with this API, we are choosing which range to replace, so the first char is not relevant anymore (and considering we're matching up multiple ranges, it may be difficult to define which range, or ranges, we want to match).

This PR fixes that by _not filtering_ anything that have ranges _only with the first char_ - the other filter (the "fuzzy" match) will still be aplied.