### PR TITLE
Cirrus: Fix `gem install fpm` on ARM Linux

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -72,6 +72,7 @@ arm_linux_task:
                 procps
                 curl
                 ruby
+                ruby-dev
                 rpm
                 build-essential
                 git


### PR DESCRIPTION
### Issue

Arm Linux CI builds are failing on Cirrus. See this failing CI run: https://cirrus-ci.com/task/6219208260845568?logs=prepare#L2634-L2639

### Issue Details

From the error message :
`mkmf.rb can't find header files for ruby at /usr/lib/ruby/include/ruby.h`

And from this StackOverflow answer: https://stackoverflow.com/questions/20559255/error-while-installing-json-gem-mkmf-rb-cant-find-header-files-for-ruby

I think we just need to install `ruby-dev` package in the Debian container.

### Solution

Apparently we need `ruby-dev` (development headers) package to build fpm gem's native extensions now?!

Well, it's an easy fix. Not sure why we didn't need this up until now, but oh, well.

### Verification process

~~Test run in Cirrus: https://cirrus-ci.com/task/5547408132669440~~

Re-run of the test run in Cirrus: https://cirrus-ci.com/task/4548855918755840