### PR TITLE
Fix `onDidChangeCursorPosition` callback event property on deleting characters

### DIFF
--- a/spec/text-editor-spec.js
+++ b/spec/text-editor-spec.js
@@ -370,9 +370,7 @@ describe('TextEditor', () => {
             'deleteToBeginningOfWord',
             'deleteToBeginningOfSubword',
             'deleteToPreviousWordBoundary',
-            'deleteToBeginningOfLine',
-            // 'deleteLine',
-            // 'joinLines'
+            'deleteToBeginningOfLine'
           ]
           cmds.forEach(command => {
             editor.setText("HelloWorld!")

--- a/spec/text-editor-spec.js
+++ b/spec/text-editor-spec.js
@@ -383,7 +383,7 @@ describe('TextEditor', () => {
           })
         });
 
-        fit('emits the event with textChanged: true if whole lines were changed', () => {
+        it('emits the event with textChanged: true if whole lines were changed', () => {
           let callbacks = [];
           let callback = evt => { callbacks.push(evt.textChanged) };
           editor.getLastCursor().onDidChangePosition(callback);
@@ -397,9 +397,13 @@ describe('TextEditor', () => {
           callbacks = [];
           editor.deleteLine();
           // One for the change, and another to reposition the cursor
-          expect(callbacks).toEqual([true, false], "on command deleteLine")
-            // 'joinLines'
-          })
+          expect(callbacks).toEqual([true, true, false, false], "on command deleteLine")
+
+          editor.setText("HelloWorld!\nGoodbye, world");
+          editor.setCursorBufferPosition([0, 5]);
+          callbacks = [];
+          editor.joinLines();
+          expect(callbacks).toEqual([true, true, false, false], "on command joinLines")
         });
 
         it("doesn't emit the event if you deleted something forward", () => {
@@ -6611,7 +6615,7 @@ describe('TextEditor', () => {
     });
   });
 
-  fdescribe('.deleteLine()', () => {
+  describe('.deleteLine()', () => {
     it('deletes the first line when the cursor is there', () => {
       editor.getLastCursor().moveToTop();
       const line1 = buffer.lineForRow(1);

--- a/spec/text-editor-spec.js
+++ b/spec/text-editor-spec.js
@@ -332,27 +332,99 @@ describe('TextEditor', () => {
         expect(editor.getCursorBufferPosition()).toEqual([1, 1]);
       });
 
-      it('emits an event with the old position, new position, and the cursor that moved', () => {
-        const cursorCallback = jasmine.createSpy('cursor-changed-position');
-        const editorCallback = jasmine.createSpy(
-          'editor-changed-cursor-position'
-        );
+      describe('listening to cursor movements', () => {
+        it('emits an event with the old position, new position, and the cursor that moved', () => {
+          const cursorCallback = jasmine.createSpy('cursor-changed-position');
+          const editorCallback = jasmine.createSpy(
+            'editor-changed-cursor-position'
+          );
 
-        editor.getLastCursor().onDidChangePosition(cursorCallback);
-        editor.onDidChangeCursorPosition(editorCallback);
+          editor.getLastCursor().onDidChangePosition(cursorCallback);
+          editor.onDidChangeCursorPosition(editorCallback);
 
-        editor.setCursorBufferPosition([2, 4]);
+          editor.setCursorBufferPosition([2, 4]);
 
-        expect(editorCallback).toHaveBeenCalled();
-        expect(cursorCallback).toHaveBeenCalled();
-        const eventObject = editorCallback.mostRecentCall.args[0];
-        expect(cursorCallback.mostRecentCall.args[0]).toEqual(eventObject);
+          expect(editorCallback).toHaveBeenCalled();
+          expect(cursorCallback).toHaveBeenCalled();
+          const eventObject = editorCallback.mostRecentCall.args[0];
+          expect(cursorCallback.mostRecentCall.args[0]).toEqual(eventObject);
 
-        expect(eventObject.oldBufferPosition).toEqual([0, 0]);
-        expect(eventObject.oldScreenPosition).toEqual([0, 0]);
-        expect(eventObject.newBufferPosition).toEqual([2, 4]);
-        expect(eventObject.newScreenPosition).toEqual([2, 4]);
-        expect(eventObject.cursor).toBe(editor.getLastCursor());
+          expect(eventObject.oldBufferPosition).toEqual([0, 0]);
+          expect(eventObject.oldScreenPosition).toEqual([0, 0]);
+          expect(eventObject.newBufferPosition).toEqual([2, 4]);
+          expect(eventObject.newScreenPosition).toEqual([2, 4]);
+          expect(eventObject.cursor).toBe(editor.getLastCursor());
+        });
+
+        it('emits the event with textChanged: true if text was edited', () => {
+          let callbacks = []
+          let callback = evt => { callbacks.push(evt.textChanged) }
+          editor.getLastCursor().onDidChangePosition(callback);
+          editor.onDidChangeCursorPosition(callback);
+
+          editor.insertText('bar')
+          expect(callbacks).toEqual([true, true])
+
+          const cmds = [
+            'backspace',
+            'deleteToBeginningOfWord',
+            'deleteToBeginningOfSubword',
+            'deleteToPreviousWordBoundary',
+            'deleteToBeginningOfLine',
+            // 'deleteLine',
+            // 'joinLines'
+          ]
+          cmds.forEach(command => {
+            editor.setText("HelloWorld!")
+            editor.setCursorBufferPosition([0, 5])
+            callbacks = []
+            editor[command].bind(editor)();
+            expect(callbacks).toEqual([true, true], `on command ${command}`)
+          })
+        });
+
+        fit('emits the event with textChanged: true if whole lines were changed', () => {
+          let callbacks = [];
+          let callback = evt => { callbacks.push(evt.textChanged) };
+          editor.getLastCursor().onDidChangePosition(callback);
+          editor.onDidChangeCursorPosition(callback);
+
+          editor.setText("HelloWorld!\nGoodbye, world");
+          editor.setCursorBufferPosition([0, 5]);
+          // TODO: Ideally, we want this event to not be called. Unfortunately,
+          // the world doesn't work like that - there's no way to delete a line
+          // without changing the current cursor position on TextBuffer.
+          callbacks = [];
+          editor.deleteLine();
+          // One for the change, and another to reposition the cursor
+          expect(callbacks).toEqual([true, false], "on command deleteLine")
+            // 'joinLines'
+          })
+        });
+
+        it("doesn't emit the event if you deleted something forward", () => {
+          let callbacks = []
+          let callback = evt => {
+            callbacks.push(evt.textChanged)
+          }
+          editor.getLastCursor().onDidChangePosition(callback);
+          editor.onDidChangeCursorPosition(callback);
+
+          const cmds = [
+            'delete',
+            'deleteToEndOfSubword',
+            'deleteToEndOfWord',
+            'deleteToEndOfLine',
+            'deleteToNextWordBoundary'
+          ]
+          cmds.forEach(command => {
+            editor.setText("HelloWorld!")
+            editor.setCursorBufferPosition([0, 5])
+            callbacks = []
+            editor[command].bind(editor)();
+            expect(callbacks).toEqual([], `on command ${command}`)
+          })
+        });
       });
     });
 
@@ -6539,7 +6611,7 @@ describe('TextEditor', () => {
     });
   });
 
-  describe('.deleteLine()', () => {
+  fdescribe('.deleteLine()', () => {
     it('deletes the first line when the cursor is there', () => {
       editor.getLastCursor().moveToTop();
       const line1 = buffer.lineForRow(1);

--- a/spec/text-editor-spec.js
+++ b/spec/text-editor-spec.js
@@ -401,7 +401,10 @@ describe('TextEditor', () => {
           editor.setCursorBufferPosition([0, 5]);
           callbacks = [];
           editor.joinLines();
-          expect(callbacks).toEqual([true, true, false, false], "on command joinLines")
+          // TODO: Again, not ideal. But still...
+          // One for moving to the line that will be deleted, one for the actual change
+          // and one to move to the "join position" between the lines
+          expect(callbacks).toEqual([false, false, true, true, false, false], "on command joinLines")
         });
 
         it("doesn't emit the event if you deleted something forward", () => {

--- a/src/cursor.js
+++ b/src/cursor.js
@@ -301,6 +301,25 @@ module.exports = class Cursor extends Model {
     if (moveToEndOfSelection && !range.isEmpty()) {
       this.setScreenPosition(range.start);
     } else {
+      const point = this.getPreviousColumnScreenPosition(
+        columnCount, { moveToEndOfSelection }
+      )
+      this.setScreenPosition(point, { clipDirection: 'backward' });
+    }
+  }
+
+  // Public: Retrieves the screen position of where the previous column starts.
+  // * `columnCount` (optional) {Number} number of columns to move (default: 1)
+  // * `options` (optional) {Object} with the following keys:
+  //   * `moveToEndOfSelection` if true, move to the right of the selection if a
+  //     selection exists.
+  //
+  // Returns a {Point}.
+  getPreviousColumnScreenPosition(columnCount = 1, { moveToEndOfSelection } = {}) {
+    const range = this.marker.getScreenRange();
+    if (moveToEndOfSelection && !range.isEmpty()) {
+      return range.start;
+    } else {
       let { row, column } = this.getScreenPosition();
 
       while (columnCount > column && row > 0) {
@@ -310,7 +329,7 @@ module.exports = class Cursor extends Model {
       }
 
       column = column - columnCount;
-      this.setScreenPosition({ row, column }, { clipDirection: 'backward' });
+      return new Point( row, column )
     }
   }
 
@@ -324,6 +343,25 @@ module.exports = class Cursor extends Model {
     const range = this.marker.getScreenRange();
     if (moveToEndOfSelection && !range.isEmpty()) {
       this.setScreenPosition(range.end);
+    } else {
+      const point = this.getNextColumnScreenPosition(
+        columnCount, { moveToEndOfSelection }
+      )
+      this.setScreenPosition(point, { clipDirection: 'forward' });
+    }
+  }
+
+  // Public: Retrieves the screen position of where the next column starts.
+  // * `columnCount` (optional) {Number} number of columns to move (default: 1)
+  // * `options` (optional) {Object} with the following keys:
+  //   * `moveToEndOfSelection` if true, move to the right of the selection if a
+  //     selection exists.
+  //
+  // Returns a {Point}.
+  getNextColumnScreenPosition(columnCount = 1, { moveToEndOfSelection } = {}) {
+    const range = this.marker.getScreenRange();
+    if (moveToEndOfSelection && !range.isEmpty()) {
+      return range.end;
     } else {
       let { row, column } = this.getScreenPosition();
       const maxLines = this.editor.getScreenLineCount();
@@ -340,7 +378,7 @@ module.exports = class Cursor extends Model {
       }
 
       column = column + columnCount;
-      this.setScreenPosition({ row, column }, { clipDirection: 'forward' });
+      return new Point(row, column);
     }
   }
 
@@ -568,7 +606,7 @@ module.exports = class Cursor extends Model {
   //   * `allowPrevious` A {Boolean} indicating whether the beginning of the
   //     previous word can be returned.
   //
-  // Returns a {Range}.
+  // Returns a {Point}.
   getBeginningOfCurrentWordBufferPosition(options = {}) {
     const allowPrevious = options.allowPrevious !== false;
     const position = this.getBufferPosition();
@@ -629,7 +667,7 @@ module.exports = class Cursor extends Model {
   //   * `wordRegex` A {RegExp} indicating what constitutes a "word"
   //     (default: {::wordRegExp}).
   //
-  // Returns a {Range}
+  // Returns a {Point}
   getBeginningOfNextWordBufferPosition(options = {}) {
     const currentBufferPosition = this.getBufferPosition();
     const start = this.isInsideWord(options)
@@ -674,6 +712,8 @@ module.exports = class Cursor extends Model {
   // * `options` (optional) {Object}
   //   * `includeNewline` A {Boolean} which controls whether the Range should
   //     include the newline.
+  //
+  // Returns a {Range}.
   getCurrentLineBufferRange(options) {
     return this.editor.bufferRangeForBufferRow(this.getBufferRow(), options);
   }

--- a/src/selection.js
+++ b/src/selection.js
@@ -716,7 +716,9 @@ module.exports = class Selection {
   //   * `bypassReadOnly` (optional) {Boolean} Must be `true` to modify text within a read-only editor. (default: false)
   deleteToBeginningOfSubword(options = {}) {
     if (!this.ensureWritable('deleteToBeginningOfSubword', options)) return;
-    const position = this.cursor.getPreviousWordBoundaryBufferPosition(options);
+    const position = this.cursor.getPreviousWordBoundaryBufferPosition({
+      wordRegex: this.cursor.subwordRegExp({ backwards: true })
+    });
     this._deleteToPreviousPoint(position, options);
   }
 

--- a/src/selection.js
+++ b/src/selection.js
@@ -824,9 +824,6 @@ module.exports = class Selection {
     let cursorPositionAfterEdit = null;
     buffer.transact(() => {
       for (let i = 0; i < rowCount; i++) {
-        // this.cursor.setBufferPosition([selectedRange.start.row]);
-        // this.cursor.moveToEndOfLine();
-        //
         // Remove trailing whitespace from the current line
         const scanRange = this.cursor.getCurrentLineBufferRange();
         this.editor.scanInBufferRange(/[ \t]+$/, scanRange, ({ range }) => {
@@ -835,10 +832,6 @@ module.exports = class Selection {
         const currentRow = selectedRange.start.row;
         const nextRow = currentRow + 1;
         const haveNextLine = nextRow <= buffer.getLastRow();
-        // if (insertSpace) this.insertText(' ', options);
-        //
-        // this.cursor.moveToEndOfLine();
-        //
 
         if(haveNextLine) {
           // Remove leading whitespace from the line below

--- a/src/selection.js
+++ b/src/selection.js
@@ -775,21 +775,23 @@ module.exports = class Selection {
   deleteLine(options = {}) {
     if (!this.ensureWritable('deleteLine', options)) return;
     const range = this.getBufferRange();
-    if (range.isEmpty()) {
-      const start = this.cursor.getScreenRow();
-      const range = this.editor.bufferRowsForScreenRows(start, start + 1);
-      if (range[1] > range[0]) {
-        this.editor.buffer.deleteRows(range[0], range[1] - 1);
+    this.editor.transact(() => {
+      if (range.isEmpty()) {
+        const start = this.cursor.getScreenRow();
+        const range = this.editor.bufferRowsForScreenRows(start, start + 1);
+        if (range[1] > range[0]) {
+          this.editor.buffer.deleteRows(range[0], range[1] - 1);
+        } else {
+          this.editor.buffer.deleteRow(range[0]);
+        }
       } else {
-        this.editor.buffer.deleteRow(range[0]);
+        const start = range.start.row;
+        let end = range.end.row;
+        if (end !== this.editor.buffer.getLastRow() && range.end.column === 0)
+          end--;
+        this.editor.buffer.deleteRows(start, end);
       }
-    } else {
-      const start = range.start.row;
-      let end = range.end.row;
-      if (end !== this.editor.buffer.getLastRow() && range.end.column === 0)
-        end--;
-      this.editor.buffer.deleteRows(start, end);
-    }
+    })
     this.cursor.setBufferPosition({
       row: this.cursor.getBufferRow(),
       column: range.start.column


### PR DESCRIPTION
When listening to cursor movements on the text editor with `onDidChangeCursorPosition`, there's a property on the event called `textChanged`. That property was ALWAYS `false` when deleting characters.

The reason being that the original implementation to delete stuff involved moving the cursor, selecting text, and replacing it with the empty string. Like, **literally moving** the cursor on the screen - if we had a sufficiently slow CPU we would be able to _see_ the cursor moving, selecting text, and deleting it. Which, basically, indeed caused a change in position, but **not** because things were deleted; in fact, when thing _did get_ deleted there was no more cursor movement, so that gave the impression that `textChanged` was simply being set incorrectly.

This also fixes "forward deletions" like pressing `delete` or commands like "delete to the next word", mainly because these deletions _don't actually change_ the cursor position, so the event is not called anyway.

The tricky ones were "delete line" and "join lines" - delete line, ideally, should not cause any cursor movement because when one deletes a line, the cursor stays in the same position if the next line is greater or equal in number of columns; unfortunately, this won't work - deleting the text where the cursor _current is_ causes a movement, so we compromise and make two movements - one for the actual deletion (caused by how things work now, with `textChanged: true`) and one to reposition the cursor (which don't change text, so `textChanged: false`). This is not an actual problem, because the old implementation caused **three** text movements.

A similar fix was made for Join Lines, which actually caused quite a lot of movements.

This PR fixes https://github.com/pulsar-edit/pulsar/issues/802 and https://github.com/atom/atom/issues/11870, and are probably one of the oldest bugs I opened with the editor.