### PR TITLE
[core] (Windows) Implement Specific File Handler Functionality

### DIFF
--- a/script/electron-builder.js
+++ b/script/electron-builder.js
@@ -216,6 +216,10 @@ let options = {
       {
         "from": "resources/win/modifyWindowsPath.ps1",
         "to": "modifyWindowsPath.ps1"
+      },
+      {
+        "from": "resources/file-icons/win/icons",
+        "to": "icons"
       }
     ],
     "target": [

--- a/src/main-process/win-shell.js
+++ b/src/main-process/win-shell.js
@@ -213,6 +213,65 @@ exports.runningAsAdmin = (callback) => {
 
 exports.appName = appName;
 
+const supportedFileTypes = [
+  {
+    ext: ".c++",
+    ico: "cplusplus.ico",
+    progID: "Pulsar.c++",
+    desc: "C++ Source File"
+  },
+  {
+    ext: ".cs",
+    ico: "csharp.ico",
+    progID: "Pulsar.cs",
+    desc: "C Sharp Source File"
+  },
+  {
+    ext: ".js",
+    ico: "javascript.ico",
+    progID: "Pulsar.js",
+    desc: "JavaScript Source File"
+  },
+  {
+    ext: ".less",
+    ico: "less.ico",
+    progID: "Pulsar.less",
+    desc: "Less Source File"
+  },
+  {
+    ext: ".rb",
+    ico: "ruby.ico",
+    progID: "Pulsar.rb",
+    desc: "Ruby Source File"
+  }
+];
+
+exports.registerSupportedFileTypes = () => {
+  for (let i = 0; i < supportedFileTypes.length; i++) {
+    let extRegister = new ShellOption(
+      `\\Software\\Classes\\${supportedFileTypes[i].ext}`,
+      [
+        { key: "OpenWithProgids", name: supportedFileTypes[i].progID, value: "" }
+      ]
+    );
+
+    extRegister.register(function () {});
+
+    let progIdRegister = new ShellOption(
+      `\\Software\Classes\\${supportedFileTypes[i].progID}`,
+      [
+        { name: "", value: supportedFileTypes[i].desc },
+        { name: "AppUserModelID", value: "dev.pulsar-edit.pulsar" },
+        { key: "DefaultIcon", name: "", value: `${Path.join(process.execPath, "..", "resources", "icons", supportedFileTypes[i].ico )}` },
+        { key: "shell\\open\\command", name: "", value: `"${appPath}" "%1"` },
+        { key: "shell\\open", name: "Icon", value: `${appPath}` },
+      ]
+    );
+
+    progIdRegister.register(function () {});
+  }
+};
+
 exports.fileHandler = new ShellOption(
   `\\Software\\Classes\\Applications\\${exeName}`,
   [


### PR DESCRIPTION
This PR relates to #803 

This PR implements the logic needed for that PR to actually work. At least the baseline logic needed on Windows Systems.

This PR would ensure that for supported file types we are able to set specific icons for those files. If we create a generic icon that could also be used for a more extensive list of "supported" file types, which would likely see the most benefit from being used to cover all file types supported by the default grammars installed within Pulsar.

But again it's good to keep in mind this does not address this behavior at all on Linux or macOS. And as of currently is missing the implementation of this behavior into functionality within the `settings-view` package.