### PR TITLE
Update the Crowdin URL in README to direct to the project page

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@
 [Electron]: https://github.com/electron/electron
 [Atom]: https://github.blog/2022-06-08-sunsetting-atom/
 [Discord]: https://discord.gg/7aEbB9dGRT 'Join the Pulsar Discord today!'
-[Crowdin]: https://crowdin.pulsar-edit.dev
+[Crowdin]: https://crowdin.com/project/pulsar-edit
 [Status]: https://cirrus-ci.com/github/pulsar-edit/pulsar/master
 [Codacy]: https://app.codacy.com/gh/pulsar-edit/pulsar
 [Reddit]: https://www.reddit.com/r/pulsaredit/


### PR DESCRIPTION
### Description of the Change

This commit updates the Crowdin URL in the README.md file to point directly to the Pulsar project's page on Crowdin. Previously, the link redirected users to the Crowdin homepage(https://crowdin.com/), which could cause confusion and an extra step for contributors looking to help with translations. The new URL provides a more streamlined and user-friendly experience for contributors.

### Release Notes

Update the Crowdin URL in README to direct to the project page.