### PR TITLE
fix(tree-sitter): pass node text to grammar

### DIFF
--- a/src/scope-resolver.js
+++ b/src/scope-resolver.js
@@ -496,7 +496,10 @@ class ScopeResolver {
       return false;
     }
 
-    let id = this.idForScope(name);
+    let id = this.idForScope(
+        name,
+        node.childCount === 0 ? node.text : undefined,
+    );
 
     let {
       startPosition: start,

--- a/src/tree-sitter-grammar.js
+++ b/src/tree-sitter-grammar.js
@@ -70,7 +70,9 @@ module.exports = class TreeSitterGrammar {
     return `TreeSitterGrammar {scopeName: ${this.scopeName}}`;
   }
 
-  idForScope(scopeName) {
+  // Though _text is unused here, some packages (eg semanticolor) use it to
+  // customize scopes on the fly.
+  idForScope(scopeName, _text) {
     if (!scopeName) {
       return undefined;
     }

--- a/src/wasm-tree-sitter-grammar.js
+++ b/src/wasm-tree-sitter-grammar.js
@@ -55,7 +55,9 @@ module.exports = class WASMTreeSitterGrammar {
     }
   }
 
-  idForScope(scopeName) {
+  // Though _text is unused here, some packages (eg semanticolor) use it to
+  // customize scopes on the fly.
+  idForScope(scopeName, _text) {
     if (!scopeName) { return undefined; }
     let id = this.idsByScope[scopeName];
     if (!id) {

--- a/src/wasm-tree-sitter-language-mode.js
+++ b/src/wasm-tree-sitter-language-mode.js
@@ -492,8 +492,8 @@ class WASMTreeSitterLanguageMode {
     return this.grammar.scopeNameForScopeId(scopeId);
   }
 
-  idForScope(name) {
-    return this.grammar.idForScope(name);
+  idForScope(name, text) {
+    return this.grammar.idForScope(name, text);
   }
 
   // Behaves like `scopeDescriptorForPosition`, but returns a list of
@@ -2999,7 +2999,7 @@ class LanguageLayer {
       this.tree = null;
       this.scopeResolver = new ScopeResolver(
         this,
-        (name) => this.languageMode.idForScope(name)
+        (name, text) => this.languageMode.idForScope(name, text)
       );
       this.foldResolver = new FoldResolver(this.buffer, this);
 


### PR DESCRIPTION
### Identify the Bug

The WASM tree-sitter language mode does not pass node text into the grammar when calling `idForScope`. This is a breaking change from the legacy tree-sitter language mode that prevents the semanticolor package from working with Pulsar's new tree-sitter modes. I believe that this only affects semanticolor, as the original change was made explicitly for that package. (See https://github.com/atom/atom/pull/20212)

#### References
- The original commit adding support in legacy grammars: 97b905a2b054c372252a6646e5649eb487487b36
- The original PR: https://github.com/atom/atom/pull/20212
- The code in the legacy mode that passes the node text: https://github.com/pulsar-edit/pulsar/blob/master/src/tree-sitter-language-mode.js#L1321-L1324
- The code in semanticolor that monkey patches `idForScope` and makes use of the text: https://github.com/digitallyserviced/semanticolor/blob/master/lib/semanticolor-grammar.js#L44-L65


### Description of the Change

I updated `ScopeResolver` and `WASMTreeSitterLanguageMode` to pass the syntax node text through to  `WASMTreeSitterGrammar`. I also updated `WASMTreeSitterGrammar` *and* `TreeSitterGrammar` to highlight why the seemingly unused parameter is needed. Once I identified what was needed, the change was easy.

### Alternate Designs

I looked around to see if there was a better way of getting the package working w/ the new mode, but didn't see anything obvious. Open to suggestions if there are other ways that I didn't see.

### Possible Drawbacks

It is a little strange to make a change like this only to support a single package. That said, I *love* that package and I'm happy to be able to keep it going.

### Verification Process

I did not add or update any tests, but I could attempt to do so if desired. I verified this by 
1. making this change in Pulsar
2. making another small change in `semanticolor` so that it recognizes `WASMTreeSitterGrammar`s, in addition to legacy grammars
3. loading a dev window and confirming that colors were applied in a modern tree-sitter grammar

### Release Notes

Added support for the semanticolor package in modern tree-sitter grammars.