### PR TITLE
[core] Stop handling `beta`, `nightly`

### DIFF
--- a/src/atom-environment.js
+++ b/src/atom-environment.js
@@ -600,7 +600,7 @@ class AtomEnvironment {
   // Public: Gets the release channel of the Pulsar application.
   //
   // Returns the release channel as a {String}. Will return a specific release channel
-  // name like 'beta' or 'nightly' if one is found in the Pulsar version or 'stable'
+  // name like 'dev' if one is found in the Pulsar version or 'stable'
   // otherwise.
   getReleaseChannel() {
     return getReleaseChannel(this.getVersion());
@@ -608,7 +608,7 @@ class AtomEnvironment {
 
   // Public: Returns a {Boolean} that is `true` if the current version is an official release.
   isReleasedVersion() {
-    return this.getReleaseChannel().match(/stable|beta|nightly/) != null;
+    return this.getReleaseChannel().match(/stable|dev/) != null;
   }
 
   // Public: Get the time taken to completely load the current window.

--- a/src/command-installer.js
+++ b/src/command-installer.js
@@ -45,14 +45,12 @@ module.exports = class CommandInstaller {
   }
 
   getCommandNameForChannel(commandName) {
-    let channelMatch = this.appVersion.match(/beta|nightly/);
+    let channelMatch = this.appVersion.match(/dev/);
     let channel = channelMatch ? channelMatch[0] : '';
 
     switch (channel) {
-      case 'beta':
-        return `${commandName}-beta`;
-      case 'nightly':
-        return `${commandName}-nightly`;
+      case 'dev':
+        return `${commandName}-dev`;
       default:
         return commandName;
     }


### PR DESCRIPTION
This PR ended up being much simpler than expected.
But it's goal was remove any explicit handling of `beta` or `nightly` for Pulsar in reference to release channels.

Since Pulsar has not used that nomenclature for over a year, it seemed past due time.

In it's place, I have added `dev`, since for our dev instance of Pulsar that is what it's currently recognized as, which makes sense since that version is only accessible when literally in dev mode.

What may be worth mentioning is this change doesn't address the already non-existent distinction between `rolling` and `regular` release channels. But that wasn't handled previously so this is no change in that respect. Here we just remove what's become useless code.
