### PR TITLE
[symbols-view] Fix issue with returning from a declaration

### DIFF
--- a/packages/symbols-view/lib/go-back-view.js
+++ b/packages/symbols-view/lib/go-back-view.js
@@ -3,7 +3,7 @@ const SymbolsView = require('./symbols-view');
 
 // TODO: Does this really need to extend SymbolsView?
 module.exports = class GoBackView extends SymbolsView {
-  toggle () {
+  toggle() {
     let previous = this.stack.pop();
     if (!previous) return;
 
@@ -23,7 +23,7 @@ module.exports = class GoBackView extends SymbolsView {
       // The editor is not there anymore; e.g., a package like `zentabs` might
       // have automatically closed it when a new editor view was opened. So we
       // should restore it if we can.
-      atom.workspace.open(previous).then(restorePosition);
+      atom.workspace.open(previous.file).then(restorePosition);
     }
   }
 }


### PR DESCRIPTION
### Identify the Bug

The `symbols-view:return-from-declaration` command will go haywire if it’s trying to return to a file that has been closed. I introduced this bug as a regression when I rewrote `symbols-view`.

### Description of the Change

A very quick fix.

### Alternate Designs

Nope.

### Possible Drawbacks

None. _Fewer_ errors are good!

### Verification Process

You can verify that the new tests pass. If you _really_ want bonus points, you can also verify this manually:

* Have a provider of project-wide symbols. You can install `pulsar-ide-typescript-alpha` or generate a `.tags` file so that `symbol-provider-ctags` can provide project-wide symbols. (The first one is easier.)
* Run **Symbols View: Go To Declaration** on a symbol defined in another file.
* When the new file is active, close the tab for the original file.
* Run **Symbols View: Return From Declaration**.

### Release Notes

Fix an issue in `symbols-view` when returning from visiting a symbol declaration.