### PR TITLE
[find-and-replace] Fix `capitalize` utility

### DIFF
--- a/packages/find-and-replace/lib/project/util.coffee
+++ b/packages/find-and-replace/lib/project/util.coffee
@@ -36,7 +36,10 @@ showIf = (condition) ->
   else
     {display: 'none'}
 
-capitalize = (str) -> str[0].toUpperCase() + str.toLowerCase().slice(1)
+capitalize = (str) ->
+  return '' if str == ''
+  str[0].toUpperCase() + str.toLowerCase().slice(1)
+
 titleize = (str) -> str.toLowerCase().replace(/(?:^|\s)\S/g, (capital) -> capital.toUpperCase())
 
 preserveCase = (text, reference) ->

--- a/packages/find-and-replace/package.json
+++ b/packages/find-and-replace/package.json
@@ -139,7 +139,7 @@
     "preserveCaseOnReplace": {
       "type": "boolean",
       "default": false,
-      "title": "Preserve case during replace.",
+      "title": "Preserve Case During Replace",
       "description": "Keep the replaced text case during replace: replacing 'user' with 'person' will replace 'User' with 'Person' and 'USER' with 'PERSON'."
     }
   }


### PR DESCRIPTION

Fixes [discussions/244](https://github.com/orgs/pulsar-edit/discussions/244).

### Identify the Bug

A utility function in the `find-and-replace` package for capitalizing strings was doomed to fail when given an empty string as input. It assumed it could call `toUpperCase` on the string’s first character.

Nobody noticed this because it doesn’t happen unless the user enables the **Preserve Case During Replace** option (which is `false` by default).

### Description of the Change

Return empty strings as-is, for _there is nothing to capitalize_.

I also took this opportunity to rename the setting from `Preserve case during replace.` to `Preserve Case During Replace`. I don’t love How We Title-Case Every Single Setting, but if we’re going to do it, we should be consistent about it.

### Alternate Designs

I really didn’t think too hard about this one.

### Possible Drawbacks

We provide such a smooth and bug-free experience that Pulsar users take us completely for granted.

### Verification Process

* Open a new file. Type a word on each of the first three lines.
* Open the Find and Replace dialog and enable the regex option. Find `^` and replace with `;`. Click on <kbd>Find All</kbd>, then on <kbd>Replace All</kbd>.
* This action should fail on master and pass on this PR branch.

### Release Notes

Fix certain find-and-replace scenarios when the “Preserve Case During Replace” setting is enabled.
