### PR TITLE
script: Update version check in Rolling release binary upload script to exclude '-dev' versions

### DIFF
--- a/script/rolling-release-scripts/rolling-release-binary-upload.js
+++ b/script/rolling-release-scripts/rolling-release-binary-upload.js
@@ -9,8 +9,9 @@ const packageJson = require("../../package.json");
 // Since cirrus always triggers this script, we must check if the version is a rolling
 // release version
 const verSegments = packageJson.version.split(".");
+const lastVerSegment = verSegments[verSegments.length - 1];
 
-if (verSegments[verSegments.length - 1].length < 4) {
+if (lastVerSegment.length < 4 || lastVerSegment.includes('-dev')) {
   console.log(`According to our version: ${packageJson.version} this is not a rolling release...`);
   console.log("Exiting without changes...");
   process.exit(0);


### PR DESCRIPTION
### Identify the Bug

<!--

Link to the issue describing the bug that you're fixing.

If there is not yet an issue for your bug, please open a new issue and then link to that issue in your pull request.
Note: In some cases, one person's "bug" is another person's "feature." If the pull request does not address an existing issue with the "bug" label, the maintainers have the final say on whether the current behavior is a bug.

-->

The Rolling Release upload script trusts CI to either give it a clean Regular version, e.g. `v1.113.0`, or a long, timestamped, Rolling version, e.g. [`v1.113.2024013003`](https://github.com/pulsar-edit/pulsar-rolling-releases/releases/tag/v1.113.2024013003).

If someone (me) messes up the CI to where the version in `package.json` of the repo is somehow still e.g. `v1.113.0-dev` when the script is run (as I accidentally did in https://github.com/pulsar-edit/pulsar/pull/858), the upload script will attempt to upload a binary based on this not-Rolling-style version string, setting up a tag on the rolling release binaries repo that shouldn't be there, and which potentially keeps getting overwritten multiple times due to the aforementioned (hypothetical, but also presently real) CI screw up persisting on `master` branch and running again after each PR lands, which I may have hypothetically, but definitely did practically, cause with https://github.com/pulsar-edit/pulsar/pull/858.

### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

Teach the Rolling release binary upload script to recognize rogue "`-dev`" version strings that should not be uploaded, and not upload if those version strings are encountered (much like we already correctly do for well-formed _Regular_ release version strings).

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

Maybe I should actually have the script exit with exit code 1 to have CI error, since this isn't a situation we should be in, attempting to upload bins without a proper version number, which screws with our Rolling release repo.

Yeah, maybe I'll go do that instead. Gonna open this as draft, because I need sleep.

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

<!--

What process did you follow to verify that the change has not introduced any regressions? Describe the actions you performed (including buttons you clicked, text you typed, commands you ran, etc.), and describe the results you observed.

-->

Worked in local testing with a `v1.113.0-dev` version string.

Script now properly rejects this, instead of over-trustingly assuming it must be a proper Rolling version since "it's not short enough to be a Regular release version."

~~Any further verification is TBD.~~ Looks like it's working. See: https://github.com/pulsar-edit/pulsar/pull/903#issuecomment-1928839952

### Release Notes

<!--

Please describe the changes in a single line that explains this improvement in
terms that a user can understand. This text will be used in Atom's release notes.

If this change is not user-facing or notable enough to be included in release notes
you may use the strings "Not applicable" or "N/A" here.

Examples:

- The GitHub package now allows you to add co-authors to commits.
- Fixed an issue where multiple cursors did not work in a file with a single line.
- Increased the performance of searching and replacing across a whole project.

-->

Tweak Rolling release binary upload script to reject `-dev` version strings, as it should.