### PR TITLE
Fix behavior of new `ScopeResolver` config caching in specs

### DIFF
--- a/spec/scope-resolver-spec.js
+++ b/spec/scope-resolver-spec.js
@@ -104,6 +104,10 @@ describe('ScopeResolver', () => {
     atom.config.set('core.useExperimentalModernTreeSitter', true);
   });
 
+  afterEach(() => {
+    ScopeResolver.clearConfigCache();
+  });
+
   it('resolves all scopes in absence of any tests or adjustments', async () => {
     await grammar.setQueryForTest('highlightsQuery', `
       (comment) @comment

--- a/src/scope-resolver.js
+++ b/src/scope-resolver.js
@@ -124,6 +124,10 @@ ConfigCache.forConfig = (config) => {
   return configCache;
 };
 
+ConfigCache.clear = () => {
+  ConfigCache.CACHES_FOR_CONFIG_OBJECTS.clear();
+};
+
 
 // A data structure for storing scope information while processing capture
 // data. The data is reset in between each task.
@@ -952,6 +956,10 @@ ScopeResolver.ADJUSTMENTS = {
 
     return position;
   }
+};
+
+ScopeResolver.clearConfigCache = () => {
+  ConfigCache.clear();
 };
 
 


### PR DESCRIPTION
This should make CI happy. I hope!