### PR TITLE
Cirrus: Install older dotenv gem version ~> 2.8 (< 3)

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -85,6 +85,7 @@ arm_linux_task:
                 libasound2-dev
                 libnss3
                 xvfb
+    - gem install dotenv -v 2.8.1
     - gem install fpm
     - git submodule init
     - git submodule update

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -85,7 +85,7 @@ arm_linux_task:
                 libasound2-dev
                 libnss3
                 xvfb
-    - gem install dotenv -v 2.8.1
+    - gem install dotenv -v '~>  2.8'
     - gem install fpm
     - git submodule init
     - git submodule update


### PR DESCRIPTION
### Short Summary (from Commit Message)

This indirect dependency has a newer version that requires Ruby 3.0 or newer. We're on Debian 10 "Buster" for now, which is still on Ruby 2.5.

Pin to dotenv 2.8.1, the latest version compatible with our older Ruby, per the error message from CI:

> The last version of dotenv (>= 0) to support your Ruby & RubyGems
> was 2.8.1. Try installing it with `gem install dotenv -v 2.8.1`
> and then running the current command again
>
> dotenv requires Ruby version >= 3.0.
> The current ruby version is 2.5.0.


### Identify the Bug

<!--

Link to the issue describing the bug that you're fixing.

If there is not yet an issue for your bug, please open a new issue and then link to that issue in your pull request.
Note: In some cases, one person's "bug" is another person's "feature." If the pull request does not address an existing issue with the "bug" label, the maintainers have the final say on whether the current behavior is a bug.

-->

See: https://github.com/pulsar-edit/pulsar/pull/929#issuecomment-1947759623

### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

Pin to dotenv 2.8.1, the latest version compatible with our older Ruby, per the error message from CI.

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

Update to newer Ruby. Would be quite the hassle. I think I'd rather wait until Cirrus updates their base images. 

(Side note: Cirrus's default base image is currently based on Debian 10 "Buster", the oldest officially-supported Debian release, and the same version we started building our GitHub Actions binaries on recently as well.)

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

Stuck on an older version of `dotenv` gem.

For more info about this package, see:
- https://rubygems.org/gems/dotenv
- https://github.com/bkeepers/dotenv

### Verification Process

<!--

What process did you follow to verify that the change has not introduced any regressions? Describe the actions you performed (including buttons you clicked, text you typed, commands you ran, etc.), and describe the results you observed.

-->

Worked before. Again, see: https://github.com/pulsar-edit/pulsar/pull/929#issuecomment-1947759623.

### Release Notes

<!--

Please describe the changes in a single line that explains this improvement in
terms that a user can understand. This text will be used in Atom's release notes.

If this change is not user-facing or notable enough to be included in release notes
you may use the strings "Not applicable" or "N/A" here.

Examples:

- The GitHub package now allows you to add co-authors to commits.
- Fixed an issue where multiple cursors did not work in a file with a single line.
- Increased the performance of searching and replacing across a whole project.

-->
N/A