### PR TITLE
CI: Python 3.12-related fixes on Cirrus CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -132,6 +132,7 @@ silicon_mac_task:
     TEAM_ID: ENCRYPTED[11f3fedfbaf4aff1859bf6c105f0437ace23d84f5420a2c1cea884fbfa43b115b7834a463516d50cb276d4c4d9128b49]
     ROLLING_UPLOAD_TOKEN: ENCRYPTED[690950798401ec3715e9d20ac29a0859d3c58097038081ff6afeaf4721e661672d34eb952d8a6442bc7410821ab8545a]
   prepare_script:
+    - brew update
     - brew install node@16 yarn git python@$PYTHON_VERSION
     - python3 -m pip install setuptools
     - git submodule init
@@ -190,6 +191,7 @@ silicon_mac_task:
 #     - arch -x86_64 xcode-select --install
 #     - arch -x86_64 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
 #     - export PATH="/usr/local/opt/node@16/bin:/usr/local/bin:$PATH"
+#     - arch -x86_64 brew update
 #     - arch -x86_64 brew install node@16 yarn git python@$PYTHON_VERSION
 #     - ln -s /usr/local/bin/python$PYTHON_VERSION /usr/local/bin/python
 #     - git submodule init

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -86,7 +86,6 @@ arm_linux_task:
                 libnss3
                 xvfb
     - gem install fpm
-    - python3 -m pip install setuptools
     - git submodule init
     - git submodule update
     - sed -i -e "s/[0-9]*-dev/`date -u +%Y%m%d%H`/g" package.json


### PR DESCRIPTION
### Identify the Bug

<!--

Link to the issue describing the bug that you're fixing.

If there is not yet an issue for your bug, please open a new issue and then link to that issue in your pull request.
Note: In some cases, one person's "bug" is another person's "feature." If the pull request does not address an existing issue with the "bug" label, the maintainers have the final say on whether the current behavior is a bug.

-->

CI is failing with Python 3.12 in Cirrus, as of https://github.com/pulsar-edit/pulsar/pull/779.

(That PR fixed Python 3.12 issues in GitHub Actions, but introduced more ones in Cirrus, which we didn't catch right away, since Cirrus is currently running only once per day, on Mondays, Wednesdays and Fridays.)

### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

- Don't install `setuptools` on the Cirrus ARM Linux task.
  - The ARM Linux Cirrus task is actually running on Python 3.7 which still ships with `distutils` out of the box... and the `python3 -m pip install setuptools` command had been failing due to "no module named 'pip'"... We only need to add `setuptools` on Python 3.12 or later anyhow, and we should be able to do `apt-get install python3-pip` at such a time as this would be needed, if ever.
- Do `brew update` before running `brew install` on the Cirrus Apple Silicon macOS task, so that it is aware of the existence of Python@3.12, and can install it successfully.

These changes resolve the two Python 3.12-related issues in Cirrus (which were introduced alongside bona-fide fixes in https://github.com/pulsar-edit/pulsar/pull/779, which is a PR I personally review-approved).

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

- We could do `apt-get install python3-pip` on the Arm Linux task.
  - This would be pretty pointless, unless we _actually_ get a copy of Python 3.12 on ARM Linux, which is also kinda pointless, or would needlessly complicate our CI, IMO. Right now it's apparently using Python 3.7, which is fine, IMO.
- We could stop updating to Python 3.12 on the Apple Silicon macOS task.
  - But as a side-effect of doing `brew update`, some other dependencies were unexpectedly updated as well, including `git` and `curl`. This is somewhat desirable for supply-chain security in CI. It uses more CPU-time, so we should watch credit usage on the macOS tasks in Cirrus after this PR. But we're only using 14 credits (September) and 11 credits (October) lately, so we're not running too close to the 50 credit-equivalent free limit per month set by Cirrus.

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

Actually upgrading to Python 3.12 on the macOS task unexpectedly increased macOS CI time by ~3 minutes on a test run. So, we should watch credit usage, but again, we're only using 14 credits (September) and 11 credits (October) lately, so we're not running too close to the 50 credit-equivalent free limit per month set by Cirrus.


### Verification Process

<!--

What process did you follow to verify that the change has not introduced any regressions? Describe the actions you performed (including buttons you clicked, text you typed, commands you ran, etc.), and describe the results you observed.

-->

Triggered a cron build on Cirrus to test this, CI is passing over there and a Rolling release was generated successfully. ✅ 

- https://cirrus-ci.com/build/5973566382931968
- https://github.com/pulsar-edit/pulsar-rolling-releases/releases/tag/v1.110.2023110623

### Release Notes

<!--

Please describe the changes in a single line that explains this improvement in
terms that a user can understand. This text will be used in Atom's release notes.

If this change is not user-facing or notable enough to be included in release notes
you may use the strings "Not applicable" or "N/A" here.

Examples:

- The GitHub package now allows you to add co-authors to commits.
- Fixed an issue where multiple cursors did not work in a file with a single line.
- Increased the performance of searching and replacing across a whole project.

-->

N/A (CI-only fix) but if I were to put it in a changelog it would be "Python 3.12-related fixes on Cirrus CI"