### PR TITLE
[core] Bump `git-utils`: `5.7.1` => `^5.7.3`

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "functional-red-black-tree": "^1.0.1",
     "fuzzy-finder": "file:packages/fuzzy-finder",
     "git-diff": "file:packages/git-diff",
-    "git-utils": "5.7.1",
+    "git-utils": "^5.7.3",
     "github": "https://codeload.github.com/pulsar-edit/github/tar.gz/refs/tags/v0.36.17-pretranspiled",
     "glob": "^7.1.1",
     "go-to-line": "file:packages/go-to-line",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4914,15 +4914,7 @@ getpass@^0.1.1:
   dependencies:
     atom-select-list "^0.8.1"
 
-git-utils@5.7.1:
-  version "5.7.1"
-  resolved "https://registry.yarnpkg.com/git-utils/-/git-utils-5.7.1.tgz#f26e95f8cc05b475b2b8b09151b68f3788c8a173"
-  integrity sha512-+mWdJDq9emWoq6GzzrGEB7SIBmAk0lNNv2wgNkgwTVZUkAFkWvgRsJ+Kvs3d1QQD6WG6vczti2WLpjmh2Twtlw==
-  dependencies:
-    fs-plus "^3.0.0"
-    nan "^2.14.0"
-
-git-utils@^5.6.0:
+git-utils@^5.6.0, git-utils@^5.7.3:
   version "5.7.3"
   resolved "https://registry.yarnpkg.com/git-utils/-/git-utils-5.7.3.tgz#3b53983204678313b305bbf278c07dc015ba2155"
   integrity sha512-in1hjFfmzY86gKBt+YMTaVyCGtX2WTnN0uPj37bI5HsrnU2oj8OFcWOEzOI5PxQXPMxFxtvRebOHAOGB8M125w==


### PR DESCRIPTION
This PR bumps the version of `git-utils` used within the core editor.
I've gone ahead and added the carrot to allow it to auto update if needed (But `git-utils` is our own library, so I can't really see that happening in an unexpected way).

The reason for this PR is rather simple, but one I've had my eye on for quite some time.

In our distributed binaries of Pulsar there are two different versions of `git-utils` included in the compressed `asar` file:

* `git-utils@5.7.1`: This is what we have had the version pinned to within the core editor 
* `git-utils@5.7.3`:  This is what was allowed to be installed via `scandal` as that library uses `git-utils@^5.6.0`

While some duplication isn't a big deal, the `git-utils` library is 85.00 MB for each copy. Meaning that this simple, minor difference in the installed versions of `git-utils` causes an increase of our binaries by ~170MB. Which when we consider `v1.110.0` when installed on Windows is `1.07GB` means that this tiny change can get us just under a 1GB install. (We should end up installing at about ~985MB after this change)

And for anyone still nervous about any functional changes to the editor, here's the [full diff](https://github.com/pulsar-edit/git-utils/compare/572d3e86e95ec40de140f4e4f6cfbb767de0701e...208a033cccb8a2fd297ac1507fcedd388a88a68b) between these versions. Which literally seems to be some repo cleanup, GitHub Actions, and sorting the dependencies. In other words should be zero functional difference.

As for the last justification, it's simply bumping versions, which is always good when they don't have breaking changes, like here.