### PR TITLE
Fix failing spec

### DIFF
--- a/spec/wasm-tree-sitter-language-mode-spec.js
+++ b/spec/wasm-tree-sitter-language-mode-spec.js
@@ -1696,6 +1696,10 @@ describe('WASMTreeSitterLanguageMode', () => {
 
   describe('.suggestedIndentForBufferRows', () => {
     it('works correctly when straddling an injection boundary', async () => {
+
+      atom.config.set('language-javascript.indentation.indentBraces', true);
+      atom.config.set('language-javascript.indentation.indentBrackets', true);
+      atom.config.set('language-javascript.indentation.indentParentheses', true);
       const jsGrammar = new WASMTreeSitterGrammar(atom.grammars, jsGrammarPath, jsConfig);
 
       jsGrammar.addInjectionPoint(HTML_TEMPLATE_LITERAL_INJECTION_POINT);

--- a/spec/wasm-tree-sitter-language-mode-spec.js
+++ b/spec/wasm-tree-sitter-language-mode-spec.js
@@ -1695,11 +1695,12 @@ describe('WASMTreeSitterLanguageMode', () => {
   });
 
   describe('.suggestedIndentForBufferRows', () => {
+    beforeEach(async () => {
+      await atom.packages.activatePackage('language-javascript');
+    })
+
     it('works correctly when straddling an injection boundary', async () => {
 
-      atom.config.set('language-javascript.indentation.indentBraces', true);
-      atom.config.set('language-javascript.indentation.indentBrackets', true);
-      atom.config.set('language-javascript.indentation.indentParentheses', true);
       const jsGrammar = new WASMTreeSitterGrammar(atom.grammars, jsGrammarPath, jsConfig);
 
       jsGrammar.addInjectionPoint(HTML_TEMPLATE_LITERAL_INJECTION_POINT);


### PR DESCRIPTION
No clue how this got through CI on the PR branch, but a spec is failing now solely because it is not inheriting a default value from a configuration. All that's needed is to explicitly set the defaults in the test, so that's what I've done.