### PR TITLE
Update Renovate preset name

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,5 +1,5 @@
 {
-  "extends": [ "config:base", ":dependencyDashboardApproval"],
+  "extends": [ "config:recommended", ":dependencyDashboardApproval"],
   "constraints": {
     "node": "< 16"
   },


### PR DESCRIPTION
### Identify the Bug

You're using the old config preset name `config:base`. Renovate renamed this to `config:recommended` a while back, see [Renovate docs, breaking changes for 36](https://docs.renovatebot.com/release-notes-for-major-versions/#breaking-changes-for-36).

When Renovate runs, it migrates old terms to new terms _internally_. So you're already using the `config:recommended` preset.

But you _should_ use the new name in your Renovate config. That way you'll find the preset when you search the Renovate docs.

I think opening a issue just for this fix is a bit too much, so there's no issue for this PR.

### Description of the Change

- Replace `config:base` with the `config:recommended` preset

### Alternate Designs

- Keep using `config:base` at the risk of confusing yourself later
- Set [`configMigration`](https://docs.renovatebot.com/configuration-options/#configmigration) to `true` to get automatic configuration update PRs from Renovate. This is an **experimental** feature!

### Possible Drawbacks

This should have no side-effects or negative impacts, as Renovate already uses `config:recommended` internally.

### Verification Process

Double checked the preset name before opening the PR.

### Release Notes

Not applicable