### PR TITLE
Fix the matching of `$'...'` strings.

### DIFF
--- a/packages/language-shellscript/grammars/tree-sitter/highlights.scm
+++ b/packages/language-shellscript/grammars/tree-sitter/highlights.scm
@@ -74,7 +74,7 @@
 ((raw_string) @punctuation.definition.string.end.shell
   (#match? @punctuation.definition.string.begin.shell ".$")
   (#set! adjust.startAndEndAroundFirstMatchOf ".$"))
-(ansi_c_string) @string.quoted.single.shell
+(ansi_c_string) @string.quoted.single.dollar.shell
 ((ansi_c_string) @punctuation.definition.string.begin.shell
   (#match? @punctuation.definition.string.begin.shell "^..")
   (#set! adjust.startAndEndAroundFirstMatchOf "^.."))

--- a/packages/language-shellscript/grammars/tree-sitter/highlights.scm
+++ b/packages/language-shellscript/grammars/tree-sitter/highlights.scm
@@ -68,6 +68,12 @@
 (string "\"" @punctuation.definition.string.end.shell
   (#is? test.last true))
 (raw_string) @string.quoted.single.shell
+((raw_string) @punctuation.definition.string.begin.shell
+  (#match? @punctuation.definition.string.begin.shell "^.")
+  (#set! adjust.startAndEndAroundFirstMatchOf "^."))
+((raw_string) @punctuation.definition.string.end.shell
+  (#match? @punctuation.definition.string.begin.shell ".$")
+  (#set! adjust.startAndEndAroundFirstMatchOf ".$"))
 (ansi_c_string) @string.quoted.single.shell
 ((ansi_c_string) @punctuation.definition.string.begin.shell
   (#match? @punctuation.definition.string.begin.shell "^..")

--- a/packages/language-shellscript/grammars/tree-sitter/highlights.scm
+++ b/packages/language-shellscript/grammars/tree-sitter/highlights.scm
@@ -69,6 +69,12 @@
   (#is? test.last true))
 (raw_string) @string.quoted.single.shell
 (ansi_c_string) @string.quoted.single.shell
+((ansi_c_string) @punctuation.definition.string.begin.shell
+  (#match? @punctuation.definition.string.begin.shell "^..")
+  (#set! adjust.startAndEndAroundFirstMatchOf "^.."))
+((ansi_c_string) @punctuation.definition.string.end.shell
+  (#match? @punctuation.definition.string.end.shell ".$")
+  (#set! adjust.startAndEndAroundFirstMatchOf ".$"))
 
 (string
   (command_substitution) @meta.embedded.line.subshell.shell)

--- a/packages/language-shellscript/grammars/tree-sitter/highlights.scm
+++ b/packages/language-shellscript/grammars/tree-sitter/highlights.scm
@@ -68,6 +68,7 @@
 (string "\"" @punctuation.definition.string.end.shell
   (#is? test.last true))
 (raw_string) @string.quoted.single.shell
+(ansi_c_string) @string.quoted.single.shell
 
 (string
   (command_substitution) @meta.embedded.line.subshell.shell)


### PR DESCRIPTION
### Requirements for Contributing a Bug Fix

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* The pull request must only fix an existing bug. To contribute other changes, you must use a different template. You can see all templates at <https://github.com/atom/.github/tree/master/.github/PULL_REQUEST_TEMPLATE>.
* The pull request must update the test suite to demonstrate the changed functionality. For guidance, please see <https://flight-manual.atom.io/hacking-atom/sections/writing-specs/>.
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution. For more details, please see <https://github.com/atom/.github/tree/master/CONTRIBUTING.md#pull-requests>.

~Please see "Verification Process" below for caveat on this PR.~

### Identify the Bug

https://github.com/pulsar-edit/pulsar/issues/775

### Description of the Change

[Update: Replaced with new description]

Added rules to `highlights.scm`:
* to account for `ansi_c_string` (which is what `$'...'` is categorized as).
* to mark the punctuation of `raw_string` (which is what `'...'` is categorized as).

### Alternate Designs

[UPDATE: Replaced with new description]

It seems like there are several possible ways to mark the punctuation, but the overall shape of the code is going to be about the same.

### Possible Drawbacks

None, pretty sure.

### Verification Process

[Update: Now verified!]

~NOT ACTUALLY VERIFIED. Very sorry.~

~As I write this, I am attempting to get a Pulsar build environment set up (on macOS), and it is not exactly straightforward. I figured it'd be most expedient to get this simple fix in the pipeline sooner rather than later. Apologies in advance if you would have preferred me to 100% validate.~

### Release Notes

Fixed scoping/highlighting of single-quoted (`'...'`) and C-style (`$'...'`) strings in shell scripts.
