### PR TITLE
[settings-view] Use new `owner` query parameter instead of old `users` endpoint

### DIFF
--- a/packages/settings-view/lib/package-card.js
+++ b/packages/settings-view/lib/package-card.js
@@ -242,7 +242,7 @@ export default class PackageCard {
 
     const packageAuthorClickHandler = (event) => {
       event.stopPropagation()
-      shell.openExternal(`https://web.pulsar-edit.dev/users/${ownerFromRepository(this.pack.repository)}`) //TODO: Fix - This does not current exist but this will at least be more accurate
+      shell.openExternal(`https://web.pulsar-edit.dev/packages?owner=${ownerFromRepository(this.pack.repository)}`)
     }
     this.refs.loginLink.addEventListener('click', packageAuthorClickHandler)
     this.disposables.add(new Disposable(() => { this.refs.loginLink.removeEventListener('click', packageAuthorClickHandler) }))


### PR DESCRIPTION
This PR builds off of @savetheclocktower's hard work on [`pulsar-edit/package-backend#215`](https://github.com/pulsar-edit/package-backend/pull/215) which allows us to filter owners of package's via query parameter.

So this PR ensures when we link to a code owner, instead of going to their user page, we instead go to the packages page with the proper query parameter set.