### PR TITLE
[symbols-view] Remap go-to-declaration commands on Windows/Linux

### DIFF
--- a/packages/symbols-view/keymaps/symbols-view.cson
+++ b/packages/symbols-view/keymaps/symbols-view.cson
@@ -5,13 +5,13 @@
 
 '.platform-win32 atom-text-editor:not([mini])':
   'ctrl-r': 'symbols-view:toggle-file-symbols'
-  'ctrl-alt-down': 'symbols-view:go-to-declaration'
-  'ctrl-alt-up': 'symbols-view:return-from-declaration'
+  'ctrl-alt-shift-down': 'symbols-view:go-to-declaration'
+  'ctrl-alt-shift-up': 'symbols-view:return-from-declaration'
 
 '.platform-linux atom-text-editor:not([mini])':
   'ctrl-r': 'symbols-view:toggle-file-symbols'
-  'ctrl-alt-down': 'symbols-view:go-to-declaration'
-  'ctrl-alt-up': 'symbols-view:return-from-declaration'
+  'ctrl-alt-shift-down': 'symbols-view:go-to-declaration'
+  'ctrl-alt-shift-up': 'symbols-view:return-from-declaration'
 
 '.platform-darwin':
   'cmd-shift-r': 'symbols-view:toggle-project-symbols'


### PR DESCRIPTION
This is a quick one. @Spiker985 discovered that the **Symbols View: Go To Declaration** and **Symbols View: Return From Declaration** commands used key shortcuts that shadowed the built-in **Editor: Add Selection Above** and **Editor: Add Selection Below** commands on Windows and Linux.

The `symbols-view` commands didn't even have mapped keys on Windows until 1.113. (If I had to guess, I'd guess that `ctags` didn't work on Windows at some point?) But these commands have always conflicted with one another on Linux!

To fix this, I'm adding a modifier key to the default key combinations on these two platforms. These new key combinations don't conflict with anything in the core `keymaps` folder, nor any other keymaps I can find in the `pulsar` project.