### PR TITLE
allow non word characters at the start or end of ctrl+f whole word se…

### DIFF
--- a/packages/find-and-replace/lib/find-options.js
+++ b/packages/find-and-replace/lib/find-options.js
@@ -90,7 +90,7 @@ module.exports = class FindOptions {
       expression = escapeRegExp(this.findPattern);
     }
 
-    if (this.wholeWord) { expression = `\\b${expression}\\b`; }
+    if (this.wholeWord) { expression = `(?:^|\\W)${expression}(?:$|\\W)`; }
 
     return new RegExp(expression, flags);
   }


### PR DESCRIPTION

### Identify the Bug

#986

### Description of the Change

instead of matching for a word boundary (non-word to word, or word to non-word)

we match for (start|nonword) and then (end|nonword), but ignore the match

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Possible Drawbacks

"whole word" might be inaccurate
<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

<!--

What process did you follow to verify that the change has not introduced any regressions? Describe the actions you performed (including buttons you clicked, text you typed, commands you ran, etc.), and describe the results you observed.

-->

### Release Notes

Allow non-word characters at the start or end of (whole word) Find
<!--

Please describe the changes in a single line that explains this improvement in
terms that a user can understand. This text will be used in Atom's release notes.

If this change is not user-facing or notable enough to be included in release notes
you may use the strings "Not applicable" or "N/A" here.

Examples:

- The GitHub package now allows you to add co-authors to commits.
- Fixed an issue where multiple cursors did not work in a file with a single line.
- Increased the performance of searching and replacing across a whole project.

-->