### PR TITLE
CI: Work around missing 'distutils' for Python 3.12+ (GHA round two)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,9 +40,12 @@ jobs:
       with:
         python-version: ${{ env.PYTHON_VERSION }}
 
-    - name: Install Python Packages
+    - name: Install Python setuptools
+      # This is needed for Python 3.12+, since many versions of node-gyp
+      # are incompatible with Python 3.12+, which no-longer ships 'distutils'
+      # out of the box. 'setuptools' package provides 'distutils'.
       run: python3 -m pip install setuptools
-      
+
     - name: Setup Git Submodule
       run: |
         git submodule init

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -27,6 +27,12 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
 
+    - name: Install Python setuptools
+      # This is needed for Python 3.12+, since many versions of node-gyp
+      # are incompatible with Python 3.12+, which no-longer ships 'distutils'
+      # out of the box. 'setuptools' package provides 'distutils'.
+      run: python3 -m pip install setuptools
+
     - name: Install Dependencies
       run: yarn install
 

--- a/.github/workflows/editor-tests.yml
+++ b/.github/workflows/editor-tests.yml
@@ -28,6 +28,12 @@ jobs:
       with:
         node-version: 16
 
+    - name: Install Python setuptools
+      # This is needed for Python 3.12+, since many versions of node-gyp
+      # are incompatible with Python 3.12+, which no-longer ships 'distutils'
+      # out of the box. 'setuptools' package provides 'distutils'.
+      run: python3 -m pip install setuptools
+
     - name: Install Dependencies
       run: yarn install
 

--- a/.github/workflows/package-tests-linux.yml
+++ b/.github/workflows/package-tests-linux.yml
@@ -22,6 +22,12 @@ jobs:
       with:
         node-version: 16
 
+    - name: Install Python setuptools
+      # This is needed for Python 3.12+, since many versions of node-gyp
+      # are incompatible with Python 3.12+, which no-longer ships 'distutils'
+      # out of the box. 'setuptools' package provides 'distutils'.
+      run: python3 -m pip install setuptools
+
     - name: Install Dependencies
       run: yarn install
 

--- a/.github/workflows/validate-wasm-grammar-prs.yml
+++ b/.github/workflows/validate-wasm-grammar-prs.yml
@@ -23,6 +23,12 @@ jobs:
       with:
         node-version: 16
 
+    - name: Install Python setuptools
+      # This is needed for Python 3.12+, since many versions of node-gyp
+      # are incompatible with Python 3.12+, which no-longer ships 'distutils'
+      # out of the box. 'setuptools' package provides 'distutils'.
+      run: python3 -m pip install setuptools
+
     - name: Install dependencies
       run: yarn install
 


### PR DESCRIPTION
### Identify the Bug

<!--

Link to the issue describing the bug that you're fixing.

If there is not yet an issue for your bug, please open a new issue and then link to that issue in your pull request.
Note: In some cases, one person's "bug" is another person's "feature." If the pull request does not address an existing issue with the "bug" label, the maintainers have the final say on whether the current behavior is a bug.

-->

The "Editor Tests" workflow is failing in GitHub Actions lately.

Similar problem as https://github.com/pulsar-edit/pulsar/pull/779, but circling back around to address it on the other workflow `.yml` files as well.

### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

Adds a step to install the `setuptools` Python package just before any of our GitHub Actions workflows try to install dependencies.

Context: `setuptools` provides a copy of the `distutils` module, which `node-gyp` tries to import, but which was deprecated in recent Python versions and does not ship out of the box in Python 3.12+. There is a fix for this in `node-gyp` 10.0, but older copies of Yarn or npm come with older node-gyp, so here we are.

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

This fix won't actually be needed for a little while on the Ubuntu-based workflows, since those are still on Python 3.8, Python 3.10, soon to be Python 3.11... Only Python 3.12+ is affected by the issue. But doing this now means it won't come back again if/when `ubuntu-latest` ships Python 3.12 or newer, I guess.

So, we could undo the change to `documentation.yml`, `package-tests-linux.yml` and `validate-wasm-grammar-prs.yml` for now and probably not need the change for a little while.

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

This adds 6 lines to all the GitHub Actions workflow `.yml` files, so it might seem too verbose, more noticeable on the really short workflow files. Especially the very simple Linux-only workflows that don't need the fix immediately. Only takes a second to run, though.

### Verification Process

<!--

What process did you follow to verify that the change has not introduced any regressions? Describe the actions you performed (including buttons you clicked, text you typed, commands you ran, etc.), and describe the results you observed.

-->

CI should pass. Specifically. the "Editor Tests" workflow on macOS should start passing with this (has been failing lately), and the other workflows shouldn't _start_ failing due to this change.

### Release Notes

<!--

Please describe the changes in a single line that explains this improvement in
terms that a user can understand. This text will be used in Atom's release notes.

If this change is not user-facing or notable enough to be included in release notes
you may use the strings "Not applicable" or "N/A" here.

Examples:

- The GitHub package now allows you to add co-authors to commits.
- Fixed an issue where multiple cursors did not work in a file with a single line.
- Increased the performance of searching and replacing across a whole project.

-->

N/A (CI-only change) but: Fix missing 'distutils' with Python 3.12+ in GitHub Actions (round two)