### PR TITLE
ppm: Install with the `yarn install --production` flag

### DIFF
--- a/package.json
+++ b/package.json
@@ -282,7 +282,7 @@
   "private": true,
   "scripts": {
     "build": "electron-rebuild",
-    "build:apm": "cd ppm && yarn install",
+    "build:apm": "cd ppm && yarn install --production",
     "start": "electron --no-sandbox --enable-logging . -f",
     "dist": "node script/electron-builder.js",
     "js-docs": "jsdoc2md --files src --configure docs/.jsdoc.json > ./docs/Pulsar-API-Documentation.md",


### PR DESCRIPTION
Saves ~5-7MB disk space, depending on how you count it. Should make the packaged Pulsar binaries slightly smaller as well. Reduces file count, may marginally improve install times of Pulsar due to reduced disk I/O.

### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

Install the `ppm` dir with [`yarn install --production`](https://classic.yarnpkg.com/lang/en/docs/cli/install/#toc-yarn-install-production-true-false) (omits `devDependencies`), rather than basic `yarn install` (which installs both `dependencies` AND `devDependencies`).

### Quantitative Performance Benefits

<!--

Describe the exact performance improvement observed (for example, reduced time to complete an operation, reduced memory use, etc.). Describe how you measured this change. Bonus points for including graphs that demonstrate the improvement or attached dumps from the built-in profiling tools.

-->

Measuring by disk usage of the `ppm` dir, using `ncdu`.

- Before:  `Total disk usage: 213.6 MiB  Apparent size: 168.0 MiB  Items: 20613`
- After: `Total disk usage: 206.4 MiB  Apparent size: 163.2 MiB  Items: 19441`

About 5-7 MB of disk savings (depending on how you measure it), 1172 fewer files/directories.

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

This omits the `coffeescript` and `coffee-lint` dependencies, among others. I don't think those (or anything in `devDependencies` are actually used in production.

Risk seems minimal, but if we missed where these things are needed, it would cause bugs.

Note: `apm` and the Atom-community fork used to publish and install apm as a package from the npm package registry. This implicitly did not include any of the `devDependencies` as well. So I feel that proves out that the `devdependencies` are NOT needed in production, or at least they weren't needed as of then. I don't think we've mistakenly relief on a `devDependency` of `ppm` in production since those times.

### Verification Process

<!--

What process did you follow to verify that the change has not introduced any regressions? Describe the actions you performed (including buttons you clicked, text you typed, commands you ran, etc.), and describe the results you observed.

-->

Admittedly I haven't really tested this, but I can take some time to do so at some point.

### Applicable Issues

<!-- Enter any applicable Issues here -->

None

### Release Notes

<!--

Please describe the changes in a single line that explains this improvement in
terms that a user can understand.  This text will be used in Atom's release notes.

If this change is not user-facing or notable enough to be included in release notes
you may use the strings "Not applicable" or "N/A" here.

Examples:

- The GitHub package now allows you to add co-authors to commits.
- Fixed an issue where multiple cursors did not work in a file with a single line.
- Increased the performance of searching and replacing across a whole project.

-->

Install ppm with the `yarn install --production` flag (save some disk space by excluding `devDependencies`)