### PR TITLE
[markdown-preview] Optimize re-rendering of content in a preview pane…

### DIFF
--- a/packages/markdown-preview/lib/main.js
+++ b/packages/markdown-preview/lib/main.js
@@ -12,9 +12,17 @@ const isMarkdownPreviewView = function (object) {
 }
 
 module.exports = {
-  activate () {
+  activate() {
     this.disposables = new CompositeDisposable()
     this.commandSubscriptions = new CompositeDisposable()
+
+    this.style = new CSSStyleSheet()
+
+    // When we upgrade Electron, we can push onto `adoptedStyleSheets`
+    // directly. For now, we have to do this silly thing.
+    let styleSheets = Array.from(document.adoptedStyleSheets ?? [])
+    styleSheets.push(this.style)
+    document.adoptedStyleSheets = styleSheets
 
     this.disposables.add(
       atom.config.observe('markdown-preview.grammars', grammars => {
@@ -50,6 +58,22 @@ module.exports = {
             })
           )
         }
+      })
+    )
+
+    this.disposables.add(
+      atom.config.observe('editor.fontFamily', (fontFamily) => {
+        // Keep the user's `fontFamily` setting in sync with preview styles.
+        // `pre` blocks will use this font automatically, but `code` elements
+        // need a specific style rule.
+        //
+        // Since this applies to all content, we should declare this only once,
+        // instead of once per preview view.
+        this.style.replaceSync(`
+          .markdown-preview code {
+            font-family: ${fontFamily} !important;
+          }
+        `)
       })
     )
 
@@ -94,12 +118,12 @@ module.exports = {
     )
   },
 
-  deactivate () {
+  deactivate() {
     this.disposables.dispose()
     this.commandSubscriptions.dispose()
   },
 
-  createMarkdownPreviewView (state) {
+  createMarkdownPreviewView(state) {
     if (state.editorId || fs.isFileSync(state.filePath)) {
       if (MarkdownPreviewView == null) {
         MarkdownPreviewView = require('./markdown-preview-view')
@@ -108,7 +132,7 @@ module.exports = {
     }
   },
 
-  toggle () {
+  toggle() {
     if (isMarkdownPreviewView(atom.workspace.getActivePaneItem())) {
       atom.workspace.destroyActivePaneItem()
       return
@@ -129,11 +153,11 @@ module.exports = {
     }
   },
 
-  uriForEditor (editor) {
+  uriForEditor(editor) {
     return `markdown-preview://editor/${editor.id}`
   },
 
-  removePreviewForEditor (editor) {
+  removePreviewForEditor(editor) {
     const uri = this.uriForEditor(editor)
     const previewPane = atom.workspace.paneForURI(uri)
     if (previewPane != null) {
@@ -144,7 +168,7 @@ module.exports = {
     }
   },
 
-  addPreviewForEditor (editor) {
+  addPreviewForEditor(editor) {
     const uri = this.uriForEditor(editor)
     const previousActivePane = atom.workspace.getActivePane()
     const options = { searchAllPanes: true }
@@ -161,7 +185,7 @@ module.exports = {
       })
   },
 
-  previewFile ({ target }) {
+  previewFile({ target }) {
     const filePath = target.dataset.path
     if (!filePath) {
       return
@@ -178,7 +202,7 @@ module.exports = {
     })
   },
 
-  async copyHTML () {
+  async copyHTML() {
     const editor = atom.workspace.getActiveTextEditor()
     if (editor == null) {
       return
@@ -191,13 +215,14 @@ module.exports = {
     const html = await renderer.toHTML(
       text,
       editor.getPath(),
-      editor.getGrammar()
+      editor.getGrammar(),
+      editor.id
     )
 
     atom.clipboard.write(html)
   },
 
-  saveAsHTML () {
+  saveAsHTML() {
     const activePaneItem = atom.workspace.getActivePaneItem()
     if (isMarkdownPreviewView(activePaneItem)) {
       atom.workspace.getActivePane().saveItemAs(activePaneItem)

--- a/packages/markdown-preview/lib/main.js
+++ b/packages/markdown-preview/lib/main.js
@@ -18,7 +18,7 @@ module.exports = {
 
     this.style = new CSSStyleSheet()
 
-    // When we upgrade Electron, we can push onto `adoptedStyleSheets`
+    // TODO: When we upgrade Electron, we can push onto `adoptedStyleSheets`
     // directly. For now, we have to do this silly thing.
     let styleSheets = Array.from(document.adoptedStyleSheets ?? [])
     styleSheets.push(this.style)

--- a/packages/markdown-preview/lib/markdown-preview-view.js
+++ b/packages/markdown-preview/lib/markdown-preview-view.js
@@ -448,6 +448,7 @@ module.exports = class MarkdownPreviewView {
 
   showError(result) {
     this.element.textContent = ''
+    this.element.classList.remove('loading')
     const h2 = document.createElement('h2')
     h2.textContent = 'Previewing Markdown Failed'
     this.element.appendChild(h2)

--- a/packages/markdown-preview/lib/renderer.js
+++ b/packages/markdown-preview/lib/renderer.js
@@ -17,91 +17,147 @@ const emojiFolder = path.join(
   'pngs'
 )
 
-exports.toDOMFragment = async function (text, filePath, grammar, callback) {
+// Creating `TextEditor` instances is costly, so we'll try to re-use instances
+// when a preview changes.
+class EditorCache {
+  static BY_ID = new Map()
 
-  text ??= "";
-
-  if (atom.config.get("markdown-preview.useOriginalParser")) {
-    const domFragment = render(text, filePath);
-
-    await highlightCodeBlocks(domFragment, grammar, makeAtomEditorNonInteractive);
-
-    return domFragment;
-
-  } else {
-    // We use the new parser!
-    const domFragment = atom.ui.markdown.render(text,
-      {
-        renderMode: "fragment",
-        filePath: filePath,
-        breaks: atom.config.get('markdown-preview.breakOnSingleNewline'),
-        useDefaultEmoji: true,
-        sanitizeAllowUnknownProtocols: atom.config.get('markdown-preview.allowUnsafeProtocols')
-      }
-    );
-    const domHTMLFragment = atom.ui.markdown.convertToDOM(domFragment);
-    await atom.ui.markdown.applySyntaxHighlighting(domHTMLFragment,
-      {
-        renderMode: "fragment",
-        syntaxScopeNameFunc: scopeForFenceName,
-        grammar: grammar
-      }
-    );
-
-    return domHTMLFragment;
+  static findOrCreateById(id) {
+    let cache = EditorCache.BY_ID.get(id)
+    if (!cache) {
+      cache = new EditorCache(id)
+      EditorCache.BY_ID.set(id, cache)
+    }
+    return cache
   }
+
+  constructor(id) {
+    this.id = id
+    this.editorsByPre = new Map()
+    this.possiblyUnusedEditors = new Set()
+  }
+
+  destroy() {
+    let editors = Array.from(this.editorsByPre.values())
+    for (let editor of editors) {
+      editor.destroy()
+    }
+    this.editorsByPre.clear()
+    this.possiblyUnusedEditors.clear()
+    EditorCache.BY_ID.delete(this.id)
+  }
+
+  // Called when we start a render. Every `TextEditor` is assumed to be stale,
+  // but any editor that is successfully looked up from the cache during this
+  // render is saved from culling.
+  beginRender() {
+    this.possiblyUnusedEditors.clear()
+    for (let editor of this.editorsByPre.values()) {
+      this.possiblyUnusedEditors.add(editor)
+    }
+  }
+
+  // Cache an editor by the PRE element that it's standing in for.
+  addEditor(pre, editor) {
+    this.editorsByPre.set(pre, editor)
+  }
+
+  getEditor(pre) {
+    let editor = this.editorsByPre.get(pre)
+    if (editor) {
+      // Cache hit! This editor will be reused, so we should prevent it from
+      // getting culled.
+      this.possiblyUnusedEditors.delete(editor)
+    }
+    return editor
+  }
+
+  endRender() {
+    // Any editor that didn't get claimed during the render is orphaned and
+    // should be disposed of.
+    let toBeDeleted = new Set()
+    for (let [pre, editor] of this.editorsByPre.entries()) {
+      if (!this.possiblyUnusedEditors.has(editor)) continue
+      toBeDeleted.add(pre)
+    }
+
+    this.possiblyUnusedEditors.clear()
+
+    for (let pre of toBeDeleted) {
+      let editor = this.editorsByPre.get(pre)
+      let element = editor.getElement()
+      if (element.parentNode) {
+        element.remove()
+      }
+      this.editorsByPre.delete(pre)
+      editor.destroy()
+    }
+  }
+}
+
+exports.EditorCache = EditorCache
+
+function chooseRender(text, filePath) {
+  if (atom.config.get("markdown-preview.useOriginalParser")) {
+    // Legacy rendering with `marked`.
+    return render(text, filePath)
+  } else {
+    // Built-in rendering with `markdown-it`.
+    let html = atom.ui.markdown.render(text, {
+      renderMode: "fragment",
+      filePath: filePath,
+      breaks: atom.config.get('markdown-preview.breakOnSingleNewline'),
+      useDefaultEmoji: true,
+      sanitizeAllowUnknownProtocols: atom.config.get('markdown-preview.allowUnsafeProtocols')
+    })
+    return atom.ui.markdown.convertToDOM(html)
+  }
+}
+
+exports.toDOMFragment = async function (text, filePath, grammar, editorId) {
+  text ??= ""
+  let defaultLanguage = getDefaultLanguageForGrammar(grammar)
+
+  // We cache editor instances in this code path because it's the one used by
+  // the preview pane, so we expect it to be updated quite frequently.
+  let cache = EditorCache.findOrCreateById(editorId)
+  cache.beginRender()
+
+  const domFragment = chooseRender(text, filePath)
+  annotatePreElements(domFragment, defaultLanguage)
+
+  return [
+    domFragment,
+    async (element) => {
+      await highlightCodeBlocks(element, grammar, cache, makeAtomEditorNonInteractive)
+      cache.endRender()
+    }
+  ]
 }
 
 exports.toHTML = async function (text, filePath, grammar) {
-
   text ??= "";
 
-  if (atom.config.get("markdown-preview.useOriginalParser")) {
-    const domFragment = render(text, filePath)
-    const div = document.createElement('div')
+  // We don't cache editor instances in this code path because it's the one
+  // used by the “Copy HTML” command, so this is likely to be a one-off for
+  // which caches won't help.
 
-    div.appendChild(domFragment)
-    document.body.appendChild(div)
+  const domFragment = chooseRender(text, filePath)
+  const div = document.createElement('div')
+  annotatePreElements(domFragment, getDefaultLanguageForGrammar(grammar))
+  div.appendChild(domFragment)
+  document.body.appendChild(div)
 
-    await highlightCodeBlocks(div, grammar, convertAtomEditorToStandardElement)
+  await highlightCodeBlocks(div, grammar, null, convertAtomEditorToStandardElement)
 
-    const result = div.innerHTML
-    div.remove()
+  const result = div.innerHTML;
+  div.remove();
 
-    return result
-  } else {
-    // We use the new parser!
-    const domFragment = atom.ui.markdown.render(text,
-      {
-        renderMode: "full",
-        filePath: filePath,
-        breaks: atom.config.get('markdown-preview.breakOnSingleNewline'),
-        useDefaultEmoji: true,
-        sanitizeAllowUnknownProtocols: atom.config.get('markdown-preview.allowUnsafeProtocols')
-      }
-    );
-    const domHTMLFragment = atom.ui.markdown.convertToDOM(domFragment);
-
-    const div = document.createElement("div");
-    div.appendChild(domHTMLFragment);
-    document.body.appendChild(div);
-
-    await atom.ui.markdown.applySyntaxHighlighting(div,
-      {
-        renderMode: "full",
-        syntaxScopeNameFunc: scopeForFenceName,
-        grammar: grammar
-      }
-    );
-
-    const result = div.innerHTML;
-    div.remove();
-
-    return result;
-  }
+  return result;
 }
 
-var render = function (text, filePath) {
+// Render with the package's own `marked` library.
+function render(text, filePath) {
   if (marked == null || yamlFrontMatter == null || cheerio == null) {
     marked = require('marked')
     yamlFrontMatter = require('yaml-front-matter')
@@ -124,12 +180,13 @@ var render = function (text, filePath) {
 
   let html = marked.parse(renderYamlTable(vars) + __content)
 
-  // emoji-images is too aggressive, so replace images in monospace tags with the actual emoji text.
+  // emoji-images is too aggressive, so replace images in monospace tags with
+  // the actual emoji text.
   const $ = cheerio.load(emoji(html, emojiFolder, 20))
-  $('pre img').each((index, element) =>
+  $('pre img').each((_index, element) =>
     $(element).replaceWith($(element).attr('title'))
   )
-  $('code img').each((index, element) =>
+  $('code img').each((_index, element) =>
     $(element).replaceWith($(element).attr('title'))
   )
 
@@ -159,7 +216,7 @@ function renderYamlTable(variables) {
 
   const markdownRows = [
     entries.map(entry => entry[0]),
-    entries.map(entry => '--'),
+    entries.map(_ => '--'),
     entries.map((entry) => {
       if (typeof entry[1] === "object" && !Array.isArray(entry[1])) {
         // Remove all newlines, or they ruin formatting of parent table
@@ -175,7 +232,7 @@ function renderYamlTable(variables) {
   )
 }
 
-var resolveImagePaths = function (element, filePath) {
+function resolveImagePaths(element, filePath) {
   const [rootDirectory] = atom.project.relativizePath(filePath)
 
   const result = []
@@ -219,55 +276,90 @@ var resolveImagePaths = function (element, filePath) {
   return result
 }
 
-var highlightCodeBlocks = function (domFragment, grammar, editorCallback) {
-  let defaultLanguage, fontFamily
-  if (
-    (grammar != null ? grammar.scopeName : undefined) === 'source.litcoffee'
-  ) {
-    defaultLanguage = 'coffee'
-  } else {
-    defaultLanguage = 'text'
-  }
+function getDefaultLanguageForGrammar(grammar) {
+  return grammar?.scopeName === 'source.litcoffee' ? 'coffee' : 'text'
+}
 
-  if ((fontFamily = atom.config.get('editor.fontFamily'))) {
-    for (const codeElement of domFragment.querySelectorAll('code')) {
-      codeElement.style.fontFamily = fontFamily
-    }
+function annotatePreElements(fragment, defaultLanguage) {
+  for (let preElement of fragment.querySelectorAll('pre')) {
+    const codeBlock = preElement.firstElementChild ?? preElement
+    const className = codeBlock.getAttribute('class')
+    const fenceName = className?.replace(/^language-/, '') ?? defaultLanguage
+    preElement.classList.add('editor-colors', `lang-${fenceName}`)
   }
+}
+
+function reassignEditorToLanguage(editor, languageScope) {
+  // When we successfully reassign the language on an editor, its
+  // `data-grammar` attribute updates on its own.
+  let result = atom.grammars.assignLanguageMode(editor, languageScope)
+  if (result) return true
+
+  // When we fail to assign the language on an editor — maybe its package is
+  // deactivated — it won't reset itself to the default grammar, so we have to
+  // do it ourselves.
+  result = atom.grammars.assignLanguageMode(editor, `text.plain.null-grammar`)
+  if (!result) return false
+}
+
+// After render, create an `atom-text-editor` for each `pre` element so that we
+// enjoy syntax highlighting.
+function highlightCodeBlocks(element, grammar, cache, editorCallback) {
+  let defaultLanguage = getDefaultLanguageForGrammar(grammar)
 
   const promises = []
-  for (const preElement of domFragment.querySelectorAll('pre')) {
-    const codeBlock =
-      preElement.firstElementChild != null
-        ? preElement.firstElementChild
-        : preElement
+
+  for (const preElement of element.querySelectorAll('pre')) {
+    const codeBlock = preElement.firstElementChild ?? preElement
     const className = codeBlock.getAttribute('class')
-    const fenceName =
-      className != null ? className.replace(/^language-/, '') : defaultLanguage
+    const fenceName = className?.replace(/^language-/, '') ?? defaultLanguage
+    let editorText = codeBlock.textContent.replace(/\r?\n$/, '')
 
-    const editor = new TextEditor({
-      readonly: true,
-      keyboardInputEnabled: false
-    })
-    const editorElement = editor.getElement()
+    // If this PRE element was present in the last render, then we should
+    // already have a cached text editor available for use.
+    let editor = cache?.getEditor(preElement) ?? null
+    let editorElement
+    if (!editor) {
+      editor = new TextEditor({ keyboardInputEnabled: false })
+      editorElement = editor.getElement()
+      editorElement.setUpdatedSynchronously(true)
+      editor.setReadOnly(true)
+      cache?.addEditor(preElement, editor)
+    } else {
+      editorElement = editor.getElement()
+    }
 
-    preElement.classList.add('editor-colors', `lang-${fenceName}`)
-    editorElement.setUpdatedSynchronously(true)
-    preElement.innerHTML = ''
-    preElement.parentNode.insertBefore(editorElement, preElement)
-    editor.setText(codeBlock.textContent.replace(/\r?\n$/, ''))
-    atom.grammars.assignLanguageMode(editor, scopeForFenceName(fenceName))
-    editor.setVisible(true)
+    // If the PRE changed its content, we need to change the content of its
+    // `TextEditor`.
+    if (editor.getText() !== editorText) {
+      editor.setReadOnly(false)
+      editor.setText(editorText)
+      editor.setReadOnly(true)
+    }
+
+    // If the PRE changed its language, we need to change the language of its
+    // `TextEditor`.
+    let scopeDescriptor = editor.getRootScopeDescriptor()[0]
+    let languageScope = scopeForFenceName(fenceName)
+    if (languageScope !== scopeDescriptor && `.${languageScope}` !== scopeDescriptor) {
+      reassignEditorToLanguage(editor, languageScope)
+    }
+
+    // If the editor is brand new, we'll have to insert it; otherwise it should
+    // already be in the right place.
+    if (!editorElement.parentNode) {
+      preElement.parentNode.insertBefore(editorElement, preElement)
+      editor.setVisible(true)
+    }
 
     promises.push(editorCallback(editorElement, preElement))
   }
   return Promise.all(promises)
 }
 
-var makeAtomEditorNonInteractive = function (editorElement, preElement) {
-  preElement.remove()
-  editorElement.setAttributeNode(document.createAttribute('gutter-hidden')) // Hide gutter
-  editorElement.removeAttribute('tabindex') // Make read-only
+function makeAtomEditorNonInteractive(editorElement) {
+  editorElement.setAttributeNode(document.createAttribute('gutter-hidden'))
+  editorElement.removeAttribute('tabindex')
 
   // Remove line decorations from code blocks.
   for (const cursorLineDecoration of editorElement.getModel()
@@ -276,9 +368,12 @@ var makeAtomEditorNonInteractive = function (editorElement, preElement) {
   }
 }
 
-var convertAtomEditorToStandardElement = (editorElement, preElement) => {
+function convertAtomEditorToStandardElement(editorElement, preElement) {
   return new Promise(function (resolve) {
     const editor = editorElement.getModel()
+    // In this code path, we're transplanting the highlighted editor HTML into
+    // the existing `pre` element, so we should empty its contents first.
+    preElement.innerHTML = ''
     const done = () =>
       editor.component.getNextUpdatePromise().then(function () {
         for (const line of editorElement.querySelectorAll(

--- a/packages/markdown-preview/lib/renderer.js
+++ b/packages/markdown-preview/lib/renderer.js
@@ -322,7 +322,6 @@ function highlightCodeBlocks(element, grammar, cache, editorCallback) {
     if (!editor) {
       editor = new TextEditor({ keyboardInputEnabled: false })
       editorElement = editor.getElement()
-      editorElement.setUpdatedSynchronously(true)
       editor.setReadOnly(true)
       cache?.addEditor(preElement, editor)
     } else {

--- a/packages/markdown-preview/package-lock.json
+++ b/packages/markdown-preview/package-lock.json
@@ -16,6 +16,7 @@
         "fs-plus": "^3.0.0",
         "github-markdown-css": "^5.5.1",
         "marked": "5.0.3",
+        "morphdom": "^2.7.2",
         "underscore-plus": "^1.0.0",
         "yaml-front-matter": "^4.1.1"
       },
@@ -23,7 +24,8 @@
         "temp": "^0.8.1"
       },
       "engines": {
-        "atom": "*"
+        "atom": "*",
+        "node": ">=12"
       }
     },
     "node_modules/@types/node": {
@@ -277,6 +279,11 @@
       "bin": {
         "mkdirp": "bin/cmd.js"
       }
+    },
+    "node_modules/morphdom": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/morphdom/-/morphdom-2.7.2.tgz",
+      "integrity": "sha512-Dqb/lHFyTi7SZpY0a5R4I/0Edo+iPMbaUexsHHsLAByyixCDiLHPHyVoKVmrpL0THcT7V9Cgev9y21TQYq6wQg=="
     },
     "node_modules/nth-check": {
       "version": "1.0.2",
@@ -566,6 +573,11 @@
       "requires": {
         "minimist": "0.0.8"
       }
+    },
+    "morphdom": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/morphdom/-/morphdom-2.7.2.tgz",
+      "integrity": "sha512-Dqb/lHFyTi7SZpY0a5R4I/0Edo+iPMbaUexsHHsLAByyixCDiLHPHyVoKVmrpL0THcT7V9Cgev9y21TQYq6wQg=="
     },
     "nth-check": {
       "version": "1.0.2",

--- a/packages/markdown-preview/package.json
+++ b/packages/markdown-preview/package.json
@@ -6,7 +6,8 @@
   "repository": "https://github.com/pulsar-edit/pulsar",
   "license": "MIT",
   "engines": {
-    "atom": "*"
+    "atom": "*",
+    "node": ">=12"
   },
   "scripts": {
     "generate-github-markdown-css": "node scripts/generate-github-markdown-css.js"
@@ -19,6 +20,7 @@
     "fs-plus": "^3.0.0",
     "github-markdown-css": "^5.5.1",
     "marked": "5.0.3",
+    "morphdom": "^2.7.2",
     "underscore-plus": "^1.0.0",
     "yaml-front-matter": "^4.1.1"
   },

--- a/packages/markdown-preview/spec/markdown-preview-spec.js
+++ b/packages/markdown-preview/spec/markdown-preview-spec.js
@@ -41,6 +41,13 @@ describe('Markdown Preview', function () {
           .getActiveItem())
     )
 
+    waitsFor(
+      'preview to finish loading',
+      () => {
+        return !preview.element.classList.contains('loading')
+      }
+    )
+
     runs(() => {
       expect(preview).toBeInstanceOf(MarkdownPreviewView)
       expect(preview.getPath()).toBe(

--- a/packages/markdown-preview/spec/markdown-preview-view-spec.js
+++ b/packages/markdown-preview/spec/markdown-preview-view-spec.js
@@ -198,12 +198,15 @@ function f(x) {
           () => renderSpy.callCount === 1
         )
 
-        runs(function () {
-          const rubyEditor = preview.element.querySelector(
-            "atom-text-editor[data-grammar='source ruby']"
-          )
-          expect(rubyEditor).toBeNull()
-        })
+        waitsFor(
+          'atom-text-editor to reassign all language modes after re-render',
+          () => {
+            let rubyEditor = preview.element.querySelector(
+              "atom-text-editor[data-grammar='source ruby']"
+            )
+            return rubyEditor == null
+          }
+        )
 
         waitsForPromise(() => atom.packages.activatePackage('language-ruby'))
 

--- a/packages/markdown-preview/styles/markdown-preview.less
+++ b/packages/markdown-preview/styles/markdown-preview.less
@@ -2,6 +2,7 @@
 // Global Markdown Preview styles
 
 .markdown-preview {
+  contain: paint;
 
   // Hide a `pre` that comes directly after an `atom-text-editor` because the
   // `atom-text-editor` is the syntax-highlighted representation.
@@ -35,14 +36,38 @@
   .task-list-item {
     list-style-type: none;
   }
+
+  &.loading {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+
+    // `.loading` on the preview element automatically shows the spinner/text.
+    // We add a slight animation delay so that, when the preview content is
+    // quick to appear (as usually happens), the spinner won't be shown. It
+    // only shows up when preview content takes a while to render.
+    &:before {
+      display: block;
+      content: 'Loading Markdown…';
+      margin: auto;
+      background-image: url(images/octocat-spinner-128.gif);
+      background-repeat: no-repeat;
+      background-size: 64px;
+      background-position: top center;
+      padding-top: 70px;
+      text-align: center;
+      opacity: 0;
+      animation-duration: 1s;
+      animation-name: appear-after-short-delay;
+      animation-delay: 0.75s;
+      animation-fill-mode: forwards;
+    }
+  }
 }
 
-.markdown-spinner {
-  margin: auto;
-  background-image: url(images/octocat-spinner-128.gif);
-  background-repeat: no-repeat;
-  background-size: 64px;
-  background-position: top center;
-  padding-top: 70px;
-  text-align: center;
+// Not an actual animation; we just use an animation so that it can appear
+// after a short delay.
+@keyframes appear-after-short-delay {
+  0% { opacity: 1; }
+  100% { opacity: 1; }
 }

--- a/packages/markdown-preview/styles/markdown-preview.less
+++ b/packages/markdown-preview/styles/markdown-preview.less
@@ -2,6 +2,13 @@
 // Global Markdown Preview styles
 
 .markdown-preview {
+
+  // Hide a `pre` that comes directly after an `atom-text-editor` because the
+  // `atom-text-editor` is the syntax-highlighted representation.
+  atom-text-editor + pre {
+    display: none;
+  }
+
   atom-text-editor {
     // only show scrollbars on hover
     .scrollbars-visible-always & {

--- a/spec/ui-spec.js
+++ b/spec/ui-spec.js
@@ -1,3 +1,4 @@
+const dedent = require('dedent');
 
 describe("Renders Markdown", () => {
   describe("properly when given no opts", () => {
@@ -6,6 +7,26 @@ describe("Renders Markdown", () => {
         .toBe("<p><strong>Hello World</strong></p>\n");
     });
   });
+
+  it(`escapes HTML in code blocks properly`, () => {
+    let input = dedent`
+    Lorem ipsum dolor.
+
+    \`\`\`html
+    <p>sit amet</p>
+    \`\`\`
+    `
+
+    let expected = dedent`
+    <p>Lorem ipsum dolor.</p>
+    <pre><code class="language-html">&lt;p&gt;sit amet&lt;/p&gt;
+    </code></pre>
+    `
+
+    expect(
+      atom.ui.markdown.render(input).trim()
+    ).toBe(expected);
+  })
 
   describe("transforms links correctly", () => {
     it("makes no changes to a fqdn link", () => {

--- a/src/ui.js
+++ b/src/ui.js
@@ -249,8 +249,8 @@ function renderMarkdown(content, givenOpts = {}) {
 
   // Here we can add some simple additions that make code highlighting possible later on,
   // but doesn't actually preform any code highlighting.
-  md.options.highlight = function(str, lang) {
-    return `<pre><code class="language-${lang}">${str}</code></pre>`;
+  md.options.highlight = function (str, lang) {
+    return `<pre><code class="language-${lang}">${md.utils.escapeHtml(str)}</code></pre>`;
   };
 
   // Process disables


### PR DESCRIPTION
…especially syntax highlighting.

### The Problem

Suppose you’re editing a large Markdown document with lots of code blocks. Actually, don’t suppose — give it a try. Take [one of my Tree-sitter blog posts](https://raw.githubusercontent.com/pulsar-edit/pulsar-edit.github.io/main/docs/blog/20231110-savetheclocktower-modern-tree-sitter-part-5.md) and put it into a Pulsar editor in Markdown mode. Now copy everything but the front matter and paste it at the end to double its size; you should have about 50 code blocks at this point.

Now open a Markdown preview pane with <kbd>Ctrl+Shift+M</kbd>. Make any change at all in the buffer and notice how irritable you suddently feel:

* In all cases, you should notice a pretty big hiccup in your editing experience.
* When the new Markdown parser is used — i.e., when **Use Original Parser** is unchecked in the settings — you’ll probably even notice that the syntax highlighting on each code block flickers with every change made.

This is a big enough annoyance to make me want to hide the preview.

The culprit here is the amount of time we spend doing things with editors. As you can imagine, it’s not exactly _cheap_ to create a new `TextEditor` instance for each code block whenever we re-render a preview. But the real pain is in the inserting-into-the-DOM phase; we pay a large cost in style recalculation because a very complex element is newly present on the page. The editor component commits one of the textbook “sins” of style recalculation: when the custom element is first added to the page, it reads its own `offsetWidth` and `offsetHeight` to determine whether it’s visible yet. That’s a “read” operation interleaved with a bunch of “write” operations — which the browser hates because it can no longer defer those writes until the most convenient time.

Years ago, the Atom developers realized they could use lots of new CSS tricks in order to speed up rendering and minimize style recalculation. My instinct is that a lot of those tricks work fine when the editor exists in its “natural” environment (taking up the entire width and height of a workspace pane) but not at all when the editor is in an unusual environment (existing among other elements in a static layout). But that’s just a guess.

I don’t know of an easy way to fix the underlying issue with TextEditor, but I do know of a way that we can make it not matter.

As I mentioned earlier, the main problem with `markdown-preview` is that the entire contents of the preview pane are replaced whenever the content changes. You don’t notice it because most of the content is the same, but it’s still a lot of work being done for what are usually very small changes. And it means that if you have 50 code blocks on a page, each one of those code blocks (and their `TextEditor`s) is disposed of and recreated every time you type something — even something that’s outside of the code blocks altogether.

### Description of the Change

If Markdown were costlier to render, we’d have had to fix this ages ago. It isn’t, so this is a problem that’s only ever cropped up in documents with lots of editors for syntax highlighting. So the fix is this:

* Introduce DOM “diffing” so that each re-render keeps the previous content on screen and alters it as little as possible to produce the new preview.
* Whenever a new code block appears in the preview output, create a `TextEditor` to represent its content instead of the `pre` tag. But _hide_ the `pre` tag instead of removing it, because otherwise the diffing is a pain.
* Cache the `TextEditor` instances and their custom `atom-text-editor` elements so that they don’t change during re-renders. The only cost we pay to create a new one is when a new code block appears on the page. And since the `pre` element _references_ themselves don’t change — because we’re diffing HTML, not replacing it — we can cache the editors using the `pre` elements themselves as the keys.

This is pretty straightforward. The strangest part of this is the fact that the `atom-text-editor` elements will be in the output, but we have to pretend they aren’t there during the diffing phase; if we didn’t, they’d get destroyed as part of diffing, since they’re not in the Markdown output that we’re trying to imitate. Luckily, [morphdom](https://www.npmjs.com/package/morphdom) — our diffing library — makes this pretty easy. (And it adds [only 5K](https://pkg-size.dev/morphdom) to our bundle size.)

This strategy for minimizing the cost of syntax highlighting is useful enough that we’ll want to use it in both parser modes, which means that we’ll no longer be asking `atom.ui.markdown` to do our syntax highlighting for us. It’ll be worth it.

### Quantitative Performance Benefits

My test was to create the document I described above — one of my blog posts, but doubled. Then I showed a Markdown preview pane and made some changes to the source outside of a text block.

Here's a “before” snapshot from a profiler. A single character change resulted in 1.5 seconds of editor lockup:

<p><img width="462" alt="Screenshot 2024-04-20 at 10 15 26 PM" src="https://github.com/pulsar-edit/pulsar/assets/3450/ef44dc34-4878-4c38-a7aa-12771198757e"></p>

On the other hand, the “after” snapshot captures me typing an entire sentence; each keystroke results in under 100ms of work. That's still a lot, but then this is a _huge_ document, and the dropped frames are barely noticeable. The tooltip in this screenshot describes just one of these narrower bars on the timeline.

<p><img width="455" alt="Screenshot 2024-04-20 at 10 18 36 PM" src="https://github.com/pulsar-edit/pulsar/assets/3450/9427ae01-5baa-4d8a-95c9-72596a470530"></p>

### Possible Drawbacks

The upside of our previous strategy (emptying the element and starting over every time) is that it cleans the slate between renders. Now that we’re trying to persist stuff, new edge cases emerge related to rendering.

I definitely had to do some experiments to make sure that editors are being destroyed when they ought to be, are being recreated when they ought to be, have their contents updated when they ought to, and change from one language to another when appropriate. Luckily, the existing spec suite was thorough enough to tell me exactly where I’d been remiss, and all the tests now pass.

### Verification Process

Mess around in that document I had you make at the top of this ticket. Stress-test it on both `master` and this branch. Do the things I mentioned in the previous section; switch a `js` code block to a `ts` code block, then switch it to a `tswtf` code block (a language string that maps to no grammar) just to make sure it turns back into an ordinary editor with no syntax highlighting.

### Applicable Issues

I pre-announced this PR in #893 in [this comment](https://github.com/pulsar-edit/pulsar/pull/893#issuecomment-2067823975) that nobody really asked for.

### Release Notes

* [markdown-preview] Improve rendering performance in preview panes, especially in documents with lots of fenced code blocks.

