### PR TITLE
Debugging when a package service is incorrect

### DIFF
--- a/src/package.js
+++ b/src/package.js
@@ -428,6 +428,8 @@ module.exports = class Package {
         methodName = versions[version];
         if (typeof this.mainModule[methodName] === 'function') {
           servicesByVersion[version] = this.mainModule[methodName]();
+        } else {
+          console.warn(`Package ${this.name} declares it provides ${name}@${version} but it doesn't expose a function in ${methodName}`)
         }
       }
       this.activationDisposables.add(
@@ -447,6 +449,8 @@ module.exports = class Package {
               this.mainModule[methodName].bind(this.mainModule)
             )
           );
+        } else {
+          console.warn(`Package ${this.name} declares it consumes ${name}@${version} but it doesn't expose a function in ${methodName}`)
         }
       }
     }


### PR DESCRIPTION
This PR is basically to add some debugging info for providers and consumers. Currently, when a package registers as a service provider or a service consumer, and doesn't actually implements the right interface (a function, basically) the package loader silently ignores it. This commit adds a warning to console so that we know a package did the wrong thing.
