### PR TITLE
meta: Update CirrusCI GitHub Token

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,6 +1,6 @@
 env:
   PYTHON_VERSION: 3.12
-  GITHUB_TOKEN: ENCRYPTED[!b0ff4671044672be50914a3a10b49af642bd8e0e681a6f4e5855ec5230a5cf9afbc53d9e90239b8d2c79455f014f383f!]
+  GITHUB_TOKEN: ENCRYPTED[!af8c6a449b6ff0a381ac6dd267d664a9e5d3551cbc9922aa98f806a0c881e10f47565f915dc277dd3f5c7cdf47f09d1b!]
   # The above token, is a GitHub API Token, that allows us to download RipGrep without concern of API limits
 
 # linux_task:


### PR DESCRIPTION
It seems this token has expired in the past few days. Unfortunately I missed when this initially occurred, and there have been a few failures within Cirrus since then because of this missing token.

But this PR updates it just in time for our next regular release.
