### PR TITLE
CI: Pin to macOS 12 runner images instead of macos-latest (GiHub Actions)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ ubuntu-latest, macos-latest, windows-latest ]
+        os: [ ubuntu-latest, macos-12, windows-latest ]
         include:
           - os: ubuntu-latest
             image: "debian:10"

--- a/.github/workflows/editor-tests.yml
+++ b/.github/workflows/editor-tests.yml
@@ -15,8 +15,8 @@ jobs:
       !startsWith(github.event.pull_request.title, '[skip-editor-ci]')
     strategy:
       matrix:
-        # os: [ubuntu-20.04, macos-latest, windows-2019]
-        os: [ubuntu-20.04, macos-latest]
+        # os: [ubuntu-20.04, macos-12, windows-2019]
+        os: [ubuntu-20.04, macos-12]
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
### Identify the Bug

<!--

Link to the issue describing the bug that you're fixing.

If there is not yet an issue for your bug, please open a new issue and then link to that issue in your pull request.
Note: In some cases, one person's "bug" is another person's "feature." If the pull request does not address an existing issue with the "bug" label, the maintainers have the final say on whether the current behavior is a bug.

-->

Alternative to https://github.com/pulsar-edit/pulsar/issues/966

(PR body below is copied from https://github.com/pulsar-edit/pulsar/issues/966 and lightly modified to reflect `macos-12` runner image rather than `macos-13`.)

Was discussed in Discord: https://discord.com/channels/992103415163396136/1236740088487219320

To recap: There is an issue with the `libiconv` library apparently not being available in macOS 14 out of the box.
### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

Pin GitHub Actions macOS runner images to macOS 12 (`macos-12`), instead of `macos-latest` which is now resolving to `macos-14` (which is ARM64-based) as of some point in April for us.

Going for this solution as the `macos-latest` runner images now refer to macOS 14 on _ARM64_ ("Apple Silicon"), which is a big change and not one we're (I'm?) prepared to migrate to just at this moment, besides that it doesn't build on macOS 14 out of the box due to an issue of `libiconv` apparently not being compatible or available (?) out of the box. This should get us passing CI faster while we evaluate what we want to do about macOS 14/ARM64.

See:

- https://github.blog/changelog/2024-01-30-github-actions-introducing-the-new-m1-macos-runner-available-to-open-source/
  - "GitHub Actions: Introducing the new M1 macOS runner available to open source!"
- https://github.blog/changelog/2024-01-30-github-actions-macos-14-sonoma-is-now-available/
  - "GitHub Actions: macOS 14 (Sonoma) is now available"
- https://github.com/actions/runner-images/tree/7bb1d84f7071bfa9c350d7552d9631d9a69bfdb0?tab=readme-ov-file#available-images

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

First of all, see https://github.com/pulsar-edit/pulsar/issues/966, this is mainly being done in response to that PR having the same `libiconv` issue as macOS 14 runners do.

Could also try and build on macOS 14, which may be possible. Notes from @savetheclocktower on how to get `superstring` to build on macOS 14, from the Discord thread:

> yeah, so this was definitely about `libiconv`. I had it installed via homebrew already, so i just needed to do `export CPPFLAGS="-I/usr/local/opt/libiconv/include"` and then run `npm run build` again — that fixed the error on my machine

Not doing that for now, since if it builds on macOS 12 (`macos-12` runner image) without changes, that's a faster fix and a neater/tidier small scope.

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

This PR means not building on macOS 14 or ARM right away, even though the resolution of `macos-latest` has been updated to `macos-14` and it is thus the "default" / perhaps best-supported macOS runner for GitHub Actions now (?). But we weren't really expecting to build on macOS 14 all of a sudden, either. (Up until very recently (some time in April) `macos-latest` runner images resolved to `macos-12` on x86-64.)

So, arguably no drawbacks.

### Verification Process

<!--

What process did you follow to verify that the change has not introduced any regressions? Describe the actions you performed (including buttons you clicked, text you typed, commands you ran, etc.), and describe the results you observed.

-->

This is a CI fix, so I will be verifying it by checking whether CI passes or not.

### Release Notes

<!--

Please describe the changes in a single line that explains this improvement in
terms that a user can understand. This text will be used in Atom's release notes.

If this change is not user-facing or notable enough to be included in release notes
you may use the strings "Not applicable" or "N/A" here.

Examples:

- The GitHub package now allows you to add co-authors to commits.
- Fixed an issue where multiple cursors did not work in a file with a single line.
- Increased the performance of searching and replacing across a whole project.

-->

N/A