### PR TITLE
CI: Fix workaround for Homebrew node in Cirrus on macOS

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -134,7 +134,6 @@ silicon_mac_task:
     ROLLING_UPLOAD_TOKEN: ENCRYPTED[f935c396a9f4bca108ec2fdedb00dbc9be2f4c411f100d577acdab42db59ea134be059ce8535396db8222a2b1eb68c27]
   prepare_script:
     - brew update
-    - brew uninstall node
     - brew install git python@$PYTHON_VERSION python-setuptools
     - git submodule init
     - git submodule update
@@ -199,7 +198,6 @@ silicon_mac_task:
 #     - arch -x86_64 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
 #     - export PATH="/usr/local/bin:$PATH"
 #     - arch -x86_64 brew update
-#     - arch -x86_64 brew uninstall node
 #     - arch -x86_64 brew install node@16 git python@$PYTHON_VERSION python-setuptools
 #     - ln -s /usr/local/bin/python$PYTHON_VERSION /usr/local/bin/python
 #     - npm install -g yarn

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -134,6 +134,7 @@ silicon_mac_task:
     ROLLING_UPLOAD_TOKEN: ENCRYPTED[f935c396a9f4bca108ec2fdedb00dbc9be2f4c411f100d577acdab42db59ea134be059ce8535396db8222a2b1eb68c27]
   prepare_script:
     - brew update
+    - brew uninstall node@20
     - brew install git python@$PYTHON_VERSION python-setuptools
     - git submodule init
     - git submodule update
@@ -198,6 +199,7 @@ silicon_mac_task:
 #     - arch -x86_64 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
 #     - export PATH="/usr/local/bin:$PATH"
 #     - arch -x86_64 brew update
+#     - arch -x86_64 brew uninstall node@20
 #     - arch -x86_64 brew install node@16 git python@$PYTHON_VERSION python-setuptools
 #     - ln -s /usr/local/bin/python$PYTHON_VERSION /usr/local/bin/python
 #     - npm install -g yarn


### PR DESCRIPTION
This workaround was necessary before because something broke.

Now the workaround is the thing that breaks things.

Go figure. \[EDIT: workaround just needed to be tweaked to hit the right package name. Mostly still valid after all.\]

---

Follow-up to https://github.com/pulsar-edit/pulsar/pull/961.

This one is a little more straight-forward than 961, thank goodness. Apparently, Homebrew's `node` cask is _not_ preinstalled anymore in the latest CI base images we've been auto-updated to, so trying to _remove it_ gives an _error_ now.

Solution: _Don't do that._ 👍 (Remove `node@20` cask instead!)


### Verification Process

Ran this through Cirrus via a custom cron job. It worked. CI is passing for that run with the fix. 👍
https://cirrus-ci.com/task/5146025353019392