### PR TITLE
Fixed delete to beginning and end of line

### DIFF
--- a/src/selection.js
+++ b/src/selection.js
@@ -657,7 +657,7 @@ module.exports = class Selection {
         prevRange, '', pick(options, 'undo', 'normalizeLineEndings')
       );
     } else {
-      const startOfLinePoint = new Point(this.cursor.getScreenRow(), 0);
+      const startOfLinePoint = new Point(this.cursor.getBufferRow(), 0);
       const prevRange = new Range(startPoint, startOfLinePoint);
       this.editor.buffer.setTextInRange(
         prevRange, '', pick(options, 'undo', 'normalizeLineEndings')
@@ -692,7 +692,7 @@ module.exports = class Selection {
       this.delete(options);
     } else {
       this._deleteToNextPoint(
-        new Point(this.cursor.getScreenRow(), Infinity),
+        new Point(this.cursor.getBufferRow(), Infinity),
         options
       );
     }


### PR DESCRIPTION
After https://github.com/pulsar-edit/pulsar/issues/810, delete to beginning and end of line are broken when soft-wrap is selected.

This PR fixes this behavior, but also changes the way "delete to end of line" works in original Atom - originally, it would delete to the end of the "visible line" - so, if one had the following code:

![image](https://github.com/pulsar-edit/pulsar/assets/138037/d040af9a-5839-409a-8bca-769aa31e8540)

And hit "delete to the end of line", this would be the result:

![image](https://github.com/pulsar-edit/pulsar/assets/138037/88565129-7da2-42ab-abf8-5b7d3f4a1cc5)

Now, it deletes the whole line:

![image](https://github.com/pulsar-edit/pulsar/assets/138037/13c05958-97fe-4438-b168-962843617213)

We might want to vote to check if that's the behavior we want