### PR TITLE
cirrus: Various fixes for macOS Cirrus CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -123,7 +123,7 @@ silicon_mac_task:
   only_if: $CIRRUS_CRON != "" || $CIRRUS_TAG != ""
   skip: $CIRRUS_CHANGE_IN_REPO == $CIRRUS_LAST_GREEN_CHANGE
   macos_instance:
-    image: ghcr.io/cirruslabs/macos-monterey-xcode:14
+    image: ghcr.io/cirruslabs/macos-ventura-xcode:latest
     memory: 8G
   env:
     CSC_LINK: ENCRYPTED[0078015a03bb6cfdbd80113ae5bbb6f448fd4bbbc40efd81bf2cb1554373046b475a4d7c77e3e3e82ac1ce2f7e3d2da5]
@@ -134,36 +134,42 @@ silicon_mac_task:
     ROLLING_UPLOAD_TOKEN: ENCRYPTED[e19187268935fd1a2e1db3304105cc4bf37d5f5a46ba519a1b952f8ac9a3d01982fa9b8274b838547aa37920774b7518]
   prepare_script:
     - brew update
-    - brew install node@16 yarn git python@$PYTHON_VERSION
-    - python3 -m pip install setuptools
+    - brew uninstall node
+    - brew install git python@$PYTHON_VERSION python-setuptools
     - git submodule init
     - git submodule update
     - ln -s /opt/homebrew/bin/python$PYTHON_VERSION /opt/homebrew/bin/python
-    - export PATH="/opt/homebrew/bin:/opt/homebrew/opt/node@16/bin:$PATH"
+    - export PATH="/opt/homebrew/bin:$PATH"
+    - mkdir tj_n && cd tj_n
+    - curl -L https://github.com/tj/n/archive/0ce85771fdff8f4b3e09ade700461b4f58a64444.tar.gz -O
+    - tar xf 0ce85771fdff8f4b3e09ade700461b4f58a64444.tar.gz
+    - sudo bash ./n-0ce85771fdff8f4b3e09ade700461b4f58a64444/bin/n 16
+    - cd ..
+    - sudo npm install -g yarn
     - sed -i -e "s/[0-9]*-dev/`date -u +%Y%m%d%H`/g" package.json
   install_script:
-    - export PATH="/opt/homebrew/bin:/opt/homebrew/opt/node@16/bin:$PATH"
+    - export PATH="/opt/homebrew/bin:$PATH"
     - yarn install --ignore-engines || yarn install --ignore-engines
   build_script:
-    - export PATH="/opt/homebrew/bin:/opt/homebrew/opt/node@16/bin:$PATH"
+    - export PATH="/opt/homebrew/bin:$PATH"
     - yarn build
     - yarn run build:apm
   build_binary_script:
-    - export PATH="/opt/homebrew/bin:/opt/homebrew/opt/node@16/bin:$PATH"
+    - export PATH="/opt/homebrew/bin:$PATH"
     - yarn dist || yarn dist
   rename_binary_script:
-    - export PATH="/opt/homebrew/bin:/opt/homebrew/opt/node@16/bin:$PATH"
+    - export PATH="/opt/homebrew/bin:$PATH"
     - node script/rename.js "Silicon.Mac"
   binary_artifacts:
     path: ./binaries/*
   test_script:
-    - export PATH="/opt/homebrew/bin:/opt/homebrew/opt/node@16/bin:$PATH"
+    - export PATH="/opt/homebrew/bin:$PATH"
     - rm -R node_modules/electron; yarn install --check-files
     - hdiutil mount binaries/*Pulsar*dmg
     - export BINARY_NAME=`ls /Volumes/Pulsar*/Pulsar.app/Contents/MacOS/Pulsar`
     - PLAYWRIGHT_JUNIT_OUTPUT_NAME=report.xml npx playwright test --reporter=junit,list
   rolling_upload_script:
-    - export PATH="/opt/homebrew/bin:/opt/homebrew/opt/node@16/bin:$PATH"
+    - export PATH="/opt/homebrew/bin:$PATH"
     - cd ./script/rolling-release-scripts
     - npm install
     - node ./rolling-release-binary-upload.js cirrus
@@ -178,7 +184,7 @@ silicon_mac_task:
 # intel_mac_task:
 #   alias: mac
 #   macos_instance:
-#     image: ghcr.io/cirruslabs/macos-monterey-xcode:14
+#     image: ghcr.io/cirruslabs/macos-ventura-xcode:latest
 #     memory: 8G
 #   env:
 #     CSC_LINK: ENCRYPTED[0078015a03bb6cfdbd80113ae5bbb6f448fd4bbbc40efd81bf2cb1554373046b475a4d7c77e3e3e82ac1ce2f7e3d2da5]
@@ -191,30 +197,32 @@ silicon_mac_task:
 #     - echo A | softwareupdate --install-rosetta
 #     - arch -x86_64 xcode-select --install
 #     - arch -x86_64 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
-#     - export PATH="/usr/local/opt/node@16/bin:/usr/local/bin:$PATH"
+#     - export PATH="/usr/local/bin:$PATH"
 #     - arch -x86_64 brew update
-#     - arch -x86_64 brew install node@16 yarn git python@$PYTHON_VERSION
+#     - arch -x86_64 brew uninstall node
+#     - arch -x86_64 brew install node@16 git python@$PYTHON_VERSION python-setuptools
 #     - ln -s /usr/local/bin/python$PYTHON_VERSION /usr/local/bin/python
+#     - npm install -g yarn
 #     - git submodule init
 #     - git submodule update
 #     - sed -i -e "s/[0-9]*-dev/`date -u +%Y%m%d%H`/g" package.json
 #   install_script:
-#     - export PATH="/usr/local/opt/node@16/bin:/usr/local/bin:$PATH"
+#     - export PATH="/usr/local/bin:$PATH"
 #     - arch -x86_64 npx yarn install --ignore-engines || arch -x86_64 npx yarn install --ignore-engines
 #   build_script:
-#     - export PATH="/usr/local/opt/node@16/bin:/usr/local/bin:$PATH"
+#     - export PATH="/usr/local/bin:$PATH"
 #     - arch -x86_64 npx yarn build
 #     - arch -x86_64 yarn run build:apm
 #   build_binary_script:
-#     - export PATH="/usr/local/opt/node@16/bin:/usr/local/bin:$PATH"
+#     - export PATH="/usr/local/bin:$PATH"
 #     - arch -x86_64 npx yarn dist || arch -x86_64 npx yarn dist
 #   rename_binary_script:
-#     - export PATH="/usr/local/opt/node@16/bin:/usr/local/bin:$PATH"
+#     - export PATH="/usr/local/bin:$PATH"
 #     - node script/rename.js "Intel.Mac"
 #   binary_artifacts:
 #     path: ./binaries/*
 #   test_script:
-#     - export PATH="/usr/local/opt/node@16/bin:/usr/local/bin:$PATH"
+#     - export PATH="/usr/local/bin:$PATH"
 #     - rm -R node_modules/electron; yarn install --check-files
 #     - hdiutil mount binaries/*Pulsar*dmg
 #     - export BINARY_NAME=`ls /Volumes/Pulsar*/Pulsar.app/Contents/MacOS/Pulsar`


### PR DESCRIPTION
### Context / Issues / Timeline

Our Cirrus CI has been on the fritz for the past month-ish.

- Last passing/green Cirrus Cron build was here:
  - Wed, 14 Feb 2024 15:00 https://cirrus-ci.com/build/6417466427965440
- Cirrus cron builds have been been failing/red since the next one, starting here:
  - Fri, 16 Feb 2024 15:00 https://cirrus-ci.com/build/4984604403171328
  - Failing due to an **ARM Linux issue**... which was fixed in https://github.com/pulsar-edit/pulsar/pull/937
- And the next one was failed/red for an additional, _different_ reason, an **expired Rolling upload (GitHub.com REST API) token**. (My fault, apologies.)
  - Mon, 19 Feb 2024 15:00 https://cirrus-ci.com/task/6096096573784064
  - Should be fixed by: https://github.com/pulsar-edit/pulsar/pull/960
- And starting several days later, there is a failed/red build due to some **Python environment configuration change**, see [PEP 668](https://peps.python.org/pep-0668/), apparently
  - Fri, 23 Feb 2024 15:00 https://cirrus-ci.com/task/6669707223236608
  - Should be fixed by the current PR installing python-setuptools with Homebrew, not pip.
  - Notice this is still on a macOS Monterey base image _"Auto-upgraded from ghcr.io/cirruslabs/macos-monterey-xcode:14 to ghcr.io/cirruslabs/macos-**monterey**-xcode:latest"_
- Several days later, another failed/red build for an _additional, new reason_: **Base images for macOS Monterey are being "auto-upgraded" to the latest OS version available, macOS Sonoma**. I suppose the older Monterey Cirrus base images are hard-deprecated, given that two newer major OS versions of macOS are out and supported on Cirrus now?
  - Wed, 6 Mar 2024 15:00 https://cirrus-ci.com/task/5226704512221184
  - Should be addressed by the current PR pinning to macOS Ventura (13.x) instead of macOS Sonoma (14.x).
  - Note the new upgrade message: _"Auto-upgraded from ghcr.io/cirruslabs/macos-monterey-xcode:14 to ghcr.io/cirruslabs/macos-**sonoma**-xcode:latest"_

### Changes / Fixes

- Pin the base (CI-provided) OS image to Ventura, not Sonoma
  - Fixes some C/C++ compilation errors??
  - Gives us older XCode & compiler toolchain, I guess?
- Get node using tj/n utility, not Homebrew
  - Homebrew "node" package is conflicting with (now deprecated) "node@16" package, loading dynamic libraries like icu4c keeps breaking...
- Get Yarn using npm global install, not from Homebrew
  - I... honestly don't even know at this point. But Yarn from Homebrew is breaking somehow, possibly due to it referring back to Homebrew "node" package, but _that's just a guess_. It's cursed, I guess.
- Get python-setuptools from Homebrew, not from pip
  - Why? Why is this necessary? Homebrew, explain? Something about our "environment being externally managed", so global package installs with pip aren't allowed. This makes sense to someone. **See PEP 668.**
- Adjust PATH exports now that there's no "node@16" from Homebrew


### Verification

These changes (plus tweaks to the `only_if:` directive so the changes would actually run) passed here!: https://cirrus-ci.com/build/4775018807164928

Old commits from my experiments are still hosted here if anyone is curious what I tried in order to get here... https://github.com/DeeDeeG/pulsar/compare/master...cirrus-macOS-fixes-old