### PR TITLE
CI: Build binaries for tag pushes (GitHub Actions)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - 'master'
+    tags:
+      - '**'
   pull_request:
   workflow_dispatch:
 


### PR DESCRIPTION
### Issue or RFC Endorsed by Pulsar's Maintainers

<!--

Link to the issue or RFC that your change relates to. This must be one of the following:

* An open issue with the `help-wanted` label
* An open issue with the `triaged` label
* An RFC with "accepted" status

To contribute an enhancement that isn't covered by one of the items above, please follow our guide for suggesting an enhancement: https://github.com/atom/.github/blob/master/CONTRIBUTING.md#suggesting-enhancements

To contribute other changes, you must use a different template. You can see all templates at https://github.com/atom/.github/tree/master/.github/PULL_REQUEST_TEMPLATE.

-->

We discussed it on Discord, starting here: https://discord.com/channels/992103415163396136/992103415163396139/1163359940660953119

### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

Run the "build Pulsar binaries" workflow for tag pushes too, not just branch pushes and PRs.

Allows us to get signed macOS intel binaries out of the usual version bump + release flow we do for Regular releases.

(Bonus: The "make signed bins on tag pushes" approach will now be more consistent across CI providers. Creating or pushing a tag triggers it across both Cirrus and GitHub Actions with this change. This should make the task of triggering signed binary builds during Regular release more predictable -- just make sure you tag the version during release. Easy enough, I think?)

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

- We could sign for any workflow triggers that have adequate credentials associated with them, which I believe would be limited to events triggered by accounts with `write` access to this repo.
  - Last this was discussed on the Discord, the idea was _not_ to sign any PR binaries, nor binaries form one-off manual runs, since they're not final or review-approved, so they shouldn't be considered officially blessed builds that are signed with the overall seal of approval. This way, the only signed binaries are ones from `master` branch (Rolling releases) and the ones associated with a tag (Regular Releases). Basically, only Release bins are signed.

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

None anticipated.

(Might make putting out Regular releases _too easy???_)

### Verification Process

<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (including buttons you clicked, text you typed, commands you ran, etc.), and describe the results you observed.

-->

We could push a random tag with this change on it and see if it signs the macOS bins or not? I guess?

This change matches with the docs (https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onpushbranchestagsbranches-ignoretags-ignore, https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet), so as long as this doesn't error as invalid syntax, I think it should "just work"<sup>:tm:</sup>?

### Release Notes

<!--

Please describe the changes in a single line that explains this improvement in
terms that a user can understand. This text will be used in Atom's release notes.

If this change is not user-facing or notable enough to be included in release notes
you may use the strings "Not applicable" or "N/A" here.

Examples:

- The GitHub package now allows you to add co-authors to commits.
- Fixed an issue where multiple cursors did not work in a file with a single line.
- Increased the performance of searching and replacing across a whole project.

-->

N/A CI-only change. But "Build signed macOS binaries on tag pushes, not just `master` branch pushes (GitHub Actions)"