### PR TITLE
CI: Increase timeout length for macOS binary builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -95,7 +95,7 @@ jobs:
         TEAM_ID: ${{ secrets.TEAM_ID }}
       uses: nick-fields/retry@943e742917ac94714d2f408a0e8320f2d1fcafcd
       with:
-        timeout_minutes: 30
+        timeout_minutes: 45
         max_attempts: 3
         retry_on: error
         command: yarn dist
@@ -104,7 +104,7 @@ jobs:
       if: ${{ runner.os == 'macOS' && github.event_name != 'push' }}
       uses: nick-fields/retry@943e742917ac94714d2f408a0e8320f2d1fcafcd
       with:
-        timeout_minutes: 30
+        timeout_minutes: 45
         max_attempts: 3
         retry_on: error
         command: yarn dist


### PR DESCRIPTION
Allow 45 minutes to hopefully reduce the timeouts we are intermittently seeing for macOS builds.

(30 minutes is occasionally too little time.)

### Issue or RFC Endorsed by Pulsar's Maintainers

<!--

Link to the issue or RFC that your change relates to. This must be one of the following:

* An open issue with the `help-wanted` label
* An open issue with the `triaged` label
* An RFC with "accepted" status

To contribute an enhancement that isn't covered by one of the items above, please follow our guide for suggesting an enhancement: https://github.com/atom/.github/blob/master/CONTRIBUTING.md#suggesting-enhancements

To contribute other changes, you must use a different template. You can see all templates at https://github.com/atom/.github/tree/master/.github/PULL_REQUEST_TEMPLATE.

-->

Ummm.... N/A. I know we've discussed it on Discord before, though: https://discord.com/channels/992103415163396136/1155585530906558464/1155691913765203998

### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

Increase the `nick-fields/retry` timeout for the macOS binary builds from 30 minutes to 45 minutes.

We've had some timeouts at 30-minutes for some of the macOS binary builds, so bumping that to be a little longer/more-generous seems like the easiest fix.

(This is for GitHub Actions only, by the way, since as far as I can tell we have no timeout in Cirrus CI, only the implicit one. Free Cirrus jobs automatically cancel after a limit of 2 hours max run time: https://cirrus-ci.org/faq/#instance-timed-out)

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

- Configure the `nick-fields/retry` action to retry for timeouts too, not just for outright errors?
- Increase the timeout even higher, to 60 minutes instead of 45 minutes??

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

Genuinely hung builds will tie up 15 additional minutes of GitHub Actions GitHub-hosted macOS runner time... If there are any genuinely hung binary builds ever. I don't recall if that has been an issue before.

### Verification Process

<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (including buttons you clicked, text you typed, commands you ran, etc.), and describe the results you observed.

-->

`nick-fields/retry`'s timeout functionality has been working _exactly as designed_ so far! I don't doubt it will continue to work.

I guess to really verify this, we'd have to have a long-running macOS build that took longer than 30 minutes. If it managed to go longer than 30 minutes, it would verfy that this change worked. To confirm the timeout functionality still works, we'd also have to see a long-running macOS build timeout after 45 minutes. This PR is intended to avoid virtually all timeouts, if it works out. So, that hopefully won't happen for a while now, heh.

### Release Notes

<!--

Please describe the changes in a single line that explains this improvement in
terms that a user can understand. This text will be used in Atom's release notes.

If this change is not user-facing or notable enough to be included in release notes
you may use the strings "Not applicable" or "N/A" here.

Examples:

- The GitHub package now allows you to add co-authors to commits.
- Fixed an issue where multiple cursors did not work in a file with a single line.
- Increased the performance of searching and replacing across a whole project.

-->

N/A (CI-only change). But: "Increase timeouts for macOS binary builds in CI", I guess.