### PR TITLE
CI: build Linux x86-64 binaries on older Linux

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,11 +24,19 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ ubuntu-20.04, windows-latest, macos-latest ]
+        os: [ ubuntu-latest, macos-latest, windows-latest ]
+        include:
+          - os: ubuntu-latest
+            image: "debian:10"
       fail-fast: false
     runs-on: ${{ matrix.os }}
+    container: ${{ matrix.image }}
 
     steps:
+    - name: Install build dependencies - Linux
+      if: ${{ runner.os == 'Linux' }}
+      run: apt-get update && apt-get install -y git python3 python3-pip make gcc g++ libx11-dev libxkbfile-dev pkg-config libsecret-1-dev rpm xvfb ffmpeg zstd
+
     - name: Checkout the latest code
       uses: actions/checkout@v3
 
@@ -38,6 +46,7 @@ jobs:
         node-version: ${{ env.NODE_VERSION }}
 
     - name: Setup Python
+      if: ${{ runner.os != 'Linux' }}
       uses: actions/setup-python@v4
       with:
         python-version: ${{ env.PYTHON_VERSION }}
@@ -48,8 +57,20 @@ jobs:
       # out of the box. 'setuptools' package provides 'distutils'.
       run: python3 -m pip install setuptools
 
+    - name: Install Yarn - Linux
+      if: ${{ runner.os == 'Linux' }}
+      run: npm install -g yarn
+
     - name: Setup Git Submodule
+      if: ${{ runner.os != 'Linux' }}
       run: |
+        git submodule init
+        git submodule update
+
+    - name: Setup Git Submodule - Linux
+      if: ${{ runner.os == 'Linux' }}
+      run: |
+        git config --global --add safe.directory /__w/pulsar/pulsar
         git submodule init
         git submodule update
 
@@ -85,6 +106,15 @@ jobs:
         command: |
           yarn build
           yarn run build:apm
+
+    - name: Cache Pulsar dependencies - Linux
+      if: ${{ runner.os == 'Linux' }}
+      uses: actions/cache/save@v3
+      with:
+        path: |
+          node_modules
+          packages
+        key: Linux-dependencies-${{ github.sha }}-${{ github.workflow }}
 
     # macOS Signing Stuff
     - name: Build Pulsar Binaries (macOS) (Signed)
@@ -135,20 +165,18 @@ jobs:
       if: ${{ runner.os == 'Windows' }}
       run: node ./script/rename.js "Windows"
 
+    - name: Cache Pulsar Binaries - Linux
+      if: ${{ runner.os == 'Linux' }}
+      uses: actions/cache/save@v3
+      with:
+        path: ./binaries
+        key: pulsar-Linux-Binaries-${{ github.sha }}-${{ github.workflow }}
+
     - name: Upload Binary Artifacts
       uses: actions/upload-artifact@v3
       with:
         name: ${{ matrix.os }} Binaries
         path: ./binaries/*
-
-    - name: Test Binary - Linux
-      if: ${{ (runner.os == 'Linux') && env.RUN_LINUX_VT }}
-      run: |
-        rm -R node_modules/electron; yarn install --check-files
-        ./binaries/*AppImage --appimage-extract
-        export BINARY_NAME='squashfs-root/pulsar'
-        mkdir -p ./tests/videos
-        Xvfb -screen 0 1024x768x24+32 :99 & nohup ffmpeg -video_size 1024x768 -f x11grab -i :99.0 ./tests/videos/out.mpg & DISPLAY=:99 PLAYWRIGHT_JUNIT_OUTPUT_NAME=report.xml npx playwright test --reporter=junit,list
 
     - name: Test Binary - Windows
       if: runner.os == 'Windows' && env.RUN_WINDOWS_VT == true
@@ -168,7 +196,7 @@ jobs:
         PLAYWRIGHT_JUNIT_OUTPUT_NAME=report.xml arch -x86_64 npx playwright test --reporter=junit,list
 
     - name: Add binaries to Rolling Release Repo
-      if: ${{ github.event_name == 'push' }}
+      if: ${{ github.event_name == 'push' && runner.os != 'Linux' }}
       # We only want to upload rolling binaries if they are a commit to master
       # Otherwise we want to not upload if it's a PR or manually triggered build
       run: |
@@ -177,6 +205,62 @@ jobs:
         node ./rolling-release-binary-upload.js
 
     - name: Upload Video Artifacts
+      if: runner.os != 'Linux'
+      uses: actions/upload-artifact@v3
+      with:
+        name: ${{ matrix.os }} Videos
+        path: ./tests/videos/**
+
+
+  test-and-upload-Linux:
+    runs-on: ubuntu-latest
+    needs: build
+
+    steps:
+    - name: Checkout the latest code
+      uses: actions/checkout@v3
+
+    - name: Setup Node
+      uses: actions/setup-node@v3
+      with:
+        node-version: ${{ env.NODE_VERSION }}
+
+    - name: Restore Cached Pulsar Binaries - Linux
+      if: ${{ runner.os == 'Linux' }}
+      uses: actions/cache/restore@v3
+      with:
+        path: ./binaries
+        key: pulsar-Linux-Binaries-${{ github.sha }}-${{ github.workflow }}
+
+    - name: Restore Cached Pulsar dependencies - Linux
+      if: ${{ runner.os == 'Linux' }}
+      uses: actions/cache/restore@v3
+      with:
+        path: |
+          node_modules
+          packages
+        key: Linux-dependencies-${{ github.sha }}-${{ github.workflow }}
+
+    - name: Test Binary - Linux
+      if: ${{ (runner.os == 'Linux') && env.RUN_LINUX_VT }}
+      run: |
+        rm -R node_modules/electron; yarn install --check-files
+        ./binaries/*AppImage --appimage-extract
+        export BINARY_NAME='squashfs-root/pulsar'
+        mkdir -p ./tests/videos
+        Xvfb -screen 0 1024x768x24+32 :99 & nohup ffmpeg -video_size 1024x768 -f x11grab -i :99.0 ./tests/videos/out.mpg & DISPLAY=:99 PLAYWRIGHT_JUNIT_OUTPUT_NAME=report.xml npx playwright test --reporter=junit,list
+
+    - name: Add binaries to Rolling Release Repo - Linux
+      if: ${{ github.event_name == 'push' && runner.os == 'Linux' }}
+      # We only want to upload rolling binaries if they are a commit to master
+      # Otherwise we want to not upload if it's a PR or manually triggered build
+      run: |
+        cd ./script/rolling-release-scripts
+        npm install
+        node ./rolling-release-binary-upload.js
+
+    - name: Upload Video Artifacts - Linux
+      if: runner.os == 'Linux'
       uses: actions/upload-artifact@v3
       with:
         name: ${{ matrix.os }} Videos

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,6 +46,9 @@ jobs:
         node-version: ${{ env.NODE_VERSION }}
 
     - name: Setup Python
+      # actions/setup-python's copy of Python is compiled for too new glibc,
+      # which won't work in a Debian 10 Docker image.
+      # Get Python from apt repos instead on Linux.
       if: ${{ runner.os != 'Linux' }}
       uses: actions/setup-python@v4
       with:
@@ -213,6 +216,10 @@ jobs:
 
 
   test-and-upload-Linux:
+    # I couldn't figure out how to get these visual tests to actually run in the
+    # Debian Docker environment. If anyone can make it work, feel free to
+    # re-combine visual testing on Linux back into the main build job above!
+    # - DeeDeeG
     runs-on: ubuntu-latest
     needs: build
 


### PR DESCRIPTION
### Issue or RFC Endorsed by Atom's Maintainers

<!--

Link to the issue or RFC that your change relates to. This must be one of the following:

* An open issue with the `help-wanted` label
* An open issue with the `triaged` label
* An RFC with "accepted" status

To contribute an enhancement that isn't covered by one of the items above, please follow our guide for suggesting an enhancement: https://github.com/atom/.github/blob/master/CONTRIBUTING.md#suggesting-enhancements

To contribute other changes, you must use a different template. You can see all templates at https://github.com/atom/.github/tree/master/.github/PULL_REQUEST_TEMPLATE.

-->

Resolves https://github.com/pulsar-edit/pulsar/issues/733
Resolves https://github.com/pulsar-edit/pulsar/issues/747

### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

**Short summary:** Build Pulsar's Linux x86-64 binaries on an older version of Linux, in a Docker container. Appears to allow older Linux distros (with older glibc) to run Pulsar.

**Details:**

This gets us building against older glibc, which is forward-compatible with modern distros (great) but also compatible with contemporaneous distris from when that older glibc was the latest (notably: older Red Hat Enterprise Linux and RHEL-alike distros, which have very long support windows and don't update their glibc within a major distro version.) This compatibility with RHEL-alike distros is the main purpose of this PR. Since those are the uswers who were asking for it. Should also help with Debian 10 users, etc. See the above-linked issues for context and the requests from users for this change.

I also added a _separate_ job that waits for the build job to finish, that will _extract and test_ the built Linux binaries in a normal `ubuntu-latest` GitHub Actions runner environment (that is: outside of any Docker container). I wasn't able to get the tests to run in the Debian 10 Docker container (playwright couldn't successfully launch Pulsar in the Docker container -- ???), so this added complexity is the cost of still doing the integration (visual editor) tests on Linux. 

(Tangent: Since the macOS visual editor tests may or may not even be running, I think this is the only way we run the visual tests at all. I like the visual tests! We should keep running them. I wish I could figure out how to do so in Docker, but it wasn't working for me. I'm not sure whether Playwright has ever played nice with Debian 10 or Docker, since Debian 11 support was the first time Playwright's release notes mentioned any deliberate Debian support. Oh, well.) 

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

Could build on an even _older_ Linux distro, for compatiblity with such _older_ distros, but I would rather keep it to fully first-party officially supported distros, personally. It's easier for us to deal with distros, during _our_ build, which are fully supported, than mess around with separate LTS infrastructure you have to opt-into. See this discussion for some context and my thoughts when asked about building for _even older_ Debian: https://github.com/pulsar-edit/pulsar/issues/733#issuecomment-1766739333

On another note: I would really like to run the tests in the same Docker container the binaries are built on. So we don't need _two_ separate jobs just to build (1) and test (2) the Linux binaries. But I couldn't get testing working within the Docker container (job 1) so I needed a second job (job 2) outside the Docker container.

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

I don't feel qualified to assess what building on older distros would do for the binary -- maybe slightly less optimization in the native C/C++ code, due to older glibc and older compiler stack? But we're a mostly JS stack, so unclear how much this would even matter if true.

I expect any difference would not be noticeable to end-users. Could be wrong, honestly.

### Verification Process

<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (including buttons you clicked, text you typed, commands you ran, etc.), and describe the results you observed.

-->

Folks on older distros tested binaries generated this way, and it worked for them:
- https://github.com/pulsar-edit/pulsar/issues/733#issuecomment-1728645942
- https://github.com/pulsar-edit/pulsar/issues/733#issuecomment-1764766927

Also basically works fine for me on a current Ubuntu-based distro (Linux Mint 21, based on Ubuntu 22.04).

### Release Notes

<!--

Please describe the changes in a single line that explains this improvement in
terms that a user can understand. This text will be used in Atom's release notes.

If this change is not user-facing or notable enough to be included in release notes
you may use the strings "Not applicable" or "N/A" here.

Examples:

- The GitHub package now allows you to add co-authors to commits.
- Fixed an issue where multiple cursors did not work in a file with a single line.
- Increased the performance of searching and replacing across a whole project.

-->

Build Linux binaries on Debian 10, for older glibc and compatibility with older Linux distros