### PR TITLE
Prevent “half screen” bug by resetting scroll position when editor regains focus

### DIFF
--- a/src/text-editor-component.js
+++ b/src/text-editor-component.js
@@ -1689,6 +1689,13 @@ module.exports = class TextEditorComponent {
   }
 
   didFocusHiddenInput() {
+    // Focusing the hidden input when it is off-screen causes the browser to
+    // scroll it into view. Since we use synthetic scrolling this behavior
+    // causes all the lines to disappear so we counteract it by always setting
+    // the scroll position to 0.
+    this.refs.scrollContainer.scrollTop = 0;
+    this.refs.scrollContainer.scrollLeft = 0;
+
     if (!this.focused) {
       this.focused = true;
       this.startCursorBlinking();


### PR DESCRIPTION
### Identify the Bug

See #191.

### Description of the Change

Pulsar uses a hidden `input` element to receive keyboard input in text editors.

When this hidden element is outside the current viewport, sometimes the browser tries to scroll a container _that isn't meant to be scrolled_ in order to bring it into view. This doesn't make sense because of how we handle scrolling, so it's _always_ the wrong thing to do, even though the browser's just trying to be helpful.

Atom used to handle this by explicitly resetting the container's `scrollTop` and `scrollLeft` to `0` after the hidden input was focused, but [this PR](https://github.com/atom/atom/pull/20892/files) changed that behavior because of a mistaken belief that it wouldn't be needed anymore.

### Alternate Designs

You can read about other possible fixes in #191. I think we settled on this one because it's just restoring a fix that Atom used to have, so it's less risky than trying a novel approach that might introduce new regressions.

### Possible Drawbacks

I honestly doubt that there are any. If this code caused any problems, it wouldn't have been previously present in Atom.

### Verification Process

Perform the reproduction steps in #191 and verify that the issue no longer occurs.

### Release Notes

Fixed an issue that sometimes caused text to shift or disappear after an editor pane regains focus.