### PR TITLE
CI: Fix tag Linux binaries are uploaded to for Rolling

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,6 +31,8 @@ jobs:
       fail-fast: false
     runs-on: ${{ matrix.os }}
     container: ${{ matrix.image }}
+    outputs:
+      timestamp: ${{ steps.linux-binary-version.outputs.timestamp }}
 
     steps:
     - name: Install build dependencies - Linux
@@ -76,6 +78,13 @@ jobs:
         git config --global --add safe.directory /__w/pulsar/pulsar
         git submodule init
         git submodule update
+
+    - name: Set Timestamp for Binary Version - Linux
+      id: linux-binary-version
+      if: ${{ runner.os == 'Linux' }}
+      # This output is currently only set for the sake of the Rolling binary upload script.
+      # See the "test-and-upload-Linux" job below.
+      run: echo "timestamp=`date -u +%Y%m%d%H`" >> "$GITHUB_OUTPUT"
 
     - name: Check Pulsar Version
       if: ${{ runner.os != 'Windows' }}
@@ -256,6 +265,12 @@ jobs:
         export BINARY_NAME='squashfs-root/pulsar'
         mkdir -p ./tests/videos
         Xvfb -screen 0 1024x768x24+32 :99 & nohup ffmpeg -video_size 1024x768 -f x11grab -i :99.0 ./tests/videos/out.mpg & DISPLAY=:99 PLAYWRIGHT_JUNIT_OUTPUT_NAME=report.xml npx playwright test --reporter=junit,list
+
+    - name: Check Pulsar Version
+      if: ${{ runner.os != 'Windows' }}
+      run: sed -i -e "s/[0-9]*-dev/${TIMESTAMP}/g" package.json
+      env:
+        TIMESTAMP: ${{needs.build.outputs.timestamp}}
 
     - name: Add binaries to Rolling Release Repo - Linux
       if: ${{ github.event_name == 'push' && runner.os == 'Linux' }}


### PR DESCRIPTION
### Identify the Bug

<!--

Link to the issue describing the bug that you're fixing.

If there is not yet an issue for your bug, please open a new issue and then link to that issue in your pull request.
Note: In some cases, one person's "bug" is another person's "feature." If the pull request does not address an existing issue with the "bug" label, the maintainers have the final say on whether the current behavior is a bug.

-->

Linux binaries are getting uploaded to the wrong tag/release name, such as [`1.113.0-dev`](https://github.com/pulsar-edit/pulsar-rolling-releases/releases/tag/v1.113.0-dev) instead of [`1.113.2024013003`](https://github.com/pulsar-edit/pulsar-rolling-releases/releases/tag/v1.113.2024013003) over at [the `pulsar-rolling-release` repo](https://github.com/pulsar-edit/pulsar-rolling-releases), since https://github.com/pulsar-edit/pulsar/pull/858 landed.

### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

The Rolling binary upload script gets the tag version from package.json in the repository files, not from the binary itself. So, we need to set this value in the repository's package.json file, regardless of what version the binary itself has.

The version string in package.json is used by the Rolling upload script to decide what the tag name will be when creating a new Rolling release. We want timestamped version strings and tag names, so that they are unique and older releases are not overwritten/clobbered/won't have conflicts (whichever would have happened, not worth finding out). Besides that this restores the convention we had been uploading the Rolling release tags with so far.

Set a version timestamp just before building the binaries, like on the other two platforms. Add this to the outputs of the "build" job if on Linux. Then read this output in the "test and upload, Linux" job. Now we have synced timestamps again (as much as we did before building Linux binaries in a Debian 10 Docker container, anyway).

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

The Rolling binary upload script could be updated to check the binary itself, but this way is easier.

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

Adds a little more to the workflow definition, which is getting a bit long, might be harder for a new contributor to read, or for existing contributors to catch up on if it's been a bit (especially if they haven't reviewed/seen https://github.com/pulsar-edit/pulsar/pull/858).

### Verification Process

<!--

What process did you follow to verify that the change has not introduced any regressions? Describe the actions you performed (including buttons you clicked, text you typed, commands you ran, etc.), and describe the results you observed.

-->

No YAML syntax error in CI, CI shouldn't complain running this PR, CI logs should look right.

Easiest to test if it's fully, properly working after landing this, but there should be good indications in CI that it's going according to plan.

~~_EDIT: Please do wait for me to do some verification of how it's looking from what we can see just in this PR. I'll be able to give it a closer look later when I get a free moment to do so. That'll give confidence this is going the right way and save the hassle of hotfixing it again if it needed it._~~

EDIT 2: Seems okay, see: https://github.com/pulsar-edit/pulsar/pull/901#issuecomment-1928799348.

### Release Notes

<!--

Please describe the changes in a single line that explains this improvement in
terms that a user can understand. This text will be used in Atom's release notes.

If this change is not user-facing or notable enough to be included in release notes
you may use the strings "Not applicable" or "N/A" here.

Examples:

- The GitHub package now allows you to add co-authors to commits.
- Fixed an issue where multiple cursors did not work in a file with a single line.
- Increased the performance of searching and replacing across a whole project.

-->

Fix the tag Linux binaries are uploaded to at the Rolling releases repo