### PR TITLE
Fix focus placement inside palettes

### DIFF
--- a/packages/bookmarks/lib/bookmarks-view.js
+++ b/packages/bookmarks/lib/bookmarks-view.js
@@ -4,7 +4,7 @@ const SelectListView = require('atom-select-list')
 
 module.exports =
 class BookmarksView {
-  constructor (editorsBookmarks) {
+  constructor(editorsBookmarks) {
     this.editorsBookmarks = editorsBookmarks
     this.selectList = new SelectListView({
       emptyMessage: 'No bookmarks found',
@@ -48,16 +48,22 @@ class BookmarksView {
     this.selectList.element.classList.add('bookmarks-view')
   }
 
-  destroy () {
+  destroy() {
     this.selectList.destroy()
     this.getModalPanel().destroy()
-    if (this.previouslyFocusedElement) {
-      this.previouslyFocusedElement.focus()
-      this.previouslyFocusedElement = null
-    }
+
+    setTimeout(() => {
+      // Don't restore previous focus if a modal panel currently has focus.
+      let focusedModal = document.activeElement.closest('atom-panel.modal')
+
+      if (this.previouslyFocusedElement && !focusedModal) {
+        this.previouslyFocusedElement.focus()
+        this.previouslyFocusedElement = null
+      }
+    }, 0);
   }
 
-  async show () {
+  async show() {
     const bookmarks = []
     for (const {editor, markerLayer} of this.editorsBookmarks) {
       for (const marker of markerLayer.getMarkers()) {
@@ -83,7 +89,7 @@ class BookmarksView {
     this.selectList.focus()
   }
 
-  hide () {
+  hide() {
     this.getModalPanel().hide()
     if (this.previouslyFocusedElement) {
       this.previouslyFocusedElement.focus()
@@ -91,7 +97,7 @@ class BookmarksView {
     }
   }
 
-  getModalPanel () {
+  getModalPanel() {
     if (!this.modalPanel) {
       this.modalPanel = atom.workspace.addModalPanel({item: this.selectList})
     }

--- a/packages/command-palette/lib/command-palette-view.js
+++ b/packages/command-palette/lib/command-palette-view.js
@@ -122,10 +122,16 @@ export default class CommandPaletteView {
 
   hide () {
     this.panel.hide()
-    if (this.previouslyFocusedElement) {
-      this.previouslyFocusedElement.focus()
-      this.previouslyFocusedElement = null
-    }
+
+    setTimeout(() => {
+      // Don't restore previous focus if a modal panel currently has focus.
+      let focusedModal = document.activeElement.closest('atom-panel.modal')
+
+      if (this.previouslyFocusedElement && !focusedModal) {
+        this.previouslyFocusedElement.focus()
+        this.previouslyFocusedElement = null
+      }
+    }, 0)
   }
 
   async update (props) {

--- a/packages/encoding-selector/lib/encoding-list-view.js
+++ b/packages/encoding-selector/lib/encoding-list-view.js
@@ -5,7 +5,7 @@ const SelectListView = require('atom-select-list')
 
 module.exports =
 class EncodingListView {
-  constructor (encodings) {
+  constructor(encodings) {
     this.encodings = encodings
     this.selectListView = new SelectListView({
       itemsClassList: ['mark-active'],
@@ -35,24 +35,29 @@ class EncodingListView {
     this.selectListView.element.classList.add('encoding-selector')
   }
 
-  destroy () {
+  destroy() {
     this.cancel()
     return this.selectListView.destroy()
   }
 
-  cancel () {
+  cancel() {
     if (this.panel != null) {
       this.panel.destroy()
     }
     this.panel = null
     this.currentEncoding = null
-    if (this.previouslyFocusedElement) {
-      this.previouslyFocusedElement.focus()
-      this.previouslyFocusedElement = null
-    }
+    setTimeout(() => {
+      // Don't restore previous focus if a modal panel currently has focus.
+      let focusedModal = document.activeElement.closest('atom-panel.modal')
+
+      if (this.previouslyFocusedElement && !focusedModal) {
+        this.previouslyFocusedElement.focus()
+        this.previouslyFocusedElement = null
+      }
+    }, 0)
   }
 
-  attach () {
+  attach() {
     this.previouslyFocusedElement = document.activeElement
     if (this.panel == null) {
       this.panel = atom.workspace.addModalPanel({item: this.selectListView})
@@ -61,7 +66,7 @@ class EncodingListView {
     this.selectListView.reset()
   }
 
-  async toggle () {
+  async toggle() {
     if (this.panel != null) {
       this.cancel()
     } else if (atom.workspace.getActiveTextEditor()) {
@@ -82,7 +87,7 @@ class EncodingListView {
     }
   }
 
-  detectEncoding () {
+  detectEncoding() {
     const editor = atom.workspace.getActiveTextEditor()
     const filePath = editor.getPath()
     if (fs.existsSync(filePath)) {

--- a/packages/fuzzy-finder/lib/fuzzy-finder-view.js
+++ b/packages/fuzzy-finder/lib/fuzzy-finder-view.js
@@ -11,7 +11,7 @@ const getIconServices = require('./get-icon-services')
 const MAX_RESULTS = 10
 
 module.exports = class FuzzyFinderView {
-  constructor (metricsReporter) {
+  constructor(metricsReporter) {
     this.previousQueryWasLineJump = false
     this.items = []
     this.metricsReporter = metricsReporter
@@ -34,7 +34,9 @@ module.exports = class FuzzyFinderView {
 
         return query
       },
-      didCancelSelection: () => { this.cancel() },
+      didCancelSelection: () => {
+        this.cancel()
+      },
       didConfirmSelection: (item) => {
         this.confirm(item, {searchAllPanes: atom.config.get('fuzzy-finder.searchAllPanes')})
       },
@@ -137,11 +139,11 @@ module.exports = class FuzzyFinderView {
     this.selectListView.update({ filter: this.filterFn })
   }
 
-  get element () {
+  get element() {
     return this.selectListView.element
   }
 
-  destroy () {
+  destroy() {
     if (this.panel) {
       this.panel.destroy()
     }
@@ -149,7 +151,7 @@ module.exports = class FuzzyFinderView {
     return this.selectListView.destroy()
   }
 
-  cancel () {
+  cancel() {
     if (atom.config.get('fuzzy-finder.preserveLastSearch')) {
       this.selectListView.refs.queryEditor.selectAll()
     } else {
@@ -159,7 +161,7 @@ module.exports = class FuzzyFinderView {
     this.hide()
   }
 
-  confirm ({uri} = {}, openOptions) {
+  confirm({uri} = {}, openOptions) {
     if (atom.workspace.getActiveTextEditor() && this.isQueryALineJump()) {
       const caretPosition = this.getCaretPosition()
       this.cancel()
@@ -176,7 +178,7 @@ module.exports = class FuzzyFinderView {
     }
   }
 
-  getEditorSelection () {
+  getEditorSelection() {
     const editor = atom.workspace.getActiveTextEditor()
     if (!editor) {
       return
@@ -188,7 +190,7 @@ module.exports = class FuzzyFinderView {
     return selectedText
   }
 
-  prefillQueryFromSelection () {
+  prefillQueryFromSelection() {
     const selectedText = this.getEditorSelection()
     if (selectedText) {
       this.selectListView.refs.queryEditor.setText(selectedText)
@@ -197,7 +199,7 @@ module.exports = class FuzzyFinderView {
     }
   }
 
-  show () {
+  show() {
     this.previouslyFocusedElement = document.activeElement
     if (!this.panel) {
       this.panel = atom.workspace.addModalPanel({item: this})
@@ -209,25 +211,31 @@ module.exports = class FuzzyFinderView {
     this.selectListView.focus()
   }
 
-  hide () {
+  hide() {
     if (this.panel) {
       this.panel.hide()
     }
 
-    if (this.previouslyFocusedElement) {
-      this.previouslyFocusedElement.focus()
-      this.previouslyFocusedElement = null
-    }
+    setTimeout(() => {
+      // Don't restore previous focus if a modal panel currently has focus.
+      let focusedModal = document.activeElement.closest('atom-panel.modal')
+
+      if (this.previouslyFocusedElement && !focusedModal) {
+        this.previouslyFocusedElement.focus()
+        this.previouslyFocusedElement = null
+      }
+    }, 0)
+
   }
 
-  async openURI (uri, caretPosition, openOptions) {
+  async openURI(uri, caretPosition, openOptions) {
     if (uri) {
       await atom.workspace.open(uri, openOptions)
       this.moveToCaretPosition(caretPosition)
     }
   }
 
-  moveToCaretPosition (caretPosition) {
+  moveToCaretPosition(caretPosition) {
     const editor = atom.workspace.getActiveTextEditor()
     if (editor && caretPosition.row >= 0) {
       editor.unfoldBufferRow(caretPosition.row)
@@ -240,7 +248,7 @@ module.exports = class FuzzyFinderView {
     }
   }
 
-  splitOpenPath (splitFn) {
+  splitOpenPath(splitFn) {
     const {uri} = this.selectListView.getSelectedItem() || {}
     const caretPosition = this.getCaretPosition()
     const editor = atom.workspace.getActiveTextEditor()
@@ -262,14 +270,14 @@ module.exports = class FuzzyFinderView {
     }
   }
 
-  isQueryALineJump () {
+  isQueryALineJump() {
     return (
       this.selectListView.getFilterQuery().trim() === '' &&
       this.selectListView.getQuery().includes(':')
     )
   }
 
-  getCaretPosition () {
+  getCaretPosition() {
     const query = this.selectListView.getQuery()
     const firstColon = query.indexOf(':')
     const secondColon = query.indexOf(':', firstColon + 1)
@@ -288,7 +296,7 @@ module.exports = class FuzzyFinderView {
     return position
   }
 
-  setItems (items) {
+  setItems(items) {
     this.items = items
     this.nativeFuzzy.setCandidates(
       indexArray(this.items.length),
@@ -312,7 +320,7 @@ module.exports = class FuzzyFinderView {
     }
   }
 
-  projectRelativePathsForFilePaths (filePaths) {
+  projectRelativePathsForFilePaths(filePaths) {
     // Don't regenerate project relative paths unless the file paths have changed
     if (filePaths !== this.filePaths) {
       this.filePaths = filePaths
@@ -324,7 +332,7 @@ module.exports = class FuzzyFinderView {
     return this.projectRelativePaths
   }
 
-  convertPathToSelectViewObject (filePath) {
+  convertPathToSelectViewObject(filePath) {
     const projectHasMultipleDirectories = atom.project.getDirectories().length > 1
 
     const [rootPath, projectRelativePath] = atom.project.relativizePath(filePath)
@@ -343,7 +351,7 @@ module.exports = class FuzzyFinderView {
   }
 }
 
-function highlight (path, matches, offsetIndex) {
+function highlight(path, matches, offsetIndex) {
   let lastIndex = 0
   let matchedChars = []
   const fragment = document.createDocumentFragment()
@@ -382,7 +390,7 @@ function highlight (path, matches, offsetIndex) {
   return fragment
 }
 
-function indexArray (length) {
+function indexArray(length) {
   const array = []
   for (let i = 0; i < length; i++) {
     array[i] = i
@@ -391,7 +399,7 @@ function indexArray (length) {
 }
 
 class FuzzyFinderItem {
-  constructor ({filePath, label, ownerGitHubUsername, filterQuery, matches, repository}) {
+  constructor({filePath, label, ownerGitHubUsername, filterQuery, matches, repository}) {
     this.filePath = filePath
     this.label = label
     this.element = document.createElement('li')

--- a/packages/grammar-selector/lib/grammar-list-view.js
+++ b/packages/grammar-selector/lib/grammar-list-view.js
@@ -83,10 +83,16 @@ module.exports = class GrammarListView {
     }
     this.panel = null;
     this.currentGrammar = null;
-    if (this.previouslyFocusedElement) {
-      this.previouslyFocusedElement.focus();
-      this.previouslyFocusedElement = null;
-    }
+
+    setTimeout(() => {
+      // Don't restore previous focus if a modal panel currently has focus.
+      let focusedModal = document.activeElement.closest('atom-panel.modal');
+
+      if (this.previouslyFocusedElement && !focusedModal) {
+        this.previouslyFocusedElement.focus();
+        this.previouslyFocusedElement = null;
+      }
+    }, 0);
   }
 
   attach() {

--- a/packages/line-ending-selector/lib/selector.js
+++ b/packages/line-ending-selector/lib/selector.js
@@ -64,8 +64,15 @@ export class Selector {
   hide() {
     // hide modal panel
     this.modalPanel.hide();
-    // focus on the previous active pane
-    this.previousActivePane.activate();
+
+    setTimeout(() => {
+      // Don't restore previous focus if a modal panel currently has focus.
+      let focusedModal = document.activeElement.closest('atom-panel.modal');
+
+      if (!focusedModal) {
+        this.previousActivePane.activate();
+      }
+    }, 0);
   }
 
   // Dispose selector

--- a/packages/spell-check/lib/corrections-view.js
+++ b/packages/spell-check/lib/corrections-view.js
@@ -93,10 +93,16 @@ export default class CorrectionsView {
             this.destroyed = true;
             this.overlayDecoration.destroy();
             await this.selectListView.destroy();
-            if (this.previouslyFocusedElement) {
-                this.previouslyFocusedElement.focus();
-                this.previouslyFocusedElement = null;
-            }
+
+            setTimeout(() => {
+                // Don't restore previous focus if a modal panel currently has focus.
+                let focusedModal = document.activeElement.closest('atom-panel.modal')
+
+                if (this.previouslyFocusedElement && !focusedModal) {
+                    this.previouslyFocusedElement.focus();
+                    this.previouslyFocusedElement = null;
+                }
+            }, 0);
         }
     }
 }

--- a/packages/spell-check/lib/main.js
+++ b/packages/spell-check/lib/main.js
@@ -6,6 +6,7 @@ let spellCheckViews = {};
 const LARGE_FILE_SIZE = 2 * 1024 * 1024;
 
 let log = (str) => {};
+let debug;
 
 module.exports = {
     activate() {


### PR DESCRIPTION
### Identify the Bug

I thought @asiloisad had opened a bug for this, but I can’t find it. Maybe it was just mentioned on Discord?

The bug can be reproduced, though:

* Press the key combination for opening the fuzzy finder (<kbd>Ctrl-T</kbd> or <kbd>Cmd-T</kbd>) by default.
* While that palette is open and focus is in the search field, invoke <kbd>Ctrl-Shift-P</kbd> or <kbd>Cmd-Shift-P</kbd> to open the command palette.
* Focus _should_ be in the command palette’s search field, but it isn’t.

### Description of the Change

This happens because each of these palettes expects that, when it loses focus, it will need to restore focus to the place the palette was opened from — usually a text editor. It doesn’t envision any workflows in which the palette closes because another palette wants focus instead.

So the fix is this: on blur, wait for focus to move, then inspect where the focus is now. If it’s inside another modal, leave it alone; otherwise restore the previous focus as planned.

### Alternate Designs

This isn’t the most elegant fix, but anything more comprehensive will probably need some sort of “god object” that knows where focus is and makes judgments about when it should go where.

### Possible Drawbacks

The only drawback to this fix that I can think of is that it needs to be made separately in every palette. This PR covers the two palettes that are in core. (The `symbols-view-redux` package, soon to come into core as `symbols-view`, will also have this fix applied.)

### Verification Process

Repeat the steps described above; focus should go where you expect. (Be sure to try it in the other order as well — first the command palette, then the file palette).

### Release Notes

- Fixed an issue where focus was mismanaged when opening one palette while another palette was visible.

