### PR TITLE
[core] Cleanup Unused Deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,6 @@
     "git-diff": "file:packages/git-diff",
     "git-utils": "5.7.1",
     "github": "https://codeload.github.com/pulsar-edit/github/tar.gz/refs/tags/v0.36.17-pretranspiled",
-    "glob": "^7.1.1",
     "go-to-line": "file:packages/go-to-line",
     "grammar-selector": "file:packages/grammar-selector",
     "grim": "2.0.3",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,6 @@
     "fs-admin": "0.19.0",
     "fs-plus": "^3.1.1",
     "fstream": "1.0.12",
-    "functional-red-black-tree": "^1.0.1",
     "fuzzy-finder": "file:packages/fuzzy-finder",
     "git-diff": "file:packages/git-diff",
     "git-utils": "5.7.1",

--- a/package.json
+++ b/package.json
@@ -143,7 +143,6 @@
     "pathwatcher": "^8.1.2",
     "postcss": "8.4.31",
     "postcss-selector-parser": "6.0.4",
-    "property-accessors": "^1.1.3",
     "pulsar-updater": "file:packages/pulsar-updater",
     "resolve": "1.18.1",
     "scandal": "^3.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5018,7 +5018,7 @@ glob@7.1.3:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^7.0.0, glob@^7.1.1, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6, glob@^7.2.0:
+glob@^7.0.0, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6, glob@^7.2.0:
   version "7.2.3"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.2.3.tgz#b8df0fb802bbfa8e89bd1d938b4e16578ed44f2b"
   integrity sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==

--- a/yarn.lock
+++ b/yarn.lock
@@ -4784,11 +4784,6 @@ function.prototype.name@^1.1.5:
     es-abstract "^1.19.0"
     functions-have-names "^1.2.2"
 
-functional-red-black-tree@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz#1b0ab3bd553b2a0d6399d29c0e3ea0b252078327"
-  integrity sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==
-
 functions-have-names@^1.2.2:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/functions-have-names/-/functions-have-names-1.2.3.tgz#0404fe4ee2ba2f607f0e0ec3c80bae994133b834"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7812,7 +7812,7 @@ prop-types@^15.5.0, prop-types@^15.5.8, prop-types@^15.6.2:
     object-assign "^4.1.1"
     react-is "^16.13.1"
 
-property-accessors@^1, property-accessors@^1.1, property-accessors@^1.1.3:
+property-accessors@^1, property-accessors@^1.1:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/property-accessors/-/property-accessors-1.1.3.tgz#1dde84024631865909ef30703365680c5f928b15"
   integrity sha512-WQTVW7rn+k6wq8FyYVM15afyoB2loEdeIzd/o7+HEA5hMZcxvRf4Khie0fBM9wLP3EJotKhiH15kY7Dd4gc57g==


### PR DESCRIPTION
While investigating our dependencies I've noticed there are a few that don't seem to be used anywhere, that we should be fine to go ahead and remove.

* `functional-red-black-tree`: This seems to have been introduced prior to being entirely transpiled over to `./src/rb-tree.js`. Meaning it's never actually been `require`d into the project.
* `property-accessors`: Seems to have been removed back in 2015 via 69833af although for some reason still appears in the repo. I can't find any reference to it anywhere, and as it's a mixin, I think we should be safe to remove.
* `glob`: Originally introduced via fa90851 when adding benchmarking functionality to Atom, but since then benchmarking mode has been totally removed from Pulsar, and this file is not required anywhere else in the codebase.

So as long as tests all pass, we should be good to remove these dependencies as they are otherwise useless.