### PR TITLE
[core] Emit an Event whenever a Grammar is AutoAssigned

### DIFF
--- a/src/grammar-registry.js
+++ b/src/grammar-registry.js
@@ -193,6 +193,10 @@ module.exports = class GrammarRegistry {
       buffer.getPath(),
       getGrammarSelectionContent(buffer)
     );
+
+    // Emit an event whenever a grammar is auto-assigned
+    this.emitter.emit("did-auto-assign-grammar", { grammar: result.grammar, buffer: buffer });
+
     this.languageOverridesByBufferId.delete(buffer.id);
     this.grammarScoresByBuffer.set(buffer, result.score);
     if (result.grammar !== buffer.getLanguageMode().grammar) {


### PR DESCRIPTION
This PR adds a new event that's emitted whenever the `GrammarRegistry` auto assigns a grammar to a file.

The event will contain the payload of:

```
{
  grammar
  buffer
}
```

This change is required for the feature I'm attempting to add to core that would allow auto-finding of packages to support unsupported file extensions.

But this event can be used to emit always, so that if there is some other potential use for this information other community packages can take advantage.