### PR TITLE
Fix focus issue if other select-list-view called by shortcut

### DIFF
--- a/packages/command-palette/lib/command-palette-view.js
+++ b/packages/command-palette/lib/command-palette-view.js
@@ -117,7 +117,7 @@ export default class CommandPaletteView {
 
     this.previouslyFocusedElement = document.activeElement
     this.panel.show()
-    this.selectListView.focus()
+    for (let i=0 ; i<2 ; i++) { this.selectListView.focus() }
   }
 
   hide () {

--- a/packages/fuzzy-finder/lib/fuzzy-finder-view.js
+++ b/packages/fuzzy-finder/lib/fuzzy-finder-view.js
@@ -206,7 +206,7 @@ module.exports = class FuzzyFinderView {
     if (atom.config.get('fuzzy-finder.prefillFromSelection') === true) {
       this.prefillQueryFromSelection()
     }
-    this.selectListView.focus()
+    for (let i=0 ; i<2 ; i++) { this.selectListView.focus() }
   }
 
   hide () {


### PR DESCRIPTION
If other package used `atom-select-list` and the same managment of `previouslyFocusedElement`, then:
1. open command-pallete (`Ctrl-Shift-P`)
2. open other `atom-select-list` by shortcut (e.g. fuzzy-finder `Ctrl-P`)
the issue has appeard - other `atom-select-list` has no focus. The same issue can be replicated by 2. then 1.

examples of community packages used `this.selectListView.focus()` in the same idea:
* https://github.com/bacadra/pulsar-bib-finder/blob/54aa86c8c09d5ce004f8315c420bd5703c9f2467/lib/bib-list.js#L135C25-L135C25
* https://github.com/bacadra/pulsar-fuzzy-files/blob/74d2f2763d7a679bd64e851ff5f2cf523c8c524e/lib/path-list.js#L127
* https://github.com/bacadra/pulsar-project-list/blob/86e32f394c0d7f7643a1505542d58f8d0bdcb1bf/lib/project-list.js#L123
* https://github.com/bacadra/pulsar-project-list/blob/86e32f394c0d7f7643a1505542d58f8d0bdcb1bf/lib/recent-list.js#L96
* https://github.com/bacadra/pulsar-sofistik-tools/blob/085e06b416a2afabe3fcf9a6079d151c2597c808/lib/example-list.js#L93