### PR TITLE
[core] Combine constant values 

### DIFF
--- a/src/atom-environment.js
+++ b/src/atom-environment.js
@@ -48,6 +48,7 @@ const StartupTime = require('./startup-time');
 const { getReleaseChannel } = require('./get-app-details.js');
 const UI = require('./ui.js');
 const packagejson = require("../package.json");
+const CONSTANTS = require("./pulsar-constants.js");
 
 const stat = util.promisify(fs.stat);
 
@@ -393,15 +394,15 @@ class AtomEnvironment {
   registerDefaultOpeners() {
     this.workspace.addOpener(uri => {
       switch (uri) {
-        case 'atom://.pulsar/stylesheet':
+        case CONSTANTS.STYLESHEET_PROTOCOL:
           return this.workspace.openTextFile(
             this.styles.getUserStyleSheetPath()
           );
-        case 'atom://.pulsar/keymap':
+        case CONSTANTS.KEYMAP_PROTOCOL:
           return this.workspace.openTextFile(this.keymaps.getUserKeymapPath());
-        case 'atom://.pulsar/config':
+        case CONSTANTS.CONFIG_PROTOCOL:
           return this.workspace.openTextFile(this.config.getUserConfigPath());
-        case 'atom://.pulsar/init-script':
+        case CONSTANTS.INIT_SCRIPT_PROTOCOL:
           return this.workspace.openTextFile(this.getUserInitScriptPath());
       }
     });

--- a/src/atom-environment.js
+++ b/src/atom-environment.js
@@ -394,15 +394,15 @@ class AtomEnvironment {
   registerDefaultOpeners() {
     this.workspace.addOpener(uri => {
       switch (uri) {
-        case CONSTANTS.STYLESHEET_PROTOCOL:
+        case CONSTANTS.STYLESHEET_URI:
           return this.workspace.openTextFile(
             this.styles.getUserStyleSheetPath()
           );
-        case CONSTANTS.KEYMAP_PROTOCOL:
+        case CONSTANTS.KEYMAP_URI:
           return this.workspace.openTextFile(this.keymaps.getUserKeymapPath());
-        case CONSTANTS.CONFIG_PROTOCOL:
+        case CONSTANTS.CONFIG_URI:
           return this.workspace.openTextFile(this.config.getUserConfigPath());
-        case CONSTANTS.INIT_SCRIPT_PROTOCOL:
+        case CONSTANTS.INIT_SCRIPT_URI:
           return this.workspace.openTextFile(this.getUserInitScriptPath());
       }
     });

--- a/src/atom-paths.js
+++ b/src/atom-paths.js
@@ -1,5 +1,6 @@
 const fs = require('fs-plus');
 const path = require('path');
+const CONSTANTS = require("./pulsar-constants.js");
 
 const hasWriteAccess = dir => {
   const testFilePath = path.join(dir, 'write.test');
@@ -28,7 +29,7 @@ const getAppDirectory = () => {
 module.exports = {
   setAtomHome: homePath => {
     // When a read-writeable .pulsar folder exists above app use that
-    const portableHomePath = path.join(getAppDirectory(), '..', '.pulsar');
+    const portableHomePath = path.join(getAppDirectory(), '..', CONSTANTS.DOT_FOLDER);
     if (fs.existsSync(portableHomePath)) {
       if (hasWriteAccess(portableHomePath)) {
         process.env.ATOM_HOME = portableHomePath;
@@ -46,7 +47,7 @@ module.exports = {
     }
 
     // Fall back to default .atom folder in users home folder
-    process.env.ATOM_HOME = path.join(homePath, '.pulsar');
+    process.env.ATOM_HOME = path.join(homePath, CONSTANTS.DOT_FOLDER);
   },
 
   setUserData: app => {

--- a/src/main-process/atom-application.js
+++ b/src/main-process/atom-application.js
@@ -31,6 +31,7 @@ const _ = require('underscore-plus');
 let FindParentDir = null;
 let Resolve = null;
 const ConfigSchema = require('../config-schema');
+const CONSTANTS = require("../pulsar-constants.js");
 
 const LocationSuffixRegExp = /(:\d+)(:\d+)?$/;
 
@@ -657,21 +658,21 @@ module.exports = class AtomApplication extends EventEmitter {
       });
     }
 
-    this.openPathOnEvent('application:about', 'atom://about');
-    this.openPathOnEvent('application:show-settings', 'atom://config');
-    this.openPathOnEvent('application:open-your-config', 'atom://.pulsar/config');
+    this.openPathOnEvent('application:about', CONSTANTS.ABOUT_UI_PROTOCOL);
+    this.openPathOnEvent('application:show-settings', CONSTANTS.CONFIG_UI_PROTOCOL);
+    this.openPathOnEvent('application:open-your-config', CONSTANTS.CONFIG_PROTOCOL);
     this.openPathOnEvent(
       'application:open-your-init-script',
-      'atom://.pulsar/init-script'
+      CONSTANTS.INIT_SCRIPT_PROTOCOL
     );
-    this.openPathOnEvent('application:open-your-keymap', 'atom://.pulsar/keymap');
+    this.openPathOnEvent('application:open-your-keymap', CONSTANTS.KEYMAP_PROTOCOL);
     this.openPathOnEvent(
       'application:open-your-snippets',
-      'atom://.pulsar/snippets'
+      CONSTANTS.SNIPPETS_PROTOCOL
     );
     this.openPathOnEvent(
       'application:open-your-stylesheet',
-      'atom://.pulsar/stylesheet'
+      CONSTANTS.STYLESHEET_PROTOCOL
     );
     this.openPathOnEvent(
       'application:open-license',
@@ -1527,7 +1528,7 @@ module.exports = class AtomApplication extends EventEmitter {
   //   :safeMode - Boolean to control the opened window's safe mode.
   openUrl({ urlToOpen, devMode, safeMode, env }) {
     const parsedUrl = url.parse(urlToOpen, true);
-    if (parsedUrl.protocol !== 'atom:') return;
+    if (parsedUrl.protocol !== CONSTANTS.PROTOCOL) return;
 
     const pack = this.findPackageWithName(parsedUrl.host, devMode);
     if (pack && pack.urlMain) {

--- a/src/main-process/atom-application.js
+++ b/src/main-process/atom-application.js
@@ -1528,7 +1528,7 @@ module.exports = class AtomApplication extends EventEmitter {
   //   :safeMode - Boolean to control the opened window's safe mode.
   openUrl({ urlToOpen, devMode, safeMode, env }) {
     const parsedUrl = url.parse(urlToOpen, true);
-    if (parsedUrl.protocol !== CONSTANTS.PROTOCOL) return;
+    if (parsedUrl.protocol !== CONSTANTS.PROTOCOL_COLON) return;
 
     const pack = this.findPackageWithName(parsedUrl.host, devMode);
     if (pack && pack.urlMain) {

--- a/src/main-process/atom-application.js
+++ b/src/main-process/atom-application.js
@@ -658,21 +658,21 @@ module.exports = class AtomApplication extends EventEmitter {
       });
     }
 
-    this.openPathOnEvent('application:about', CONSTANTS.ABOUT_UI_PROTOCOL);
-    this.openPathOnEvent('application:show-settings', CONSTANTS.CONFIG_UI_PROTOCOL);
-    this.openPathOnEvent('application:open-your-config', CONSTANTS.CONFIG_PROTOCOL);
+    this.openPathOnEvent('application:about', CONSTANTS.ABOUT_UI_URI);
+    this.openPathOnEvent('application:show-settings', CONSTANTS.CONFIG_UI_URI);
+    this.openPathOnEvent('application:open-your-config', CONSTANTS.CONFIG_URI);
     this.openPathOnEvent(
       'application:open-your-init-script',
-      CONSTANTS.INIT_SCRIPT_PROTOCOL
+      CONSTANTS.INIT_SCRIPT_URI
     );
-    this.openPathOnEvent('application:open-your-keymap', CONSTANTS.KEYMAP_PROTOCOL);
+    this.openPathOnEvent('application:open-your-keymap', CONSTANTS.KEYMAP_URI);
     this.openPathOnEvent(
       'application:open-your-snippets',
-      CONSTANTS.SNIPPETS_PROTOCOL
+      CONSTANTS.SNIPPETS_URI
     );
     this.openPathOnEvent(
       'application:open-your-stylesheet',
-      CONSTANTS.STYLESHEET_PROTOCOL
+      CONSTANTS.STYLESHEET_URI
     );
     this.openPathOnEvent(
       'application:open-license',

--- a/src/main-process/atom-protocol-handler.js
+++ b/src/main-process/atom-protocol-handler.js
@@ -1,6 +1,7 @@
 const { protocol } = require('electron');
 const fs = require('fs');
 const path = require('path');
+const CONSTANTS = require("../pulsar-constants.js");
 
 // Handles requests with 'atom' protocol.
 //
@@ -30,7 +31,7 @@ module.exports = class AtomProtocolHandler {
 
   // Creates the 'atom' custom protocol handler.
   registerAtomProtocol() {
-    protocol.registerFileProtocol('atom', (request, callback) => {
+    protocol.registerFileProtocol(CONSTANTS.PROTOCOL_NAME, (request, callback) => {
       const relativePath = path.normalize(request.url.substr(7));
 
       let filePath;

--- a/src/main-process/atom-protocol-handler.js
+++ b/src/main-process/atom-protocol-handler.js
@@ -31,7 +31,7 @@ module.exports = class AtomProtocolHandler {
 
   // Creates the 'atom' custom protocol handler.
   registerAtomProtocol() {
-    protocol.registerFileProtocol(CONSTANTS.PROTOCOL_NAME, (request, callback) => {
+    protocol.registerFileProtocol(CONSTANTS.PROTOCOL, (request, callback) => {
       const relativePath = path.normalize(request.url.substr(7));
 
       let filePath;

--- a/src/main-process/parse-command-line.js
+++ b/src/main-process/parse-command-line.js
@@ -3,6 +3,7 @@
 const dedent = require('dedent');
 const yargs = require('yargs');
 const { app } = require('electron');
+const CONSTANTS = require("../pulsar-constants.js");
 
 module.exports = function parseCommandLine(processArgs) {
   // macOS Gatekeeper adds a flag ("-psn_0_[six or seven digits here]") when it intercepts Pulsar launches.
@@ -28,7 +29,7 @@ module.exports = function parseCommandLine(processArgs) {
     A file may be opened at the desired line (and optionally column) by
     appending the numbers right after the file name, e.g. \`pulsar file:5:8\`.
 
-    Paths that start with \`atom://\` will be interpreted as URLs.
+    Paths that start with \`${CONSTANTS.PROTOCOL_PATH}\` will be interpreted as URLs.
 
     Environment Variables:
 
@@ -36,7 +37,7 @@ module.exports = function parseCommandLine(processArgs) {
                               Defaults to \`~/github/atom\`.
 
       ATOM_HOME               The root path for all configuration files and folders.
-                              Defaults to \`~/.pulsar\`.`
+                              Defaults to \`~/${CONSTANTS.DOT_FOLDER}\`.`
   );
   options
     .alias('d', 'dev')
@@ -76,7 +77,7 @@ module.exports = function parseCommandLine(processArgs) {
     .boolean('safe')
     .describe(
       'safe',
-      'Do not load packages from ~/.pulsar/packages or ~/.pulsar/dev/packages.'
+      `Do not load packages from ~/${CONSTANTS.DOT_FOLDER}/packages or ~/${CONSTANTS.DOT_FOLDER}/dev/packages.`
     );
   options
     .boolean('benchmark')
@@ -171,7 +172,7 @@ module.exports = function parseCommandLine(processArgs) {
     args = {
       uriHandler: true,
       'uri-handler': true,
-      _: args._.filter(str => str.startsWith('atom://')).slice(0, 1)
+      _: args._.filter(str => str.startsWith(CONSTANTS.PROTOCOL_PATH)).slice(0, 1)
     };
   }
 
@@ -219,7 +220,7 @@ module.exports = function parseCommandLine(processArgs) {
       // In the next block, .startsWith() only works on strings. So, skip non-string arguments.
       continue;
     }
-    if (path.startsWith('atom://')) {
+    if (path.startsWith(CONSTANTS.PROTOCOL_PATH)) {
       urlsToOpen.push(path);
     } else {
       pathsToOpen.push(path);

--- a/src/main-process/parse-command-line.js
+++ b/src/main-process/parse-command-line.js
@@ -29,7 +29,7 @@ module.exports = function parseCommandLine(processArgs) {
     A file may be opened at the desired line (and optionally column) by
     appending the numbers right after the file name, e.g. \`pulsar file:5:8\`.
 
-    Paths that start with \`${CONSTANTS.PROTOCOL_PATH}\` will be interpreted as URLs.
+    Paths that start with \`${CONSTANTS.PROTOCOL_COLON_SLASHES}\` will be interpreted as URLs.
 
     Environment Variables:
 
@@ -172,7 +172,7 @@ module.exports = function parseCommandLine(processArgs) {
     args = {
       uriHandler: true,
       'uri-handler': true,
-      _: args._.filter(str => str.startsWith(CONSTANTS.PROTOCOL_PATH)).slice(0, 1)
+      _: args._.filter(str => str.startsWith(CONSTANTS.PROTOCOL_COLON_SLASHES)).slice(0, 1)
     };
   }
 
@@ -220,7 +220,7 @@ module.exports = function parseCommandLine(processArgs) {
       // In the next block, .startsWith() only works on strings. So, skip non-string arguments.
       continue;
     }
-    if (path.startsWith(CONSTANTS.PROTOCOL_PATH)) {
+    if (path.startsWith(CONSTANTS.PROTOCOL_COLON_SLASHES)) {
       urlsToOpen.push(path);
     } else {
       pathsToOpen.push(path);

--- a/src/main-process/start.js
+++ b/src/main-process/start.js
@@ -8,6 +8,7 @@ const fs = require('fs');
 const CSON = require('season');
 const Config = require('../config');
 const StartupTime = require('../startup-time');
+const CONSTANTS = require("../pulsar-constants.js");
 
 StartupTime.setStartTime();
 
@@ -70,7 +71,7 @@ module.exports = function start(resourcePath, devResourcePath, startTime) {
   }
 
   const releaseChannel = getReleaseChannel(app.getVersion());
-  let appUserModelId = 'dev.pulsar-edit.pulsar.' + process.arch;
+  let appUserModelId = `${CONSTANTS.APP_IDENTIFIER}.${process.arch}`;
 
   // If the release channel is not stable, we append it to the app user model id.
   // This allows having the different release channels as separate items in the taskbar.

--- a/src/protocol-handler-installer.js
+++ b/src/protocol-handler-installer.js
@@ -13,7 +13,7 @@ module.exports = class ProtocolHandlerInstaller {
 
   async isDefaultProtocolClient() {
     return ipcRenderer.invoke('isDefaultProtocolClient', {
-      protocol: CONSTANTS.PROTOCOL_NAME,
+      protocol: CONSTANTS.PROTOCOL,
       path: process.execPath,
       args: ['--uri-handler', '--']
     });
@@ -25,7 +25,7 @@ module.exports = class ProtocolHandlerInstaller {
     return (
       this.isSupported() &&
       ipcRenderer.invoke('setAsDefaultProtocolClient', {
-        protocol: CONSTANTS.PROTOCOL_NAME,
+        protocol: CONSTANTS.PROTOCOL,
         path: process.execPath,
         args: ['--uri-handler', '--']
       })
@@ -83,13 +83,13 @@ module.exports = class ProtocolHandlerInstaller {
     };
 
     notification = notifications.addInfo(
-      `Register as default ${CONSTANTS.PROTOCOL_PATH} URI handler?`,
+      `Register as default ${CONSTANTS.PROTOCOL_COLON_SLASHES} URI handler?`,
       {
         dismissable: true,
         icon: 'link',
         description:
-          `Pulsar is not currently set as the default handler for ${CONSTANTS.PROTOCOL_PATH} URIs. Would you like Pulsar to handle ` +
-          `${CONSTANTS.PROTOCOL_PATH} URIs?`,
+          `Pulsar is not currently set as the default handler for ${CONSTANTS.PROTOCOL_COLON_SLASHES} URIs. Would you like Pulsar to handle ` +
+          `${CONSTANTS.PROTOCOL_COLON_SLASHES} URIs?`,
         buttons: [
           {
             text: 'Yes',

--- a/src/protocol-handler-installer.js
+++ b/src/protocol-handler-installer.js
@@ -1,4 +1,5 @@
 const { ipcRenderer } = require('electron');
+const CONSTANTS = require("./pulsar-constants.js");
 
 const SETTING = 'core.uriHandlerRegistration';
 const PROMPT = 'prompt';
@@ -12,7 +13,7 @@ module.exports = class ProtocolHandlerInstaller {
 
   async isDefaultProtocolClient() {
     return ipcRenderer.invoke('isDefaultProtocolClient', {
-      protocol: 'atom',
+      protocol: CONSTANTS.PROTOCOL_NAME,
       path: process.execPath,
       args: ['--uri-handler', '--']
     });
@@ -24,7 +25,7 @@ module.exports = class ProtocolHandlerInstaller {
     return (
       this.isSupported() &&
       ipcRenderer.invoke('setAsDefaultProtocolClient', {
-        protocol: 'atom',
+        protocol: CONSTANTS.PROTOCOL_NAME,
         path: process.execPath,
         args: ['--uri-handler', '--']
       })
@@ -82,13 +83,13 @@ module.exports = class ProtocolHandlerInstaller {
     };
 
     notification = notifications.addInfo(
-      'Register as default atom:// URI handler?',
+      `Register as default ${CONSTANTS.PROTOCOL_PATH} URI handler?`,
       {
         dismissable: true,
         icon: 'link',
         description:
-          'Pulsar is not currently set as the default handler for atom:// URIs. Would you like Pulsar to handle ' +
-          'atom:// URIs?',
+          `Pulsar is not currently set as the default handler for ${CONSTANTS.PROTOCOL_PATH} URIs. Would you like Pulsar to handle ` +
+          `${CONSTANTS.PROTOCOL_PATH} URIs?`,
         buttons: [
           {
             text: 'Yes',

--- a/src/pulsar-constants.js
+++ b/src/pulsar-constants.js
@@ -1,0 +1,25 @@
+// A definition for all Pulsar Constants that are ubiquitous throughout the codebase
+
+module.exports = {
+  PROTOCOL_NAME: "atom",
+  PROTOCOL: `${this.PROTOCOL_NAME}:`,
+  PROTOCOL_PATH: `${this.PROTOCOL}//`,
+  // ^^ atom://
+  // If changing the protocol name, it must be changed in ./static/index.html
+  DOT_FOLDER: ".pulsar", // The folder where all user data and configuration data is stored
+  APP_IDENTIFIER: "dev.pulsar-edit.pulsar",
+  // atom://.pulsar/stylesheet
+  STYLESHEET_PROTOCOL: `${this.PROTOCOL_PATH}${this.DOT_FOLDER}/stylesheet`,
+  // atom://.pulsar/keymap
+  KEYMAP_PROTOCOL: `${this.PROTOCOL_PATH}${this.DOT_FOLDER}/keymap`,
+  // atom://.pulsar/config
+  CONFIG_PROTOCOL: `${this.PROTOCOL_PATH}${this.DOT_FOLDER}/config`,
+  // atom://.pulsar/init-script
+  INIT_SCRIPT_PROTOCOL: `${this.PROTOCOL_PATH}${this.DOT_FOLDER}/init-script`,
+  // atom://.pulsar/snippets
+  SNIPPETS_PROTOCOL: `${this.PROTOCOL_PATH}${this.DOT_FOLDER}/snippets`,
+  // atom://config
+  CONFIG_UI_PROTOCOL: `${this.PROTOCOL_PATH}config`,
+  // atom://about
+  ABOUT_UI_PROTOCOL: `${this.PROTOCOL_PATH}about`
+};

--- a/src/pulsar-constants.js
+++ b/src/pulsar-constants.js
@@ -9,17 +9,17 @@ module.exports = {
   DOT_FOLDER: ".pulsar", // The folder where all user data and configuration data is stored
   APP_IDENTIFIER: "dev.pulsar-edit.pulsar",
   // atom://.pulsar/stylesheet
-  STYLESHEET_PROTOCOL: `${this.PROTOCOL_PATH}${this.DOT_FOLDER}/stylesheet`,
+  STYLESHEET_URI: `${this.PROTOCOL_PATH}${this.DOT_FOLDER}/stylesheet`,
   // atom://.pulsar/keymap
-  KEYMAP_PROTOCOL: `${this.PROTOCOL_PATH}${this.DOT_FOLDER}/keymap`,
+  KEYMAP_URI: `${this.PROTOCOL_PATH}${this.DOT_FOLDER}/keymap`,
   // atom://.pulsar/config
-  CONFIG_PROTOCOL: `${this.PROTOCOL_PATH}${this.DOT_FOLDER}/config`,
+  CONFIG_URI: `${this.PROTOCOL_PATH}${this.DOT_FOLDER}/config`,
   // atom://.pulsar/init-script
-  INIT_SCRIPT_PROTOCOL: `${this.PROTOCOL_PATH}${this.DOT_FOLDER}/init-script`,
+  INIT_SCRIPT_URI: `${this.PROTOCOL_PATH}${this.DOT_FOLDER}/init-script`,
   // atom://.pulsar/snippets
-  SNIPPETS_PROTOCOL: `${this.PROTOCOL_PATH}${this.DOT_FOLDER}/snippets`,
+  SNIPPETS_URI: `${this.PROTOCOL_PATH}${this.DOT_FOLDER}/snippets`,
   // atom://config
-  CONFIG_UI_PROTOCOL: `${this.PROTOCOL_PATH}config`,
+  CONFIG_UI_URI: `${this.PROTOCOL_PATH}config`,
   // atom://about
-  ABOUT_UI_PROTOCOL: `${this.PROTOCOL_PATH}about`
+  ABOUT_UI_URI: `${this.PROTOCOL_PATH}about`
 };

--- a/src/pulsar-constants.js
+++ b/src/pulsar-constants.js
@@ -1,25 +1,27 @@
 // A definition for all Pulsar Constants that are ubiquitous throughout the codebase
+const CONSTANTS = {};
 
-module.exports = {
-  PROTOCOL_NAME: "atom",
-  PROTOCOL: `${this.PROTOCOL_NAME}:`,
-  PROTOCOL_PATH: `${this.PROTOCOL}//`,
-  // ^^ atom://
-  // If changing the protocol name, it must be changed in ./static/index.html
-  DOT_FOLDER: ".pulsar", // The folder where all user data and configuration data is stored
-  APP_IDENTIFIER: "dev.pulsar-edit.pulsar",
-  // atom://.pulsar/stylesheet
-  STYLESHEET_URI: `${this.PROTOCOL_PATH}${this.DOT_FOLDER}/stylesheet`,
-  // atom://.pulsar/keymap
-  KEYMAP_URI: `${this.PROTOCOL_PATH}${this.DOT_FOLDER}/keymap`,
-  // atom://.pulsar/config
-  CONFIG_URI: `${this.PROTOCOL_PATH}${this.DOT_FOLDER}/config`,
-  // atom://.pulsar/init-script
-  INIT_SCRIPT_URI: `${this.PROTOCOL_PATH}${this.DOT_FOLDER}/init-script`,
-  // atom://.pulsar/snippets
-  SNIPPETS_URI: `${this.PROTOCOL_PATH}${this.DOT_FOLDER}/snippets`,
-  // atom://config
-  CONFIG_UI_URI: `${this.PROTOCOL_PATH}config`,
-  // atom://about
-  ABOUT_UI_URI: `${this.PROTOCOL_PATH}about`
-};
+CONSTANTS.PROTOCOL = "atom";
+CONSTANTS.PROTOCOL_COLON = `${CONSTANTS.PROTOCOL}:`;
+CONSTANTS.PROTOCOL_COLON_SLASHES = `${CONSTANTS.PROTOCOL_COLON}//`;
+// ^^ atom://
+// If changing the protocol name, it must be changed in ./static/index.html
+CONSTANTS.DOT_FOLDER = ".pulsar";
+// ^^ The folder where all user data and configuration data is stored
+CONSTANTS.APP_IDENTIFIER = "dev.pulsar-edit.pulsar";
+CONSTANTS.STYLESHEET_URI = `${CONSTANTS.PROTOCOL_COLON_SLASHES}${CONSTANTS.DOT_FOLDER}/stylesheet`;
+// ^^ atom://.pulsar/stylesheet
+CONSTANTS.KEYMAP_URI = `${CONSTANTS.PROTOCOL_COLON_SLASHES}${CONSTANTS.DOT_FOLDER}/keymap`;
+// ^^ atom://.pulsar/keymap
+CONSTANTS.CONFIG_URI = `${CONSTANTS.PROTOCOL_COLON_SLASHES}${CONSTANTS.DOT_FOLDER}/config`;
+// ^^ atom://.pulsar/config
+CONSTANTS.INIT_SCRIPT_URI = `${CONSTANTS.PROTOCOL_COLON_SLASHES}${CONSTANTS.DOT_FOLDER}/init-script`;
+// ^^ atom://.pulsar/init-script
+CONSTANTS.SNIPPETS_URI = `${CONSTANTS.PROTOCOL_COLON_SLASHES}${CONSTANTS.DOT_FOLDER}/snippets`;
+// ^^ atom://.pulsar/snippets
+CONSTANTS.CONFIG_UI_URI = `${CONSTANTS.PROTOCOL_COLON_SLASHES}config`;
+// ^^ atom://config
+CONSTANTS.ABOUT_UI_URI = `${CONSTANTS.PROTOCOL_COLON_SLASHES}about`;
+// ^^ atom://about
+
+module.exports = CONSTANTS;

--- a/src/uri-handler-registry.js
+++ b/src/uri-handler-registry.js
@@ -1,5 +1,6 @@
 const url = require('url');
 const { Emitter, Disposable } = require('event-kit');
+const CONSTANTS = require("./pulsar-constants.js");
 
 // Private: Associates listener functions with URIs from outside the application.
 //
@@ -95,7 +96,7 @@ module.exports = class URIHandlerRegistry {
   async handleURI(uri) {
     const parsed = url.parse(uri, true);
     const { protocol, slashes, auth, port, host } = parsed;
-    if (protocol !== 'atom:' || slashes !== true || auth || port) {
+    if (protocol !== CONSTANTS.PROTOCOL || slashes !== true || auth || port) {
       throw new Error(
         `URIHandlerRegistry#handleURI asked to handle an invalid URI: ${uri}`
       );

--- a/src/uri-handler-registry.js
+++ b/src/uri-handler-registry.js
@@ -96,7 +96,7 @@ module.exports = class URIHandlerRegistry {
   async handleURI(uri) {
     const parsed = url.parse(uri, true);
     const { protocol, slashes, auth, port, host } = parsed;
-    if (protocol !== CONSTANTS.PROTOCOL || slashes !== true || auth || port) {
+    if (protocol !== CONSTANTS.PROTOCOL_COLON || slashes !== true || auth || port) {
       throw new Error(
         `URIHandlerRegistry#handleURI asked to handle an invalid URI: ${uri}`
       );

--- a/src/window-event-handler.js
+++ b/src/window-event-handler.js
@@ -307,7 +307,7 @@ module.exports = class WindowEventHandler {
     if (uri && uri[0] !== '#') {
       if (/^https?:\/\//.test(uri)) {
         this.applicationDelegate.openExternal(uri);
-      } else if (uri.startsWith(CONSTANTS.PROTOCOL_PATH)) {
+      } else if (uri.startsWith(CONSTANTS.PROTOCOL_COLON_SLASHES)) {
         this.atomEnvironment.uriHandlerRegistry.handleURI(uri);
       }
     }

--- a/src/window-event-handler.js
+++ b/src/window-event-handler.js
@@ -1,6 +1,7 @@
 const { Disposable, CompositeDisposable } = require('event-kit');
 const listen = require('./delegated-listener');
 const { debounce } = require('underscore-plus');
+const CONSTANTS = require("./pulsar-constants.js");
 
 // Handles low-level events related to the `window`.
 module.exports = class WindowEventHandler {
@@ -306,7 +307,7 @@ module.exports = class WindowEventHandler {
     if (uri && uri[0] !== '#') {
       if (/^https?:\/\//.test(uri)) {
         this.applicationDelegate.openExternal(uri);
-      } else if (uri.startsWith('atom://')) {
+      } else if (uri.startsWith(CONSTANTS.PROTOCOL_PATH)) {
         this.atomEnvironment.uriHandlerRegistry.handleURI(uri);
       }
     }


### PR DESCRIPTION
Much like #705, this PR aims to reduce the amount of duplicated data throughout the Pulsar codebase.

Although instead of focusing on values derived from functions, this PR focuses and raw values throughout the codebase. And moves all of them to `pulsar-constants.js`. 

This module exports several values like the `PROTOCOL` ("atom:"), and different URI paths all with the goal of making sure we can declare these values once, and have them updated across the entire codebase.