### PR TITLE
[language-go] Add missing keywords:

### DIFF
--- a/packages/language-go/grammars/tree-sitter-go/highlights.scm
+++ b/packages/language-go/grammars/tree-sitter-go/highlights.scm
@@ -47,6 +47,8 @@
 
 [
   "struct"
+  "interface"
+  "map"
 ] @storage.type._TYPE_.go
 
 (struct_type
@@ -62,6 +64,7 @@
 [
   "break"
   "case"
+  "chan"
   "continue"
   "default"
   "defer"


### PR DESCRIPTION
This PR adds a couple of missing keywords for Go's modern tree-sitter implementation. The modified items are:

- `interface`: Added to `@storage.type._TYPE_.go`, same as `struct`
- `map`: Added to `@storage.type._TYPE_.go`, same as `struct`
- `chan`: Added to `@keyword.control._TYPE_.go`, along with other reserved keywords.

I also noticed the compiled grammar seems outdated. Using the [tree-sitter-tools](https://web.pulsar-edit.dev/packages/tree-sitter-tools) package, I was able to see errors when parsing [type parameters](https://go.dev/blog/intro-generics).

![image](https://github.com/pulsar-edit/pulsar/assets/48367298/c3d358a3-a8f9-40a8-896a-0a9103e19554)

If the `.wasm` shipped by the language package is compiled from the tree-sitter reference implementation, I can also add an updated version to this PR.