### PR TITLE
Ensure editor is visible before measuring block decorations

### DIFF
--- a/src/text-editor-component.js
+++ b/src/text-editor-component.js
@@ -274,7 +274,7 @@ module.exports = class TextEditorComponent {
       this.remeasureCharacterDimensions = false;
     }
 
-    this.measureBlockDecorations();
+    if (this.isVisible()) this.measureBlockDecorations();
 
     this.updateSyncBeforeMeasuringContent();
     if (useScheduler === true) {
@@ -5121,7 +5121,7 @@ function debounce(fn, wait) {
     }
   }
 
-  return function() {
+  return function () {
     timestamp = Date.now();
     if (!timeout) timeout = setTimeout(later, wait);
   };


### PR DESCRIPTION
### Identify the Bug

The bug is probably the cause of [this issue in the `github` package](https://github.com/pulsar-edit/github/issues/40#issuecomment-1870658494).

### Description of the Change

For the reasons described in the link above, this change is certainly more correct than what we already had:

* The goal of `measureBlockDecorations` is to pre-compute the heights of certain editor additions (like the “stage hunk” controls in the `github` diff view that exhibits the bug)
* This bug is happening because the text editor is not yet visible when this code is running, so it is pre-computing a bunch of `0` values for things that definitely would have height if the editor were visible
* It’s obviously wrong to do memoization of invalid values

But how do we know this fixes the issue? After all, the fact that this code block is being run before the editor is visible seems like it’s a bug in itself!

Perhaps so, but

* we know that this code path will run at least once more — in Etch, it would be very unlikely for this editor to go from hidden to visible without going through the `updateSync` code path
* hence if we’re hitting `updateSync` when the editor is not yet visible, it’s safe to assume that there will be later trip through the same code path, hence another opportunity to measure the block decorations when they will be more accurate
* in this particular case, introducing this conditional made the issue impossible to reproduce (for me)

### Alternate Designs

This was the only fix I could think of that didn’t involve doing a deep dive into the exact timing of editors being hidden and shown as a result of changing tabs in a workspace pane.

### Possible Drawbacks

I can’t think of any. Any scenarios that could be affected negatively by this code change are scenarios in which this bug was already manifesting. At worst it’s a lateral move!

### Verification Process

My [comment linked above](https://github.com/pulsar-edit/github/issues/40#issuecomment-1870658494) illustrates one way I was able to trigger this bug. I can attest that those instructions didn’t reproduce the bug anymore once this fix was applied. But I advise you to try it on your own.

### Release Notes

Fix a measurement issue that was causing visual glitches in the `github` package’s diff views.