### PR TITLE
Improve "Project does not exists" popup

### DIFF
--- a/spec/atom-environment-spec.js
+++ b/spec/atom-environment-spec.js
@@ -764,7 +764,12 @@ describe('AtomEnvironment', () => {
           expect(atom.notifications.addWarning).toHaveBeenCalledWith(
             'Unable to open project folders',
             {
-              description: `The directories \`${nonExistent}\` and \`${existingFile}\` do not exist.`
+              description: `The directories \`${nonExistent}\` and \`${existingFile}\` do not exist.`,
+              dismissable: true,
+              buttons: [
+                { text: 'Remove all', onDidClick: jasmine.any(Function) },
+                { text: 'Skip for now', onDidClick: jasmine.any(Function) }
+              ]
             }
           );
         });

--- a/src/atom-environment.js
+++ b/src/atom-environment.js
@@ -1739,7 +1739,36 @@ or use Pane::saveItemAs for programmatic saving.`);
           '` do not exist.';
       }
 
-      this.notifications.addWarning(message, { description });
+      let notification;
+
+      let removeMissingPaths = async () => {
+        this.applicationDelegate.setProjectRoots(this.project.getPaths());
+
+        for (const missingFolder of missingFolders) {
+          const { pathToOpen } = missingFolder;
+
+          this.notifications.addWarning(`Removed ${pathToOpen}`);
+        }
+
+        if (notification) {
+          notification.dismiss();
+        }
+      };
+
+      let skipRemove = () => {
+        if (notification) {
+          notification.dismiss();
+        }
+      }
+
+      notification = this.notifications.addWarning(message, {
+        description,
+        dismissable: true,
+        buttons: [
+          { text: 'Remove all', onDidClick: removeMissingPaths },
+          { text: 'Skip for now', onDidClick: skipRemove }
+        ]
+      });
     }
 
     ipcRenderer.send('window-command', 'window:locations-opened');


### PR DESCRIPTION
### Identify the Bug

This is a first improvement to fix #833.

### Description of the Change

I've changed the warning to be dismissable (won't auto-hide anymore) and added two buttons. The first one "Remove all", removes all missing folders from the project. The second one just closes the pop-up for now.

### Alternate Designs

On the ticket there were some discussions if we can add an option to fix the paths or remove only some of them. I think just removing all of the deleted folders solves the problem most of the time, I would not write this right now.

There's a reason behind adding a "Snooze" button, something like we already have for new versions' popup. I'm happy to add it, if you also see the need for this.

### Possible Drawbacks

Without the snooze button, the auto-hiding popup will became a permanent popup on every start.

### Verification Process

Follow the steps described on the issue.

### Release Notes

The missing folder popup warning now has a button to remove the missing folders from the workspace.

### Other things to discuss

* [ ] The function I extended with the new logic is already a huge one, I'd like to move the missing folder handling out to a new function. As I'm not a regular maintainer, I don't know if you have a policy about it (e.g.: don't do this because xy reason, follow some naming convention, etc)
* [ ] The extended tests are failing for me on local. I'm not entirely sure why, as most of the jasmine docs indicates that the `any` helper should work with the old jasmine version we're using here.