### PR TITLE
[tree-sitter] Share config caches between `ScopeResolver`s

### DIFF
--- a/packages/language-clojure/grammars/ts/highlights.scm
+++ b/packages/language-clojure/grammars/ts/highlights.scm
@@ -34,9 +34,12 @@
 ((list_lit
   "(" @punctuation.section.expression.begin (#is-not? test.descendantOfNodeWithData "clojure.dismissTag")
   .
-  (sym_lit) @meta.definition.global @keyword.control (#eq? @meta.definition.global "ns")
+  (sym_lit) @meta.definition.global @keyword.control
+    (#eq? @meta.definition.global "ns")
   .
-  (sym_lit) @meta.definition.global @entity.global
+  ; We need to distinguish this `@meta.definition.global` from the one above or
+  ; else this query will fail.
+  (sym_lit) @meta.definition.global.__TEXT__ @entity.global
   ")" @punctuation.section.expression.end)
  @meta.namespace.clojure
  (#set! isNamespace true))

--- a/packages/language-clojure/package.json
+++ b/packages/language-clojure/package.json
@@ -5,7 +5,7 @@
   "main": "lib/main",
   "engines": {
     "atom": "*",
-    "node": "*"
+    "node": ">=12"
   },
   "repository": "https://github.com/pulsar-edit/pulsar",
   "license": "MIT",

--- a/spec/scope-resolver-spec.js
+++ b/spec/scope-resolver-spec.js
@@ -32,19 +32,41 @@ const jsRegexGrammarPath = resolve(
 );
 let jsRegexConfig = CSON.readFileSync(jsRegexGrammarPath);
 
-async function getAllCaptures(grammar, languageMode, layer = null) {
+async function getAllCapturesWithScopeResolver(grammar, languageMode, scopeResolver, layer = null) {
   let query = await grammar.getQuery('highlightsQuery');
   layer = layer ?? languageMode.rootLanguageLayer;
-  let scopeResolver = new ScopeResolver(
-    layer,
-    (name) => languageMode.idForScope(name),
-  );
   let { start, end } = languageMode.buffer.getRange();
   let { tree } = layer;
   return {
     captures: query.captures(tree.rootNode, start, end),
     scopeResolver
   };
+}
+
+function makeScopeResolver(languageMode, layer) {
+  layer = layer ?? languageMode.rootLanguageLayer;
+  return new ScopeResolver(
+    layer,
+    (name) => languageMode.idForScope(name),
+  );
+}
+
+async function getAllCaptures(grammar, languageMode, layer = null) {
+  layer = layer ?? languageMode.rootLanguageLayer;
+  let scopeResolver = makeScopeResolver(languageMode, layer);
+  return getAllCapturesWithScopeResolver(grammar, languageMode, scopeResolver, layer);
+}
+
+async function getAllMatchesWithScopeResolver(...args) {
+  let { captures, scopeResolver } = await getAllCapturesWithScopeResolver(...args);
+  let matches = [];
+  for (let capture of captures) {
+    let range = scopeResolver.store(capture);
+    if (range) {
+      matches.push(capture);
+    }
+  }
+  return matches;
 }
 
 async function getAllMatches(...args) {
@@ -1136,12 +1158,33 @@ describe('ScopeResolver', () => {
       `);
       await languageMode.ready;
 
-      let matched = await getAllMatches(grammar, languageMode);
+      let scopeResolver = makeScopeResolver(languageMode);
+
+      let matched = await getAllMatchesWithScopeResolver(grammar, languageMode, scopeResolver);
       expect(matched.length).toBe(4);
 
       atom.config.set('core.careAboutBooleans', "something-else");
 
-      matched = await getAllMatches(grammar, languageMode);
+      matched = await getAllMatchesWithScopeResolver(grammar, languageMode, scopeResolver);
+      expect(matched.length).toBe(0);
+
+      atom.config.set(
+        'core.careAboutBooleans',
+        'something',
+        { scope: [grammar.scopeName] }
+      );
+
+      matched = await getAllMatchesWithScopeResolver(grammar, languageMode, scopeResolver);
+      expect(matched.length).toBe(4);
+
+      atom.config.set('core.careAboutBooleans', "something");
+
+      atom.config.set(
+        'core.careAboutBooleans',
+        'something-else',
+        { scope: [grammar.scopeName] }
+      );
+      matched = await getAllMatchesWithScopeResolver(grammar, languageMode, scopeResolver);
       expect(matched.length).toBe(0);
     });
 


### PR DESCRIPTION
### Identify the Bug

This is a subtle one.

If I do

```js
atom.config.onDidChange(() => {
  // do something
});
```

then I’m creating some hidden costly work. `atom.config` has to compare old values to new values before invoking `onDidChange` callbacks because some “changes” don’t actually result in different config data. And in this case, because we’re listing to _all_ config changes rather than a specific key, it won’t invoke our callback until it’s done a deep equality comparison of the old and new config objects. That's a little expensive.

This isn’t a problem by itself. The problem is that each instance of `ScopeResolver` was calling a snippet like the one above in order to know when to clear its config cache (which it uses to look up values for `test.config` scope tests).

I noticed the effect of this in a window in which I had a very large `d.ts` file open in the background (one that defined several thousand DOM builtin types). I noticed a huge amount of lag when I changed a config value. I eventually realized that said `d.ts` file had several thousand JSDoc comment blocks, and each JSDoc comment block has its own `LanguageLayer`… which in turn has its own `ScopeResolver`. So I was unwittingly creating several thousand `atom.config.onDidChange` listeners, each of which was doing a separate deep equality check.

### Description of the Change

This is easy to fix. A `ScopeResolver` keeps its own config cache because it makes scoped lookups; e.g., a `ScopeResolver` for a JavaScript layer will do all its lookups with a `source.js` scope name so that it can respect language-specific overrides. But that means that every JavaScript `ScopeResolver` can share a cache, every Ruby `ScopeResolver` can share a cache… and so on. Better still, we can get away with defining only one `atom.config.onDidChange` handler; it can be in charge of clearing _every_ `ScopeResolver`’s cache.

### Alternate Designs

At first my goal was simply to reduce extra calls to `atom.config.onDidChange`. After some trial and error, I decided it also made sense to reduce the number of unique cache objects that were being created.

### Possible Drawbacks

Slightly harder to understand, I think? (But it’s not like anyone understands this code except for me in the first place.)

### Verification Process

Make sure the tests pass.

The original specs for `test.config` weren’t actually testing the cache invalidation behavior because the test helpers constructed a new `ScopeResolver` for each assertion. I rewrote one of the specs to reuse the same `ScopeResolver` across several assertions.

Now, that spec tests all permutations: it ensures the right thing happens when a setting is set globally and in scope-specific fashion, including when those values clash.

### Release Notes

I’m not even sure this is worth a line in the release notes.
