### PR TITLE
CI: Upgrade or replace all deprecated GH Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,10 +40,10 @@ jobs:
       run: apt-get update && apt-get install -y git python3 python3-pip make gcc g++ libx11-dev libxkbfile-dev pkg-config libsecret-1-dev rpm xvfb ffmpeg zstd
 
     - name: Checkout the latest code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Setup Node
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ env.NODE_VERSION }}
 
@@ -52,7 +52,7 @@ jobs:
       # which won't work in a Debian 10 Docker image.
       # Get Python from apt repos instead on Linux.
       if: ${{ runner.os != 'Linux' }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ env.PYTHON_VERSION }}
 
@@ -101,7 +101,7 @@ jobs:
       run: npx node-gyp install ${{ env.NODE_VERSION }}
 
     - name: Install Pulsar Dependencies
-      uses: nick-fields/retry@943e742917ac94714d2f408a0e8320f2d1fcafcd
+      uses: nick-fields/retry@7152eba30c6575329ac0576536151aca5a72780e
       with:
         timeout_minutes: 30
         max_attempts: 3
@@ -110,7 +110,7 @@ jobs:
         on_retry_command: rm -R node_modules
 
     - name: Build Pulsar
-      uses: nick-fields/retry@943e742917ac94714d2f408a0e8320f2d1fcafcd
+      uses: nick-fields/retry@7152eba30c6575329ac0576536151aca5a72780e
       with:
         timeout_minutes: 30
         max_attempts: 3
@@ -121,7 +121,7 @@ jobs:
 
     - name: Cache Pulsar dependencies - Linux
       if: ${{ runner.os == 'Linux' }}
-      uses: actions/cache/save@v3
+      uses: actions/cache/save@v4
       with:
         path: |
           node_modules
@@ -140,7 +140,7 @@ jobs:
         APPLEID: ${{ secrets.APPLEID }}
         APPLEID_PASSWORD: ${{ secrets.APPLEID_PASSWORD }}
         TEAM_ID: ${{ secrets.TEAM_ID }}
-      uses: nick-fields/retry@943e742917ac94714d2f408a0e8320f2d1fcafcd
+      uses: nick-fields/retry@7152eba30c6575329ac0576536151aca5a72780e
       with:
         timeout_minutes: 45
         max_attempts: 3
@@ -149,7 +149,7 @@ jobs:
 
     - name: Build Pulsar Binaries (macOS) (Unsigned)
       if: ${{ runner.os == 'macOS' && github.event_name != 'push' }}
-      uses: nick-fields/retry@943e742917ac94714d2f408a0e8320f2d1fcafcd
+      uses: nick-fields/retry@7152eba30c6575329ac0576536151aca5a72780e
       with:
         timeout_minutes: 45
         max_attempts: 3
@@ -158,7 +158,7 @@ jobs:
 
     - name: Build Pulsar Binaries
       if: ${{ runner.os != 'macOS' }}
-      uses: nick-fields/retry@943e742917ac94714d2f408a0e8320f2d1fcafcd
+      uses: nick-fields/retry@7152eba30c6575329ac0576536151aca5a72780e
       with:
         timeout_minutes: 30
         max_attempts: 3
@@ -179,13 +179,13 @@ jobs:
 
     - name: Cache Pulsar Binaries - Linux
       if: ${{ runner.os == 'Linux' }}
-      uses: actions/cache/save@v3
+      uses: actions/cache/save@v4
       with:
         path: ./binaries
         key: pulsar-Linux-Binaries-${{ github.sha }}-${{ github.workflow }}
 
     - name: Upload Binary Artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ matrix.os }} Binaries
         path: ./binaries/*
@@ -219,7 +219,7 @@ jobs:
     - name: Upload Video Artifacts
       # Run whether this job passed or failed, unless explicitly cancelled.
       if: ${{ !cancelled() && runner.os != 'Linux' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ matrix.os }} Videos
         path: ./tests/videos/**
@@ -235,23 +235,23 @@ jobs:
 
     steps:
     - name: Checkout the latest code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Setup Node
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ env.NODE_VERSION }}
 
     - name: Restore Cached Pulsar Binaries - Linux
       if: ${{ runner.os == 'Linux' }}
-      uses: actions/cache/restore@v3
+      uses: actions/cache/restore@v4
       with:
         path: ./binaries
         key: pulsar-Linux-Binaries-${{ github.sha }}-${{ github.workflow }}
 
     - name: Restore Cached Pulsar dependencies - Linux
       if: ${{ runner.os == 'Linux' }}
-      uses: actions/cache/restore@v3
+      uses: actions/cache/restore@v4
       with:
         path: |
           node_modules
@@ -285,7 +285,7 @@ jobs:
     - name: Upload Video Artifacts - Linux
       # Run whether this job passed or failed, unless explicitly cancelled.
       if: ${{ !cancelled() && runner.os == 'Linux' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ matrix.os }} Videos
         path: ./tests/videos/**

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -20,10 +20,10 @@ jobs:
 
     steps:
     - name: Checkout the Latest Code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Setup NodeJS - ${{ matrix.node-version }}
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node-version }}
 
@@ -43,6 +43,6 @@ jobs:
       run: yarn run private-js-docs
 
     - name: Commit All Changes
-      uses: stefanzweifel/git-auto-commit-action@v4
+      uses: stefanzweifel/git-auto-commit-action@v5
       with:
         commit_message: GH Action Documentation

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -43,6 +43,14 @@ jobs:
       run: yarn run private-js-docs
 
     - name: Commit All Changes
-      uses: stefanzweifel/git-auto-commit-action@v5
-      with:
-        commit_message: GH Action Documentation
+      run: |
+        if [ -n "`git status -s | grep "^ M"`" ]; then
+          echo "Uncommitted changes to repo files detected. Committing and pushing now."
+          git config user.name "${GITHUB_ACTOR}"
+          git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
+          git add -u
+          git commit -m "GH Action Documentation"
+          git push origin HEAD
+        else
+          echo "No changes detected in repo files. Nothing to commit!"
+        fi

--- a/.github/workflows/editor-tests.yml
+++ b/.github/workflows/editor-tests.yml
@@ -41,4 +41,9 @@ jobs:
       run: yarn build
 
     - name: Run Tests
+      if: runner.os != 'Linux'
+      run: node script/run-tests.js spec
+
+    - name: Run Tests with xvfb-run (Linux)
+      if: runner.os == 'Linux'
       run: xvfb-run --auto-servernum node script/run-tests.js spec

--- a/.github/workflows/editor-tests.yml
+++ b/.github/workflows/editor-tests.yml
@@ -21,10 +21,10 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - name: Checkout the latest code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Setup node
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: 16
 
@@ -41,6 +41,4 @@ jobs:
       run: yarn build
 
     - name: Run Tests
-      uses: coactions/setup-xvfb@v1.0.1
-      with:
-        run: node script/run-tests.js spec
+      run: xvfb-run --auto-servernum node script/run-tests.js spec

--- a/.github/workflows/package-tests-linux.yml
+++ b/.github/workflows/package-tests-linux.yml
@@ -15,10 +15,10 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - name: Checkout the latest code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Setup node
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: 16
 
@@ -42,14 +42,14 @@ jobs:
 
     - name: Cache pulsar
       id: cache-pulsar
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: pulsar.deb
         key: pulsar-${{ github.sha }}
 
     - name: Cache dependencies
       id: cache-dependencies
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: |
           node_modules
@@ -163,15 +163,15 @@ jobs:
 
     steps:
     - name: Checkout the latest code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Setup NodeJS
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: 16
 
     - name: Restore dependencies from Cache
       id: restore-dependencies
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: |
           node_modules
@@ -188,7 +188,7 @@ jobs:
 
     - name: Restore pulsar from Cache
       id: restore-pulsar
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: pulsar.deb
         key: pulsar-${{ github.sha }}

--- a/.github/workflows/validate-wasm-grammar-prs.yml
+++ b/.github/workflows/validate-wasm-grammar-prs.yml
@@ -13,13 +13,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout the Latest Code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         fetch-depth: 0
         # Make sure we get all commits, so that we can compare to early commits
 
     - name: Setup Node
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: 16
 


### PR DESCRIPTION
### Summary of changes

- Upgraded a bunch of deprecated versions of GitHub Actions we rely on to their latest major versions.
- Replaced `setup-xvfb` action with a direct `xvfb-run` command (short inline bash script).
- Replaced `git-auto-commit-action` with a short inline bash script.

### Motivation and Context

Context: Node 16 actions are deprecated. See: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/

Most of these were old versions of actions which were running on Node 16. Upgraded them to newer versions which run on Node 20 instead.

Also tried to replace `setup-xvfb` action with a direct `xvfb-run` command, as the `setup-xvfb` action hasn't been updated in a while, its author isn't responding to an issue asking for it to update from Node 16 to Node 20, and GitHub Actions Ubuntu runners include `xvfb` out of the box now, something that may not have been true (???) when the action was first created. I dunno. Worth a try. UPDATE: Working.

UPDATE: Also replaced `git-auto-commit-action` with a short inline script, avoiding _another_ external dependency. (Bash scripts generally don't expire or bitrot very quickly, so this one should last us for a while!) (This one had an update to run on Node 20 instead of 16, but I'm good with git, and from that vantage point, this seemed like a good thing to take in-house and cut out the external dependency.) 

Side note: For both of these actions that I made into inline scripts in the workflow .yml files, I studied what the action itself did, and replicated as closely as I thought would be relevant to our use of it. They pass in CI, meaning they are doing what they are supposed to. It just works :tm:. So far, at least.

### Verification Process

Going to let CI run on this PR! Let's hope this works. Update: CI is passing!

Also tested the `Documentation` workflow on my fork. Worked.

FWIW, I reviewed the changelogs of all updated Actions. Didn't see anything too crazy or out-of-place.

### Screenshots

<details><summary>Before (lots of deprecation warnings) (click to expand):</summary>

![Pulsar's CI summary page showing an Annotations box with numerous two warnings about numerous deprecated packages --  Node js 16 actions are deprecated  Please update the following actions to use Node js 20](https://github.com/pulsar-edit/pulsar/assets/20157115/0cad215b-aca7-40d6-95a9-e63e90269164)

</details>

<details><summary>After (no deprecation warnings) (click to expand):</summary>

![Pulsar's CI summary page, with no Annotations box, no deprecation warnings](https://github.com/pulsar-edit/pulsar/assets/20157115/a1c238c4-4e8a-4be4-a5a8-6cd2f071cc40)

</details>