### PR TITLE
Default to no emoji when rendering Markdown

### DIFF
--- a/src/ui.js
+++ b/src/ui.js
@@ -83,7 +83,7 @@ function renderMarkdown(content, givenOpts = {}) {
     sanitizeAllowSelfClose: true,
     breaks: false, // Convert `\n` in paragraphs into `<br>`
     handleFrontMatter: true, // Determines if Front Matter content should be parsed
-    useDefaultEmoji: true, // Use `markdown-it-emoji`
+    useDefaultEmoji: false, // Use `markdown-it-emoji`
     useGitHubHeadings: false, // Use `markdown-it-github-headings`
     useTaskCheckbox: true, // Use `markdown-it-task-checkbox`
     taskCheckboxDisabled: true, // `markdown-it-task-checkbox`: Disable checkbox interactivity


### PR DESCRIPTION
### Identify the Bug

I saw this linter message when I opened the `package-backend` project and grew curious:

<img width="442" alt="Screenshot 2023-12-30 at 4 49 47 PM" src="https://github.com/pulsar-edit/pulsar/assets/3450/00a73390-b410-45a3-a3d6-e5389925cef9">

Turns out that emoji is an interpretation of `:@`.

I am guessing that most people who render Markdown would not _expect_ that the character sequence `:@` would, in all cases, be converted to an emoji. So let's make that an opt-in feature.

### Description of the Change

Change the default for `useDefaultEmoji` in `atom.ui.markdown.render` to `false`.

### Alternate Designs

I thought about removing this option altogether out of spite, but I calmed down.

### Possible Drawbacks

Nah.

### Verification Process

In the devtools console, run

```js
atom.notifications.addError("foo", { description: ":@" });
```

and inspect the output. On `master` it'll be a smiley; on this PR branch it'll be the literal text `:@`.

### Release Notes

Switch default to false for converting ASCII emoticons to emoji when rendering Markdown.