### PR TITLE
[settings-view] Don’t display heading anchor icons within a README

### DIFF
--- a/packages/settings-view/lib/package-readme-view.js
+++ b/packages/settings-view/lib/package-readme-view.js
@@ -25,8 +25,7 @@ export default class PackageReadmeView {
 
     const markdownOpts = {
       breaks: false,
-      taskCheckboxDisabled: true,
-      useGitHubHeadings: true
+      taskCheckboxDisabled: true
     };
 
     if (readmeIsLocal) {


### PR DESCRIPTION
### Identify the Bug

In the `settings-view` page for a package, when we convert a `README.md` to HTML, we are generating GitHub-style heading links, along with icons. We should not be doing this.

Here's why:

* Clicking on the anchor doesn't do anything in Pulsar.
* Typically these icons are displayed just to make it clear that a heading is linkable, and the user can right-click on the link and select “Copy Link URL” or something like that… but you can't do that in Pulsar, either. The context menu only offers you the commands for splitting the pane in each of four directions.

Hence they do nothing but clutter up the view.

### Description of the Change

A one-liner!

### Alternate Designs

Instead of doing this, I was almost lazy enough not to do this, which I suppose is a different kind of design decision.

### Possible Drawbacks

None. This change improves the world.

### Verification Process

An easy one: just look at the one-line change, trust that it does what I say it does, and click on an “Approve” button.

### Release Notes

- Refrain from rendering anchor icons when showing a package's README file in `settings-view`.
