### PR TITLE
Link to Homebrew version of `libiconv`…

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -137,10 +137,13 @@ silicon_mac_task:
     - brew update
     - brew uninstall node@20
     - brew install git python@$PYTHON_VERSION python-setuptools
+    - brew install libiconv
     - git submodule init
     - git submodule update
     - ln -s /opt/homebrew/bin/python$PYTHON_VERSION /opt/homebrew/bin/python
     - export PATH="/opt/homebrew/bin:$PATH"
+    - export LDFLAGS="-L$(brew --prefix)/opt/libiconv/lib"
+    - export CPPFLAGS="-I$(brew --prefix)/opt/libiconv/include"
     - mkdir tj_n && cd tj_n
     - curl -L https://github.com/tj/n/archive/0ce85771fdff8f4b3e09ade700461b4f58a64444.tar.gz -O
     - tar xf 0ce85771fdff8f4b3e09ade700461b4f58a64444.tar.gz
@@ -150,9 +153,13 @@ silicon_mac_task:
     - sed -i -e "s/[0-9]*-dev/`date -u +%Y%m%d%H`/g" package.json
   install_script:
     - export PATH="/opt/homebrew/bin:$PATH"
+    - export LDFLAGS="-L$(brew --prefix)/opt/libiconv/lib"
+    - export CPPFLAGS="-I$(brew --prefix)/opt/libiconv/include"
     - yarn install --ignore-engines || yarn install --ignore-engines
   build_script:
     - export PATH="/opt/homebrew/bin:$PATH"
+    - export LDFLAGS="-L$(brew --prefix)/opt/libiconv/lib"
+    - export CPPFLAGS="-I$(brew --prefix)/opt/libiconv/include"
     - yarn build
     - yarn run build:apm
   build_binary_script:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -142,8 +142,6 @@ silicon_mac_task:
     - git submodule update
     - ln -s /opt/homebrew/bin/python$PYTHON_VERSION /opt/homebrew/bin/python
     - export PATH="/opt/homebrew/bin:$PATH"
-    - export LDFLAGS="-L$(brew --prefix)/opt/libiconv/lib"
-    - export CPPFLAGS="-I$(brew --prefix)/opt/libiconv/include"
     - mkdir tj_n && cd tj_n
     - curl -L https://github.com/tj/n/archive/0ce85771fdff8f4b3e09ade700461b4f58a64444.tar.gz -O
     - tar xf 0ce85771fdff8f4b3e09ade700461b4f58a64444.tar.gz


### PR DESCRIPTION
…to work around incompatible version of `libiconv` bundled with newer versions of XCode.

For whatever reason, macOS v13 and greater have a version of `libiconv` with API incompatibilities with what `superstring` expects. The fix is to use Homebrew's version of `libiconv` and specify the library path via `LDFLAGS` and `CPPFLAGS` (though it's possible we only need the former).

It's nearly certain that we'll eventually need this fix for building Intel Mac binaries as well. I think it's just that CirrusCI forced us off of macOS 12 before GitHub did.