### PR TITLE
Update copyright year to 2024

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022-2023 Pulsar-Edit
+Copyright (c) 2022-2024 Pulsar-Edit
 Original work copyright (c) 2011-2022 GitHub Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy


### PR DESCRIPTION
Updates the copyright year to 2024. 

Just to mention there are a number of bundled packages with 2022 and 2023 copyright dates. I wasn't planning on updating those as really the overarching root licence file should deal with those. Or do we think these should be updated too? There are plenty of 2022 bundled package licences we didn't bump to 2023.

In particular the two 2023 ones are `symbol-provider-ctags` and `symbol-provider-tree-sitter` - the latter of which is currently marked as "Copyright (c) 2023 Andrew Dupont" - @savetheclocktower do you wish for this to be bumped or have Pulsar-Edit added?
