### PR TITLE
Fix(fuzzy-finder) fs.lstatSync throws Exception if not a file or dir

### DIFF
--- a/packages/fuzzy-finder/lib/fuzzy-finder-view.js
+++ b/packages/fuzzy-finder/lib/fuzzy-finder-view.js
@@ -166,10 +166,14 @@ module.exports = class FuzzyFinderView {
       this.moveToCaretPosition(caretPosition)
     } else if (!uri) {
       this.cancel()
-    } else if (fs.lstatSync(uri).isDirectory()) {
-      this.selectListView.update({errorMessage: 'Selected path is a directory'})
-      setTimeout(() => { this.selectListView.update({errorMessage: null}) }, 2000)
     } else {
+      try {
+        if (fs.lstatSync(uri).isDirectory()) {
+          this.selectListView.update({errorMessage: 'Selected path is a directory'})
+          setTimeout(() => { this.selectListView.update({errorMessage: null}) }, 2000)
+          return
+        }
+      } catch (e) {}
       const caretPosition = this.getCaretPosition()
       this.cancel()
       this.openURI(uri, caretPosition, openOptions)


### PR DESCRIPTION
### Identify the Bug

While trying to fix a self-hosted teletype version, I noticed the fuzzy-finder is broken with teletype and it is because of this:

If you try to use the fuzzy-finder while connected via teletype, it fails with an exception.  
This is caused by a check if the uri is a directory. The used `fs.lstatSync` will throw if given path is not found.
Previously it used a fs-plus method, which did not throw.
Because it throws, the else branch is never reached for the teletype URIs.

### Description of the Change

wrap `fs.lstatSync` in a try-catch block

### Alternate Designs

I would love to do something like this

```diff
    } else if (fs.lstatSync(uri, {throwIfNoEntry: false})?.isDirectory()) {
```

unfortunately `throwIfNoEntry` is only available in newer versions of `fs`.

Alternative 2: Could revert to fs-plus, the old code did not throw
Alternative 3: It could be sufficient to explicitly check if it is a teletype URI, I do not know if there could be other types of URI.
Teletype URIs all start with `atom://teletype/`

### Possible Drawbacks

Code could be harder to read.

### Verification Process

I used the fuzzy-finder, did not crash. Also did not crash with teletype.

### Release Notes

N/A