### PR TITLE
Changelog: Update Changelog for 1.118.0 Regular release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@
 - Project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
+
+## 1.118.0
+
+- Various tree-sitter grammar improvements
+  - Docs fixes
+  - A parser update for PHP
+  - Miscellaneous grammar fixes and improvements
+- Add a preference `core.allowWindowTransparency` so that themes and user stylesheets
+  can make editor windows' backgrounds transparent.
 - Added a new modern tree sitter "test" for highlight query - `ancestorTypeNearerThan`
   that matches if it finds the _first_ type as an ancestor, but _not matches_ if
   any "other" ancestors are found before
@@ -17,6 +26,17 @@
   injection points on Clojure. Added support for highligting metadata, and added
   better support for "def" elements (example - don't syntax `default` or
   `definition` as a `def`, but highlights `p/defresolver`)
+- Fix `textChanged` property to be accurate when deleting characters
+- Fix `ppm publish` for publishing brand new packages
+
+### Pulsar
+
+- Fixed: Tree-sitter rolling fixes, 1.118 edition [@savetheclocktower](https://github.com/pulsar-edit/pulsar/pull/1010)
+- Added: src: Allow windows to be transparent, behind a pref (off by default) [@DeeDeeG](https://github.com/pulsar-edit/pulsar/pull/982)
+- Added: Another batch of Clojure enhancements [@mauricioszabo](https://github.com/pulsar-edit/pulsar/pull/729)
+- Fixed: Fix `onDidChangeCursorPosition` callback event property on deleting characters [@mauricioszabo](https://github.com/pulsar-edit/pulsar/pull/810)
+- Bumped: Update ppm to commit 3542dee00f4622f7458f2f65f05e5 [@DeeDeeG](https://github.com/pulsar-edit/pulsar/pull/1014)
+- Updated: Cirrus: Update Rolling upload token [@DeeDeeG](https://github.com/pulsar-edit/pulsar/pull/1011)
 
 ## 1.117.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,22 +12,22 @@
   - Docs fixes
   - A parser update for PHP
   - Miscellaneous grammar fixes and improvements
-- Add a preference `core.allowWindowTransparency` so that themes and user stylesheets
+- Added a preference `core.allowWindowTransparency` so that themes and user stylesheets
   can make editor windows' backgrounds transparent.
 - Added a new modern tree sitter "test" for highlight query - `ancestorTypeNearerThan`
-  that matches if it finds the _first_ type as an ancestor, but _not matches_ if
+  that matches if it finds the _first_ type as an ancestor, but _doesn't match_ if
   any "other" ancestors are found before
 - Syntax quoting and unquoting in Clojure now highlights correctly, and also
   highlights full qualified keywords differently than generated ones
 - `content` field of addInjectionPoint for modern-tree-sitter now supports a second
   `buffer` argument, for better customization if one wants to
-- EDN is back to be detected as Clojure (for compatibility) but highlights as EDN
+- EDN is back to being detected as Clojure (for compatibility) but highlights as EDN
 - Fixed syntax quoting on Clojure grammar (newer tree-sitter), fixed some
   injection points on Clojure. Added support for highligting metadata, and added
-  better support for "def" elements (example - don't syntax `default` or
+  better support for "def" elements (for example - doesn't scope `default` or
   `definition` as a `def`, but highlights `p/defresolver`)
-- Fix `textChanged` property to be accurate when deleting characters
-- Fix `ppm publish` for publishing brand new packages
+- Fixed `textChanged` property to be accurate when deleting characters
+- Fixed `ppm publish` for publishing brand new packages
 
 ### Pulsar
 

--- a/packages/welcome/lib/changelog-view.js
+++ b/packages/welcome/lib/changelog-view.js
@@ -50,25 +50,42 @@ export default class ChangeLogView {
             <p>Feel free to read our <a href="https://github.com/pulsar-edit/pulsar/blob/master/CHANGELOG.md">Full Change Log</a>.</p>
             <ul>
               <li>
-                [markdown-preview] Improve rendering performance in preview panes, especially in documents with lots of fenced code blocks.
+                Various tree-sitter grammar improvements
+                <ul>
+                  <li>
+                    Docs Fixes
+                  </li>
+                  <li>
+                    A parser update for PHP
+                  </li>
+                  <li>
+                    Miscellaneous grammar fixes and improvements
+                  </li>
+                </ul>
               </li>
               <li>
-                [markdown-preview] GitHub-style Markdown preview now uses up-to-date styles and supports dark mode.
+                Add a preference <code>core.allowWindowTransparency</code> so that themes and user stylesheets can make editor windows' backgrounds transparent.
               </li>
               <li>
-                Pulsar's OS level theme will now change according to the selected editor theme if <code>core.syncWindowThemeWithPulsarTheme</code> is enabled.
+                Added a new modern tree sitter "test" for highlight query - <code>ancestorTypeNearerThan</code> that matches if it finds the <i>first</i> type as an ancestor, but <i>not matches</i> if any "other" ancestors are found before
               </li>
               <li>
-                [language-sass] Add SCSS Tree-sitter grammar.
+                Syntax quoting and unquoting in Clojure now highlights correctly, and also highlights full qualified keywords differently than generated ones
               </li>
               <li>
-                [language-ruby] Update to latest Tree-sitter Ruby parser.
+                <code>content</code> field of addInjectionPoint for modern-tree-sitter now supports a second <code>buffer</code> argument, for better customization if one wants to
               </li>
               <li>
-                [language-gfm] Make each block-level HTML tag its own injection.
+                EDN is back to be detected as Clojure (for compatibility) but highlights as EDN
               </li>
               <li>
-                [language-typescript] More highlighting fixes, especially for operators.
+                Fixed syntax quoting on Clojure grammar (newer tree-sitter), fixed some injection points on Clojure. Added support for highligting metadata, and added better support for "def" elements (example - don't syntax <code>default</code> or <code>definition</code> as a <code>def</code>, but highlights <code>p/defresolver</code>)
+              </li>
+              <li>
+                Fix <code>textChanged</code> property to be accurate when deleting characters
+              </li>
+              <li>
+                Fix <code>ppm publish</code> for publishing brand new packages
               </li>
             </ul>
 

--- a/packages/welcome/lib/changelog-view.js
+++ b/packages/welcome/lib/changelog-view.js
@@ -64,10 +64,10 @@ export default class ChangeLogView {
                 </ul>
               </li>
               <li>
-                Add a preference <code>core.allowWindowTransparency</code> so that themes and user stylesheets can make editor windows' backgrounds transparent.
+                Added a preference <code>core.allowWindowTransparency</code> so that themes and user stylesheets can make editor windows' backgrounds transparent.
               </li>
               <li>
-                Added a new modern tree sitter "test" for highlight query - <code>ancestorTypeNearerThan</code> that matches if it finds the <i>first</i> type as an ancestor, but <i>not matches</i> if any "other" ancestors are found before
+                Added a new modern tree sitter "test" for highlight query - <code>ancestorTypeNearerThan</code> that matches if it finds the <i>first</i> type as an ancestor, but <i>doesn't match</i> if any "other" ancestors are found before
               </li>
               <li>
                 Syntax quoting and unquoting in Clojure now highlights correctly, and also highlights full qualified keywords differently than generated ones
@@ -76,16 +76,16 @@ export default class ChangeLogView {
                 <code>content</code> field of addInjectionPoint for modern-tree-sitter now supports a second <code>buffer</code> argument, for better customization if one wants to
               </li>
               <li>
-                EDN is back to be detected as Clojure (for compatibility) but highlights as EDN
+                EDN is back to being detected as Clojure (for compatibility) but highlights as EDN
               </li>
               <li>
-                Fixed syntax quoting on Clojure grammar (newer tree-sitter), fixed some injection points on Clojure. Added support for highligting metadata, and added better support for "def" elements (example - don't syntax <code>default</code> or <code>definition</code> as a <code>def</code>, but highlights <code>p/defresolver</code>)
+                Fixed syntax quoting on Clojure grammar (newer tree-sitter), fixed some injection points on Clojure. Added support for highligting metadata, and added better support for "def" elements (for example - doesn't scope <code>default</code> or <code>definition</code> as a <code>def</code>, but highlights <code>p/defresolver</code>)
               </li>
               <li>
-                Fix <code>textChanged</code> property to be accurate when deleting characters
+                Fixed <code>textChanged</code> property to be accurate when deleting characters
               </li>
               <li>
-                Fix <code>ppm publish</code> for publishing brand new packages
+                Fixed <code>ppm publish</code> for publishing brand new packages
               </li>
             </ul>
 


### PR DESCRIPTION
Adding the Changelog entries for 1.118.0.

(Some of these were populated under "Unreleased" from the big Clojurescript enhancement PR, and are now under a new "1.118.0" heading instead, as per the usual process.)

The highlights in Welcome package's `lib/changelog-view.js` are probably longer than usual. But I don't see a problem with that!

![Changelog view from Welcome package for 1 118 0, after grammar and copy editing](https://github.com/pulsar-edit/pulsar/assets/20157115/5ea9d0cb-0f92-48d1-bd70-bfcb0c4e1799)
