### PR TITLE
Update README badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 [![Badge Discussions]][Discussions]  
 [![Badge Discord]][Discord]  
 [![Badge Reddit]][Reddit]
+[![Badge Mastodon]][Mastodon]
+[![Badge Lemmy]][Lemmy]
 
 [![Badge Status]][Status]  
 [![Badge License]][License]
@@ -51,6 +53,8 @@
 [Status]: https://cirrus-ci.com/github/pulsar-edit/pulsar/master
 [Codacy]: https://app.codacy.com/gh/pulsar-edit/pulsar
 [Reddit]: https://www.reddit.com/r/pulsaredit/
+[Mastodon]: https://fosstodon.org/@pulsaredit/
+[Lemmy]: https://lemmy.ml/c/pulsaredit/
 
 [#]: #
 
@@ -72,14 +76,18 @@
 <!---------------------------{ Badges }--------------------------->
 
 [Badge OpenCollective]: https://opencollective.com/pulsar-edit/tiers/badge.svg
-[Badge Discussions]: https://img.shields.io/github/discussions/pulsar-edit/.github?style=for-the-badge&labelColor=78af9f&color=5a8377
+[Badge Discussions]: https://img.shields.io/github/discussions/pulsar-edit/.github?style=for-the-badge&logo=GitHub&labelColor=78af9f&color=5a8377
 [Badge Upstream]: https://img.shields.io/badge/Upstream_Status-Sunset-966227.svg?style=for-the-badge&labelColor=c38033
 [Badge Discord]: https://img.shields.io/badge/Discord-4b7494.svg?style=for-the-badge&labelColor=6399c4&logoColor=white&logo=Discord
 [Badge License]: https://img.shields.io/badge/License-MIT-ac7f31.svg?style=for-the-badge&labelColor=e5ab42
 [Badge Crowdin]: https://badges.crowdin.net/pulsar-edit/localized.svg
 [Badge Codacy]: https://app.codacy.com/project/badge/Grade/24873ecb93dc4c1d865202ce5b24efc1
-[Badge Reddit]: https://img.shields.io/reddit/subreddit-subscribers/pulsaredit?style=for-the-badge&label=Reddit&logoColor=white&logo=Reddit&labelColor=e05d44&color=b14835
+<!-- Reddit subscribers badge broken. See: https://github.com/badges/shields/issues/9817 & https://github.com/badges/shields/issues/9256 -->
+<!-- [Badge Reddit]: https://img.shields.io/reddit/subreddit-subscribers/pulsaredit?style=for-the-badge&label=Reddit&logoColor=white&logo=Reddit&labelColor=e05d44&color=b14835 -->
+[Badge Reddit]: https://img.shields.io/badge/%2Fr%2Fpulsaredit-e05d44?style=for-the-badge&logo=Reddit&logoColor=white&labelColor=e05d44&color=b14835
 [Badge Status]: https://img.shields.io/cirrus/github/pulsar-edit/pulsar?style=for-the-badge&labelColor=c77b7f&label=Build%20Status&color=8d575a
+[Badge Mastodon]: https://img.shields.io/mastodon/follow/109416671848539153?domain=https%3A%2F%2Ffosstodon.org%2F&style=for-the-badge&logo=Mastodon&logoColor=white&label=Mastodon&labelColor=9292fc&color=6364FF
+[Badge Lemmy]: https://img.shields.io/lemmy/pulsaredit%40lemmy.ml?style=for-the-badge&logo=Lemmy&logoColor=white&label=Lemmy&labelColor=64ad82&color=00A846
 
 
 <!--------------------------{ Buttons }--------------------------->

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@
 <!---------------------------{ Badges }--------------------------->
 
 [Badge OpenCollective]: https://opencollective.com/pulsar-edit/tiers/badge.svg
-[Badge Discussions]: https://img.shields.io/github/discussions/pulsar-edit/.github?style=for-the-badge&logo=GitHub&labelColor=78af9f&color=5a8377
+[Badge Discussions]: https://img.shields.io/github/discussions/pulsar-edit/.github?style=for-the-badge&logo=GitHub&labelColor=50555b&color=35393d
 [Badge Upstream]: https://img.shields.io/badge/Upstream_Status-Sunset-966227.svg?style=for-the-badge&labelColor=c38033
 [Badge Discord]: https://img.shields.io/badge/Discord-4b7494.svg?style=for-the-badge&labelColor=6399c4&logoColor=white&logo=Discord
 [Badge License]: https://img.shields.io/badge/License-MIT-ac7f31.svg?style=for-the-badge&labelColor=e5ab42
@@ -86,8 +86,8 @@
 <!-- [Badge Reddit]: https://img.shields.io/reddit/subreddit-subscribers/pulsaredit?style=for-the-badge&label=Reddit&logoColor=white&logo=Reddit&labelColor=e05d44&color=b14835 -->
 [Badge Reddit]: https://img.shields.io/badge/%2Fr%2Fpulsaredit-e05d44?style=for-the-badge&logo=Reddit&logoColor=white&labelColor=e05d44&color=b14835
 [Badge Status]: https://img.shields.io/cirrus/github/pulsar-edit/pulsar?style=for-the-badge&labelColor=c77b7f&label=Build%20Status&color=8d575a
-[Badge Mastodon]: https://img.shields.io/mastodon/follow/109416671848539153?domain=https%3A%2F%2Ffosstodon.org%2F&style=for-the-badge&logo=Mastodon&logoColor=white&label=Mastodon&labelColor=9292fc&color=6364FF
-[Badge Lemmy]: https://img.shields.io/lemmy/pulsaredit%40lemmy.ml?style=for-the-badge&logo=Lemmy&logoColor=white&label=Lemmy&labelColor=64ad82&color=00A846
+[Badge Mastodon]: https://img.shields.io/mastodon/follow/109416671848539153?domain=https%3A%2F%2Ffosstodon.org%2F&style=for-the-badge&logo=Mastodon&logoColor=white&label=Mastodon&labelColor=a0a0d8&color=7c7cc1
+[Badge Lemmy]: https://img.shields.io/lemmy/pulsaredit%40lemmy.ml?style=for-the-badge&logo=Lemmy&logoColor=white&label=Lemmy&labelColor=64ad82&color=1d9b52
 
 
 <!--------------------------{ Buttons }--------------------------->

--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@
 
 [![Badge Discussions]][Discussions]  
 [![Badge Discord]][Discord]  
-[![Badge Reddit]][Reddit]
-[![Badge Mastodon]][Mastodon]
-[![Badge Lemmy]][Lemmy]
+[![Badge Reddit]][Reddit]  
+[![Badge Mastodon]][Mastodon]  
+[![Badge Lemmy]][Lemmy]  
 
 [![Badge Status]][Status]  
 [![Badge License]][License]


### PR DESCRIPTION
Changes:
- Adds Mastodon badge w/ followers
- Adds Lemmy community badge w/ subscribers
- Updates Reddit badge to static - currently broken saying "Subreddit is private" - see https://github.com/badges/shields/issues/9817 & https://github.com/badges/shields/issues/9256
- Changes Discussions badge colour to something more "GitHub-y"
- Adds GitHub logo to Discussions badge