### PR TITLE
Fix issue with Markdown rendering after line break in strict mode

### DIFF
--- a/src/ui.js
+++ b/src/ui.js
@@ -292,8 +292,8 @@ function renderMarkdown(content, givenOpts = {}) {
         if (match) {
           // We define breakline as a custom Token Type
           let token = state.push("html_inline", "breakline", 0);
-          token.content = "<br/>";
-          state.pos += "<br/>".length;
+          token.content = "<br>";
+          state.pos += match[0].length;
           return true;
         }
       }


### PR DESCRIPTION
### Identify the Bug

I noticed this text in the core settings:

<img width="492" alt="Screenshot 2024-01-22 at 11 51 13 AM" src="https://github.com/pulsar-edit/pulsar/assets/3450/b32218d8-8fb7-4881-8b46-323c4389b297">

But the text is correct in the config schema, so what's going on?

I'll distill it for you:

```js
atom.ui.markdown.render(`profile.<br>Changing`);
//-> "<p>profile.<br>Changing</p>\n"

atom.ui.markdown.render(`profile.<br>Changing`, { disableMode: 'strict' });
//-> "<p>profile.<br>hanging</p>\n"
```

### Description of the Change

I don't know enough about why this callback is in place, but I assume the reasoning is sound. Nonetheless, we're advancing a fixed number of characters in the parser when consuming it, even though the matched line break can be of variable width (`<br>`, `<br />`, etc.).

### Alternate Designs

I did not think about this for long enough to consider alternate designs.

### Possible Drawbacks

I might have misinterpreted this code, though it certainly does seem to fix the problem.

I also took the liberty of changing the token content from `<br/>` to `<br>`, since the former is invalid HTML (you'd need a space before the closing slash) and we're way past the XHTML days. But as far as I can tell, this makes no difference to the parser output anyway.

### Verification Process

Run the example code from above in the console. It should do the wrong thing on `master` and the right thing on this PR branch. Also, the setting in question (in Core) should render correctly.

### Release Notes

- Fixed a rendering error in `atom.ui.markdown.render` when `disableMode` was set to `"strict"` and the input contained HTML line breaks.