### PR TITLE
Remove ambiguity in all text movement method names…

### DIFF
--- a/src/cursor.js
+++ b/src/cursor.js
@@ -356,18 +356,25 @@ module.exports = class Cursor extends Model {
     this.goalColumn = column;
   }
 
-  // Public: Moves the cursor to the beginning of the line.
+  // Public: Moves the cursor to the beginning of the screen line.
   moveToBeginningOfScreenLine() {
     this.setScreenPosition([this.getScreenRow(), 0]);
   }
 
   // Public: Moves the cursor to the beginning of the buffer line.
+  //
+  // Deprecated; prefer {::moveToBeginningOfBufferLine}.
   moveToBeginningOfLine() {
+    this.moveToBeginningOfBufferLine();
+  }
+
+  // Public: Moves the cursor to the beginning of the buffer line.
+  moveToBeginningOfBufferLine() {
     this.setBufferPosition([this.getBufferRow(), 0]);
   }
 
-  // Public: Moves the cursor to the beginning of the first character in the
-  // line.
+  // Public: Moves the cursor to the beginning of the first non-whitespace
+  // character in the screen line.
   moveToFirstCharacterOfLine() {
     let targetBufferColumn;
     const screenRow = this.getScreenRow();
@@ -405,13 +412,20 @@ module.exports = class Cursor extends Model {
     ]);
   }
 
-  // Public: Moves the cursor to the end of the line.
+  // Public: Moves the cursor to the end of the screen line.
   moveToEndOfScreenLine() {
     this.setScreenPosition([this.getScreenRow(), Infinity]);
   }
 
   // Public: Moves the cursor to the end of the buffer line.
+  //
+  // Deprecated; prefer {::moveToEndOfBufferLine}.
   moveToEndOfLine() {
+    this.moveToEndOfBufferLine();
+  }
+
+  // Public: Moves the cursor to the end of the buffer line.
+  moveToEndOfBufferLine() {
     this.setBufferPosition([this.getBufferRow(), Infinity]);
   }
 

--- a/src/selection.js
+++ b/src/selection.js
@@ -308,27 +308,49 @@ module.exports = class Selection {
   }
 
   // Public: Selects all the text from the current cursor position to the
-  // beginning of the line.
+  // beginning of the buffer line.
+  //
+  // Deprecated; prefer {::selectToBeginningOfBufferLine}.
   selectToBeginningOfLine() {
-    this.modifySelection(() => this.cursor.moveToBeginningOfLine());
+    this.selectToBeginningOfBufferLine();
+  }
+
+  // Public: Selects all the text from the current cursor position to the
+  // beginning of the screen line.
+  selectToBeginningOfScreenLine() {
+    this.modifiySelection(() => this.cursor.moveToBeginningOfScreenLine());
+  }
+
+  // Public: Selects all the text from the current cursor position to the
+  // beginning of the buffer line.
+  selectToBeginningOfBufferLine() {
+    this.modifySelection(() => this.cursor.moveToBeginningOfBufferLine());
   }
 
   // Public: Selects all the text from the current cursor position to the first
-  // character of the line.
+  // non-whitespace character of the screen line.
   selectToFirstCharacterOfLine() {
     this.modifySelection(() => this.cursor.moveToFirstCharacterOfLine());
   }
 
+  // Public: Selects all the text from the current cursor position to the end
+  // of the screen line.
+  //
+  // Deprecated; prefer {::selectToEndOfScreenLine}.
+  selectToEndOfLine() {
+    this.selectToEndOfScreenLine();
+  }
+
   // Public: Selects all the text from the current cursor position to the end of
   // the screen line.
-  selectToEndOfLine() {
+  selectToEndOfScreenLine() {
     this.modifySelection(() => this.cursor.moveToEndOfScreenLine());
   }
 
   // Public: Selects all the text from the current cursor position to the end of
   // the buffer line.
   selectToEndOfBufferLine() {
-    this.modifySelection(() => this.cursor.moveToEndOfLine());
+    this.modifySelection(() => this.cursor.moveToEndOfBufferLine());
   }
 
   // Public: Selects all the text from the current cursor position to the
@@ -632,14 +654,41 @@ module.exports = class Selection {
     this.deleteSelectedText(options);
   }
 
-  // Public: Removes from the beginning of the line which the selection begins on
-  // all the way through to the end of the selection.
+  // Public: Removes from the beginning of the buffer line which the selection
+  // begins on all the way through to the end of the selection.
+  //
+  // Deprecated; prefer {::deleteToBeginningOfBufferLine}.
+  deleteToBeginningOfLine(options = {}) {
+    return this.deleteToBeginningOfBufferLine(options);
+  }
+
+  // Public: Removes all text from the beginning of the buffer line which the
+  // selection begins on all the way through to the end of the selection. When
+  // the cursor is on the first column of the buffer line and the selection is
+  // empty, deletes the preceding newline character.
   //
   // * `options` (optional) {Object}
   //   * `bypassReadOnly` (optional) {Boolean} Must be `true` to modify text within a read-only editor. (default: false)
-  deleteToBeginningOfLine(options = {}) {
-    if (!this.ensureWritable('deleteToBeginningOfLine', options)) return;
+  deleteToBeginningOfBufferLine(options = {}) {
+    if (!this.ensureWritable('deleteToBeginningOfBufferLine', options)) return;
     if (this.isEmpty() && this.cursor.isAtBeginningOfLine()) {
+      this.selectLeft();
+    } else {
+      this.selectToBeginningOfLine();
+    }
+    this.deleteSelectedText(options);
+  }
+
+  // Public: Removes all text from the beginning of the screen line which the
+  // selection begins on all the way through to the end of the selection. When
+  // the cursor is on the first column of the buffer line and the selection is
+  // empty, deletes the preceding newline character.
+  //
+  // * `options` (optional) {Object}
+  //   * `bypassReadOnly` (optional) {Boolean} Must be `true` to modify text within a read-only editor. (default: false)
+  deleteToBeginningOfScreenLine(options = {}) {
+    if (!this.ensureWritable('deleteToBeginningOfBufferLine', options)) return;
+    if (this.isEmpty()) {
       this.selectLeft();
     } else {
       this.selectToBeginningOfLine();
@@ -659,20 +708,45 @@ module.exports = class Selection {
   }
 
   // Public: If the selection is empty, removes all text from the cursor to the
-  // end of the line. If the cursor is already at the end of the line, it
-  // removes the following newline. If the selection isn't empty, only deletes
-  // the contents of the selection.
+  // end of the screen line. If the cursor is already at the end of the screen
+  // line, it takes no action. If the selection isn't empty, only deletes the
+  // contents of the selection.
+  //
+  // Deprecated; prefer {::deleteToEndOfScreenLine}.
+  deleteToEndOfLine(options = {}) {
+    return this.deleteToEndOfScreenLine(options);
+  }
+
+  // Public: If the selection is empty, removes all text from the cursor to the
+  // end of the screen line. If the cursor is already at the end of the screen
+  // line, it takes no action. If the selection isn't empty, only deletes the
+  // contents of the selection.
   //
   // * `options` (optional) {Object}
   //   * `bypassReadOnly` (optional) {Boolean} Must be `true` to modify text within a read-only editor. (default: false)
-  deleteToEndOfLine(options = {}) {
-    if (!this.ensureWritable('deleteToEndOfLine', options)) return;
+  deleteToEndOfScreenLine(options = {}) {
+    if (!this.ensureWritable('deleteToEndOfScreenLine', options)) return;
+    if (this.isEmpty()) {
+      this.selectToEndOfScreenLine();
+    }
+    this.deleteSelectedText(options);
+  }
+
+  // Public: If the selection is empty, removes all text from the cursor to the
+  // end of the buffer line. If the cursor is already at the end of the buffer
+  // line, it deletes the following newline. If the selection isn't empty, only
+  // deletes the contents of the selection.
+  //
+  // * `options` (optional) {Object}
+  //   * `bypassReadOnly` (optional) {Boolean} Must be `true` to modify text within a read-only editor. (default: false)
+  deleteToEndOfBufferLine(options = {}) {
+    if (!this.ensureWritable('deleteToEndOfBufferLine', options)) return;
     if (this.isEmpty()) {
       if (this.cursor.isAtEndOfLine()) {
         this.delete(options);
         return;
       }
-      this.selectToEndOfLine();
+      this.selectToEndOfBufferLine();
     }
     this.deleteSelectedText(options);
   }
@@ -861,10 +935,17 @@ module.exports = class Selection {
 
   // Public: Cuts the selection until the end of the screen line.
   //
+  // Deprecated; prefer {::cutToEndOfScreenLine}.
+  cutToEndOfLine(maintainClipboard, options = {}) {
+    return this.cutToEndOfScreenLine(maintainClipboard, options);
+  }
+
+  // Public: Cuts the selection until the end of the screen line.
+  //
   // * `maintainClipboard` {Boolean}
   // * `options` (optional) {Object}
   //   * `bypassReadOnly` (optional) {Boolean} Must be `true` to modify text within a read-only editor. (default: false)
-  cutToEndOfLine(maintainClipboard, options = {}) {
+  cutToEndOfScreenLine(maintainClipboard, options = {}) {
     if (!this.ensureWritable('cutToEndOfLine', options)) return;
     if (this.isEmpty()) this.selectToEndOfLine();
     return this.cut(maintainClipboard, false, options.bypassReadOnly);

--- a/src/text-editor.js
+++ b/src/text-editor.js
@@ -2352,29 +2352,73 @@ module.exports = class TextEditor {
     );
   }
 
-  // Extended: For each selection, if the selection is empty, delete all characters
-  // of the containing line that precede the cursor. Otherwise delete the
-  // selected text.
+  // Extended: For each selection, if the selection is empty, delete all
+  // characters of the containing buffer line that precede the cursor.
+  // Otherwise delete the selected text.
+  //
+  // Deprecated; prefer {::deleteToBeginningOfBufferLine}.
+  deleteToBeginningOfLine() {
+    return this.deleteToBeginningOfBufferLine();
+  }
+
+  // Extended: For each selection, if the selection is empty, delete all
+  // characters of the containing buffer line that precede the cursor.
+  // Otherwise delete the selected text.
   //
   // * `options` (optional) {Object}
   //   * `bypassReadOnly` (optional) {Boolean} Must be `true` to modify a read-only editor. (default: false)
-  deleteToBeginningOfLine(options = {}) {
-    if (!this.ensureWritable('deleteToBeginningOfLine', options)) return;
+  deleteToBeginningOfBufferLine(options = {}) {
+    if (!this.ensureWritable('deleteToBeginningOfBufferLine', options)) return;
     this.mutateSelectedText(selection =>
-      selection.deleteToBeginningOfLine(options)
+      selection.deleteToBeginningOfBufferLine(options)
+    );
+  }
+
+  // Extended: For each selection, if the selection is empty, delete all
+  // characters of the containing screen line that precede the cursor.
+  // Otherwise delete the selected text.
+  //
+  // * `options` (optional) {Object}
+  //   * `bypassReadOnly` (optional) {Boolean} Must be `true` to modify a read-only editor. (default: false)
+  deleteToBeginningOfScreenLine(options = {}) {
+    if (!this.ensureWritable('deleteToBeginningOfScreenLine', options)) return;
+    this.mutateSelectedText(selection =>
+      selection.deleteToBeginningOfScreenLine(options)
     );
   }
 
   // Extended: For each selection, if the selection is not empty, deletes the
-  // selection; otherwise, deletes all characters of the containing line
+  // selection; otherwise, deletes all characters of the containing screen line
+  // following the cursor. If the cursor is already at the end of the screen
+  // line, takes no action.
+  //
+  // Deprecated; prefer {::deleteToEndOfScreenLine}.
+  deleteToEndOfLine(options = {}) {
+    return this.deleteToEndOfScreenLine(options);
+  }
+
+  // Extended: For each selection, if the selection is not empty, deletes the
+  // selection; otherwise, deletes all characters of the containing screen line
+  // following the cursor. If the cursor is already at the end of the screen
+  // line, takes no action.
+  //
+  // * `options` (optional) {Object}
+  //   * `bypassReadOnly` (optional) {Boolean} Must be `true` to modify a read-only editor. (default: false)
+  deleteToEndOfScreenLine(options = {}) {
+    if (!this.ensureWritable('deleteToEndOfScreenLine', options)) return;
+    this.mutateSelectedText(selection => selection.deleteToEndOfScreenLine(options));
+  }
+
+  // Extended: For each selection, if the selection is not empty, deletes the
+  // selection; otherwise, deletes all characters of the containing buffer line
   // following the cursor. If the cursor is already at the end of the line,
   // deletes the following newline.
   //
   // * `options` (optional) {Object}
   //   * `bypassReadOnly` (optional) {Boolean} Must be `true` to modify a read-only editor. (default: false)
-  deleteToEndOfLine(options = {}) {
-    if (!this.ensureWritable('deleteToEndOfLine', options)) return;
-    this.mutateSelectedText(selection => selection.deleteToEndOfLine(options));
+  deleteToEndOfBufferLine(options = {}) {
+    if (!this.ensureWritable('deleteToEndOfBufferLine', options)) return;
+    this.mutateSelectedText(selection => selection.deleteToEndOfBufferLine(options));
   }
 
   // Extended: For each selection, if the selection is empty, delete all characters
@@ -3726,13 +3770,31 @@ module.exports = class TextEditor {
     return this.expandSelectionsForward(selection => selection.selectAll());
   }
 
-  // Essential: Move the cursor of each selection to the beginning of its line
-  // while preserving the selection's tail position.
+  // Essential: Move the cursor of each selection to the beginning of its
+  // buffer line while preserving the selection's tail position.
+  //
+  // Deprecated; prefer {::selectToBeginningOfBufferLine}.
+  selectToBeginningOfLine() {
+    return this.selectToBeginningOfBufferLine();
+  }
+
+  // Essential: Move the cursor of each selection to the beginning of its
+  // screen line while preserving the selection's tail position.
   //
   // This method may merge selections that end up intersecting.
-  selectToBeginningOfLine() {
+  selectToBeginningOfScreenLine() {
     return this.expandSelectionsBackward(selection =>
-      selection.selectToBeginningOfLine()
+      selection.selectToBeginningOfScreenLine()
+    );
+  }
+
+  // Essential: Move the cursor of each selection to the beginning of its
+  // buffer line while preserving the selection's tail position.
+  //
+  // This method may merge selections that end up intersecting.
+  selectToBeginningOfBufferLine() {
+    return this.expandSelectionsBackward(selection =>
+      selection.selectToBeginningOfBufferLine()
     );
   }
 
@@ -3748,13 +3810,31 @@ module.exports = class TextEditor {
     );
   }
 
-  // Essential: Move the cursor of each selection to the end of its line while
-  // preserving the selection's tail position.
+  // Essential: Move the cursor of each selection to the end of its screen line
+  // while preserving the selection's tail position.
+  //
+  // Deprecated; prefer {::selectToEndOfScreenLine}.
+  selectToEndOfLine() {
+    return this.selectToEndOfScreenLine();
+  }
+
+  // Essential: Move the cursor of each selection to the end of its screen line
+  // while preserving the selection's tail position.
   //
   // This method may merge selections that end up intersecting.
-  selectToEndOfLine() {
+  selectToEndOfScreenLine() {
     return this.expandSelectionsForward(selection =>
-      selection.selectToEndOfLine()
+      selection.selectToEndOfScreenLine()
+    );
+  }
+
+  // Essential: Move the cursor of each selection to the end of its buffer line
+  // while preserving the selection's tail position.
+  //
+  // This method may merge selections that end up intersecting.
+  selectToEndOfBufferLine() {
+    return this.expandSelectionsForward(selection =>
+      selection.selectToEndOfBufferLine()
     );
   }
 
@@ -4788,13 +4868,22 @@ module.exports = class TextEditor {
   // of the containing screen line following the cursor. Otherwise cut the selected
   // text.
   //
+  // Deprecated; prefer {::cutToEndOfScreenLine}.
+  cutToEndOfLine(options = {}) {
+    return this.cutToEndOfScreenLine(options);
+  }
+
+  // Essential: For each selection, if the selection is empty, cut all characters
+  // of the containing screen line following the cursor. Otherwise cut the selected
+  // text.
+  //
   // * `options` (optional) {Object}
   //   * `bypassReadOnly` (optional) {Boolean} Must be `true` to modify a read-only editor.
-  cutToEndOfLine(options = {}) {
+  cutToEndOfScreenLine(options = {}) {
     if (!this.ensureWritable('cutToEndOfLine', options)) return;
     let maintainClipboard = false;
     this.mutateSelectedText(selection => {
-      selection.cutToEndOfLine(maintainClipboard, options);
+      selection.cutToEndOfScreenLine(maintainClipboard, options);
       maintainClipboard = true;
     });
   }


### PR DESCRIPTION
…of the form `(select|delete|cut|move)To(Beginning|End)OfLine`.

Also add most permutations of the form `(select|delete|cut|move)To(Beginning|End)Of(Screen|Buffer)Line`.

The ambiguous names are the ones that do not specify whether they operate on buffer coordinates or screen coordinates, and their behavior is inconsistent as a result. The behavior of each existing ambiguous method is preserved; the old method names are now aliases for the new ones.

This is a work in progress; the same work should be done in aliasing the respective command names that map to the old methods, plus creating new command names for the new methods.

Fixes #1041 — or at least I imagine it will once it's out of draft.

This is meant to be a collaboration, which is why I've created it on the `pulsar-edit` source. My goal here is not to forget the work of #810; it's as follows:

* Ensure that there are no behavior changes from the existing deprecated methods. (Running the existing tests should demonstrate this.)
* Write a bunch of new tests to prove that the new methods do the things they claim. Especially focus on tests that do lots of soft-wrapping and therefore vary wildly between buffer and screen coordinates.
* Once all of that works, we should be able to change the implementations of these methods where needed to fix the underlying issue from #810. We'll know we've done it right if all the tests keep passing.
