### PR TITLE
:bug: :white_check_mark: Fix caching for "Dismiss this Version" in pulsar-updater

### DIFF
--- a/packages/pulsar-updater/spec/cache-spec.js
+++ b/packages/pulsar-updater/spec/cache-spec.js
@@ -1,20 +1,41 @@
 const cache = require("../src/cache.js");
 
 describe("pulsar-updater cache", () => {
+  beforeEach(() => {
+    jasmine.useRealClock();
+  });
+
   it("returns key for path", () => {
     let key = cache.cacheKeyForPath("test");
     expect(key).toBe("pulsar-updater:test");
   });
 
-  it("returns expired properly according to date", () => {
-    let expiry = cache.isItemExpired({ createdOn: Date.now() });
+  it("returns not expired properly according to date", () => {
+    let expiry = cache.isItemExpired({ createdOn: Date.now() }, 'some-key');
     expect(expiry).toBe(false);
   });
 
-  it("returns not expired if offline", () => {
-    spyOn(cache, "online").andReturn(true);
+  it("returns expired properly according to date", () => {
+    let expiry = cache.isItemExpired({ createdOn: 0 }, 'some-key');
+    expect(expiry).toBe(true);
+  });
 
-    let expiry = cache.isItemExpired({ createdOn: 0 });
+  it("returns not expired properly for last-update-check", () => {
+    let expiry = cache.isItemExpired({ createdOn: 0 }, 'last-update-check');
     expect(expiry).toBe(false);
-  })
+  });
+
+  if(jasmine.version_.major > 1) {
+    // TODO: The current version right now is 1.3.1 of jasmine-node
+    // https://github.com/kevinsawicki/jasmine-node
+    //
+    // This is an unmaintained package that tried to implement jasmine for node,
+    // however we have an official jasmine implementation since then
+    it("returns not expired if offline", () => {
+      spyOnProperty(window.navigator, 'onLine').and.returnValue(false);
+
+      let expiry = cache.isItemExpired({ createdOn: 0 }, 'some-key');
+      expect(expiry).toBe(false);
+    });
+  }
 });

--- a/packages/pulsar-updater/src/cache.js
+++ b/packages/pulsar-updater/src/cache.js
@@ -23,7 +23,7 @@ function getCacheItem(key) {
 
   let cached = JSON.parse(obj);
 
-  if (typeof cached === "object" && !isItemExpired(cached)) {
+  if (typeof cached === "object" && !isItemExpired(cached, key)) {
     return JSON.parse(cached.data);
   }
 


### PR DESCRIPTION
### Identify the Bug

https://github.com/pulsar-edit/pulsar/issues/784

### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

I found that the code was expecting the local storage key to keep the last-update-check value in cache ifinitely, but it was not provided as an argument, so I added it.

Then I looked into the tests and extended them to cover the fix as well. I added a dummy key to all `isItemExpired` call to reflect on how the code should work.

While I was adding and fixing theses tests, I found that they produced false positive results because the tests were using fake timers, `Date.now()` was always 1000 which meant that all cache-tests produced a non-expired cache entry. I set jasmine to use `jasmine.useRealClock();`

Then, there's the last test: it meant to mock out the `online()` method which was required from the other file into a `cache` object. However, this method on the `cache` is not the same as the one called from the `isItemExpired()` method from jasmine's perspective, hence the mock wasn't working - see the false positive results. The proper way to check this behaviour would be to mock out `window.navigator`'s `onLine` property, however, Pulsar is using an old and unmaintained implementation of the jasmine test-framework which doesn't support this feature yet. I wrote how the test should look like and moved it behind a condition, we'll run this only with more recent jasmine version.
 
### Alternate Designs

-

### Possible Drawbacks

-

### Verification Process

I've run the new tests on the package.

### Release Notes

- Fixed the issue with the "Dismiss this Version" button
