### PR TITLE
electron-builder: Add '--no-sandbox' launch arg for Linux build targets

### DIFF
--- a/script/electron-builder.js
+++ b/script/electron-builder.js
@@ -176,6 +176,7 @@ let options = {
         "to": "pulsar.svg"
       },
     ],
+    "executableArgs": ['--no-sandbox'],
   },
   "mac": {
     "icon": icnsIcon,


### PR DESCRIPTION
Fixes Dev Tools not being able to be opened, among other subtle issue.

This is a frequently reported bug, and we try to apply this workaround elsewhere, it's just that the .desktop file that electron-builder generates skips the workaround we have applie e.g. in the /us/bin/pulsar launcher script.

### Identify the Bug

<!--

Link to the issue describing the bug that you're fixing.

If there is not yet an issue for your bug, please open a new issue and then link to that issue in your pull request.
Note: In some cases, one person's "bug" is another person's "feature." If the pull request does not address an existing issue with the "bug" label, the maintainers have the final say on whether the current behavior is a bug.

-->

Appears to apply to:

- https://github.com/pulsar-edit/pulsar/issues/199
- https://github.com/pulsar-edit/pulsar/issues/437

_May_ apply to:

- https://github.com/pulsar-edit/pulsar/issues/397
- https://github.com/pulsar-edit/pulsar/issues/828

### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

Specify the `--no-sandbox` flag in our `linux` config for `electron-builder`.

This adds a `--no-sandbox` flag to the `.desktop` file installed by the `.deb` installer, allowing Dev Tools to work as expected with our older (pre-13) version of Electron on newer Linux distros when launching Pulsar from the OS's graphical app launcher interface.

_This is the same workaround we already do in our launcher bash script `/usr/bin/pulsar`. Just applying the workaround here too, so we are consistently applying the workaround for all the ways a user has available to launch Pulsar (I hope this gets all of them), at least for our officially supported releases. (This probably doesn't affect the community-supported FlatPak.)_

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

- The `--in-process-gpu` flag is a quirkier, potentially less-compatible alternative when compared to `--no-sandbox`. I consider it a less reliable workaround than `--no-sandbox`, however. I think `--in-process-gpu` may be buggy for some scenarios, if I recall correctly, but it's honestly hard to comprehensively know these things for all of the Linux ecosystem at once.
- We can stop using either flag (and still retain working Dev Tools!) once we get on Electron 13 or newer, if I recall correctly.
- Users who prefer the sandbox to be on, at the expense of not being able to access Dev Tools, can remove the flag from their `.desktop` launcher file manually.
- I tried making the `.desktop` file point to our launcher bash script `/usr/bin/pulsar` instead (this should be another way that users can apply the `--no-sandbox` workaround, if they can edit that path to be the "Exec=" line of the `.desktop` file) but I had no luck getting `electron-builder` to accept that as the executable path in the `electron-builder` config script.

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

Having no sandboxing in place is presumably a bona-fide security downgrade.

However, Atom's security posture, which we have inherited, has relied mostly on trusting package authors -- packages are able to do essentially arbitrary code execution by way of the NodeJS and Atom APIs. "Sandboxing" against untrusted code seems to me to be patching a whole in the wall while the gate is wide open. A good idea, but also not a comprehensive solution for the threat model of Atom/Pulsar, IMO. Meanwhile, and for what it's worth, browsing arbitrary _websites_ is not particularly easy in Atom/Pulsar, if it can indeed be done. Thankfully, most packages don't appear to do stuff over the network, once they've been installed. But there is no guarantee of this, to my knowledge.

Regardless of whether that assessment of the threat model is perfect or not, we have users who ask for the Dev Tools to be available, and this is the workaround needed to do it.

_NOTE: We have applied this workaround for a while now via the bash launcher script `/usr/bin/pulsar`. This is just being consistent by applying it to the GUI launcher as well._

### Verification Process

<!--

What process did you follow to verify that the change has not introduced any regressions? Describe the actions you performed (including buttons you clicked, text you typed, commands you ran, etc.), and describe the results you observed.

-->

Ran CI with this change on my personal fork of Pulsar. Using the binaries built with this change, on a VM running a Ubuntu 24.04 Live session, after installing the `.deb`, Pulsar was launchable from the OS's GUI app launcher and Dev Tools worked fine.

(Without this change, there were errors, and the app wouldn't launch at all from the OS's GUI launcher, if I recall correctly. But running `pulsar` from the terminal worked fine, with or without this PR's change, as `pulsar` in the terminal calls the bash launcher script `/usr/bin/pulsar`, which has the `--no-sandbox` flag applied already, from well before this PR.)

### Release Notes

<!--

Please describe the changes in a single line that explains this improvement in
terms that a user can understand. This text will be used in Atom's release notes.

If this change is not user-facing or notable enough to be included in release notes
you may use the strings "Not applicable" or "N/A" here.

Examples:

- The GitHub package now allows you to add co-authors to commits.
- Fixed an issue where multiple cursors did not work in a file with a single line.
- Increased the performance of searching and replacing across a whole project.

-->

Fixed `--no-sandbox` flag not being applied to the `.desktop` launcher on Linux (Fixes Dev Tools)