### PR TITLE
[meta] Install Python package `setuptools` && Use Python `3.12.x`

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,5 +1,5 @@
 env:
-  PYTHON_VERSION: 3.11.5
+  PYTHON_VERSION: 3.12
   GITHUB_TOKEN: ENCRYPTED[!b0ff4671044672be50914a3a10b49af642bd8e0e681a6f4e5855ec5230a5cf9afbc53d9e90239b8d2c79455f014f383f!]
   # The above token, is a GitHub API Token, that allows us to download RipGrep without concern of API limits
 
@@ -86,6 +86,7 @@ arm_linux_task:
                 libnss3
                 xvfb
     - gem install fpm
+    - python3 -m pip install setuptools
     - git submodule init
     - git submodule update
     - sed -i -e "s/[0-9]*-dev/`date -u +%Y%m%d%H`/g" package.json
@@ -133,6 +134,7 @@ silicon_mac_task:
     ROLLING_UPLOAD_TOKEN: ENCRYPTED[690950798401ec3715e9d20ac29a0859d3c58097038081ff6afeaf4721e661672d34eb952d8a6442bc7410821ab8545a]
   prepare_script:
     - brew install node@16 yarn git python@$PYTHON_VERSION
+    - python3 -m pip install setuptools
     - git submodule init
     - git submodule update
     - ln -s /opt/homebrew/bin/python$PYTHON_VERSION /opt/homebrew/bin/python

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,5 +1,5 @@
 env:
-  PYTHON_VERSION: 3.10
+  PYTHON_VERSION: 3.11.5
   GITHUB_TOKEN: ENCRYPTED[!b0ff4671044672be50914a3a10b49af642bd8e0e681a6f4e5855ec5230a5cf9afbc53d9e90239b8d2c79455f014f383f!]
   # The above token, is a GitHub API Token, that allows us to download RipGrep without concern of API limits
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ on:
 env:
   # Variables needed for build information
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  PYTHON_VERSION: '3.11.5'
+  PYTHON_VERSION: '3.12'
   NODE_VERSION: 16
   ROLLING_UPLOAD_TOKEN: ${{ secrets.ROLLING_RELEASE_UPLOAD_TOKEN }}
   # Below variables allow us to quickly control visual tests for each platform
@@ -40,6 +40,9 @@ jobs:
       with:
         python-version: ${{ env.PYTHON_VERSION }}
 
+    - name: Install Python Packages
+      run: python3 -m pip install setuptools
+      
     - name: Setup Git Submodule
       run: |
         git submodule init

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ on:
 env:
   # Variables needed for build information
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  PYTHON_VERSION: '3.11'
+  PYTHON_VERSION: '3.11.5'
   NODE_VERSION: 16
   ROLLING_UPLOAD_TOKEN: ${{ secrets.ROLLING_RELEASE_UPLOAD_TOKEN }}
   # Below variables allow us to quickly control visual tests for each platform


### PR DESCRIPTION
We've been seeing failures to build PPM on Windows after the new version of Python `3.11.6`, claiming `distutils` cannot be found (Just like we see and know has been removed on Python `3.12.x`)

~~So in an attempt to fix this I'm pinning Python to `3.11.5` on all build platforms in an attempt to fix this.~~

But this does raise another question: Why doesn't our CI tell us it failed on this step?

---

EDIT:

So seems this was actually fixed by installing the Python package `setuptools` as recommended in the Python [changelog](https://docs.python.org/dev/whatsnew/3.12.html#distutils). This package paired with Python `3.12.x` seems to have been able to successfully build on every platform. Hopefully putting an end to each Python version breaking something (For the time being)