### PR TITLE
Testing superstring in CI, 3rd edition

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -121,7 +121,7 @@ arm_linux_task:
 
 silicon_mac_task:
   alias: mac
-  only_if: $CIRRUS_CRON != "" || $CIRRUS_TAG != ""
+  # only_if: $CIRRUS_CRON != "" || $CIRRUS_TAG != ""
   skip: $CIRRUS_CHANGE_IN_REPO == $CIRRUS_LAST_GREEN_CHANGE
   macos_instance:
     image: ghcr.io/cirruslabs/macos-ventura-xcode:latest
@@ -151,13 +151,13 @@ silicon_mac_task:
     - sed -i -e "s/[0-9]*-dev/`date -u +%Y%m%d%H`/g" package.json
   install_script:
     - export PATH="/opt/homebrew/bin:$PATH"
-    - export LDFLAGS="-L$(brew --prefix)/opt/libiconv/lib"
-    - export CPPFLAGS="-I$(brew --prefix)/opt/libiconv/include"
+    # - export LDFLAGS="-L$(brew --prefix)/opt/libiconv/lib"
+    # - export CPPFLAGS="-I$(brew --prefix)/opt/libiconv/include"
     - yarn install --ignore-engines || yarn install --ignore-engines
   build_script:
     - export PATH="/opt/homebrew/bin:$PATH"
-    - export LDFLAGS="-L$(brew --prefix)/opt/libiconv/lib"
-    - export CPPFLAGS="-I$(brew --prefix)/opt/libiconv/include"
+    # - export LDFLAGS="-L$(brew --prefix)/opt/libiconv/lib"
+    # - export CPPFLAGS="-I$(brew --prefix)/opt/libiconv/include"
     - yarn build
     - yarn run build:apm
   build_binary_script:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -100,6 +100,13 @@ jobs:
       # for this issue. At that point this additional step can be removed.
       run: npx node-gyp install ${{ env.NODE_VERSION }}
 
+    - name: Install GNU libiconv (macOS)
+      if: ${{ runner.os == 'macOS' }}
+      # Now that macOS ships with FreeBSD's version of libiconv, we need to
+      # download the GNU version from Homebrew. `superstring` will detect its
+      # presence and use it when compiling.
+      run: brew install libiconv
+
     - name: Install Pulsar Dependencies
       uses: nick-fields/retry@7152eba30c6575329ac0576536151aca5a72780e
       with:

--- a/.github/workflows/editor-tests.yml
+++ b/.github/workflows/editor-tests.yml
@@ -28,6 +28,10 @@ jobs:
       with:
         node-version: 16
 
+    - name: Install libiconv
+      if: runner.os != 'Linux'
+      run: brew install libiconv
+
     - name: Install Python setuptools
       # This is needed for Python 3.12+, since many versions of node-gyp
       # are incompatible with Python 3.12+, which no-longer ships 'distutils'

--- a/package.json
+++ b/package.json
@@ -26,8 +26,8 @@
   "electronVersion": "12.2.3",
   "resolutions": {
     "es5-ext": "https://github.com/pulsar-edit/es5-ext#169f6ae9b2675675269a0ba265f83c29c7b56244",
-    "superstring": "https://github.com/savetheclocktower/superstring.git#1171e881619a2b4a5a4b20f47a9b66285b54bf24",
-    "text-buffer/superstring": "https://github.com/savetheclocktower/superstring.git#1171e881619a2b4a5a4b20f47a9b66285b54bf24"
+    "superstring": "https://github.com/savetheclocktower/superstring.git#77b9a673c969e935aeac977d9debb7566011921c",
+    "text-buffer/superstring": "https://github.com/savetheclocktower/superstring.git#77b9a673c969e935aeac977d9debb7566011921c"
   },
   "dependencies": {
     "@atom/source-map-support": "^0.3.4",
@@ -167,7 +167,7 @@
     "spell-check": "file:packages/spell-check",
     "status-bar": "file:packages/status-bar",
     "styleguide": "file:./packages/styleguide",
-    "superstring": "https://github.com/savetheclocktower/superstring.git#1171e881619a2b4a5a4b20f47a9b66285b54bf24",
+    "superstring": "https://github.com/savetheclocktower/superstring.git#77b9a673c969e935aeac977d9debb7566011921c",
     "symbol-provider-ctags": "file:./packages/symbol-provider-ctags",
     "symbol-provider-tree-sitter": "file:./packages/symbol-provider-tree-sitter",
     "symbols-view": "file:./packages/symbols-view",

--- a/package.json
+++ b/package.json
@@ -26,8 +26,8 @@
   "electronVersion": "12.2.3",
   "resolutions": {
     "es5-ext": "https://github.com/pulsar-edit/es5-ext#169f6ae9b2675675269a0ba265f83c29c7b56244",
-    "superstring": "https://github.com/savetheclocktower/superstring.git#873a2ea88d9f699ba1767636c548ceb58e5715cc",
-    "text-buffer/superstring": "https://github.com/savetheclocktower/superstring.git#873a2ea88d9f699ba1767636c548ceb58e5715cc"
+    "superstring": "https://github.com/savetheclocktower/superstring.git#3175c946282943411605daaa65dc2b5a8d6a145a",
+    "text-buffer/superstring": "https://github.com/savetheclocktower/superstring.git#3175c946282943411605daaa65dc2b5a8d6a145a"
   },
   "dependencies": {
     "@atom/source-map-support": "^0.3.4",
@@ -167,7 +167,7 @@
     "spell-check": "file:packages/spell-check",
     "status-bar": "file:packages/status-bar",
     "styleguide": "file:./packages/styleguide",
-    "superstring": "https://github.com/savetheclocktower/superstring.git#873a2ea88d9f699ba1767636c548ceb58e5715cc",
+    "superstring": "https://github.com/savetheclocktower/superstring.git#3175c946282943411605daaa65dc2b5a8d6a145a",
     "symbol-provider-ctags": "file:./packages/symbol-provider-ctags",
     "symbol-provider-tree-sitter": "file:./packages/symbol-provider-tree-sitter",
     "symbols-view": "file:./packages/symbols-view",

--- a/package.json
+++ b/package.json
@@ -26,8 +26,8 @@
   "electronVersion": "12.2.3",
   "resolutions": {
     "es5-ext": "https://github.com/pulsar-edit/es5-ext#169f6ae9b2675675269a0ba265f83c29c7b56244",
-    "superstring": "https://github.com/savetheclocktower/superstring.git#9466a42018e197668a185b0b456a9e414720b331",
-    "text-buffer/superstring": "https://github.com/savetheclocktower/superstring.git#9466a42018e197668a185b0b456a9e414720b331"
+    "superstring": "https://github.com/savetheclocktower/superstring.git#6f2232cc14b9c3de9357c2d51273f909e1dd1881",
+    "text-buffer/superstring": "https://github.com/savetheclocktower/superstring.git#6f2232cc14b9c3de9357c2d51273f909e1dd1881"
   },
   "dependencies": {
     "@atom/source-map-support": "^0.3.4",
@@ -167,7 +167,7 @@
     "spell-check": "file:packages/spell-check",
     "status-bar": "file:packages/status-bar",
     "styleguide": "file:./packages/styleguide",
-    "superstring": "https://github.com/savetheclocktower/superstring.git#9466a42018e197668a185b0b456a9e414720b331",
+    "superstring": "https://github.com/savetheclocktower/superstring.git#6f2232cc14b9c3de9357c2d51273f909e1dd1881",
     "symbol-provider-ctags": "file:./packages/symbol-provider-ctags",
     "symbol-provider-tree-sitter": "file:./packages/symbol-provider-tree-sitter",
     "symbols-view": "file:./packages/symbols-view",

--- a/package.json
+++ b/package.json
@@ -26,8 +26,8 @@
   "electronVersion": "12.2.3",
   "resolutions": {
     "es5-ext": "https://github.com/pulsar-edit/es5-ext#169f6ae9b2675675269a0ba265f83c29c7b56244",
-    "superstring": "https://github.com/savetheclocktower/superstring.git#77b9a673c969e935aeac977d9debb7566011921c",
-    "text-buffer/superstring": "https://github.com/savetheclocktower/superstring.git#77b9a673c969e935aeac977d9debb7566011921c"
+    "superstring": "https://github.com/savetheclocktower/superstring.git#16e353d2cfc1b4eedd42059623040bd198811b4a",
+    "text-buffer/superstring": "https://github.com/savetheclocktower/superstring.git#16e353d2cfc1b4eedd42059623040bd198811b4a"
   },
   "dependencies": {
     "@atom/source-map-support": "^0.3.4",
@@ -167,7 +167,7 @@
     "spell-check": "file:packages/spell-check",
     "status-bar": "file:packages/status-bar",
     "styleguide": "file:./packages/styleguide",
-    "superstring": "https://github.com/savetheclocktower/superstring.git#77b9a673c969e935aeac977d9debb7566011921c",
+    "superstring": "https://github.com/savetheclocktower/superstring.git#16e353d2cfc1b4eedd42059623040bd198811b4a",
     "symbol-provider-ctags": "file:./packages/symbol-provider-ctags",
     "symbol-provider-tree-sitter": "file:./packages/symbol-provider-tree-sitter",
     "symbols-view": "file:./packages/symbols-view",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,9 @@
   "license": "MIT",
   "electronVersion": "12.2.3",
   "resolutions": {
-    "es5-ext": "https://github.com/pulsar-edit/es5-ext#169f6ae9b2675675269a0ba265f83c29c7b56244"
+    "es5-ext": "https://github.com/pulsar-edit/es5-ext#169f6ae9b2675675269a0ba265f83c29c7b56244",
+    "superstring": "https://github.com/savetheclocktower/superstring.git#9466a42018e197668a185b0b456a9e414720b331",
+    "text-buffer/superstring": "https://github.com/savetheclocktower/superstring.git#9466a42018e197668a185b0b456a9e414720b331"
   },
   "dependencies": {
     "@atom/source-map-support": "^0.3.4",
@@ -165,7 +167,7 @@
     "spell-check": "file:packages/spell-check",
     "status-bar": "file:packages/status-bar",
     "styleguide": "file:./packages/styleguide",
-    "superstring": "^2.4.4",
+    "superstring": "https://github.com/savetheclocktower/superstring.git#9466a42018e197668a185b0b456a9e414720b331",
     "symbol-provider-ctags": "file:./packages/symbol-provider-ctags",
     "symbol-provider-tree-sitter": "file:./packages/symbol-provider-tree-sitter",
     "symbols-view": "file:./packages/symbols-view",

--- a/package.json
+++ b/package.json
@@ -26,8 +26,8 @@
   "electronVersion": "12.2.3",
   "resolutions": {
     "es5-ext": "https://github.com/pulsar-edit/es5-ext#169f6ae9b2675675269a0ba265f83c29c7b56244",
-    "superstring": "https://github.com/savetheclocktower/superstring.git#6f2232cc14b9c3de9357c2d51273f909e1dd1881",
-    "text-buffer/superstring": "https://github.com/savetheclocktower/superstring.git#6f2232cc14b9c3de9357c2d51273f909e1dd1881"
+    "superstring": "https://github.com/savetheclocktower/superstring.git#873a2ea88d9f699ba1767636c548ceb58e5715cc",
+    "text-buffer/superstring": "https://github.com/savetheclocktower/superstring.git#873a2ea88d9f699ba1767636c548ceb58e5715cc"
   },
   "dependencies": {
     "@atom/source-map-support": "^0.3.4",
@@ -167,7 +167,7 @@
     "spell-check": "file:packages/spell-check",
     "status-bar": "file:packages/status-bar",
     "styleguide": "file:./packages/styleguide",
-    "superstring": "https://github.com/savetheclocktower/superstring.git#6f2232cc14b9c3de9357c2d51273f909e1dd1881",
+    "superstring": "https://github.com/savetheclocktower/superstring.git#873a2ea88d9f699ba1767636c548ceb58e5715cc",
     "symbol-provider-ctags": "file:./packages/symbol-provider-ctags",
     "symbol-provider-tree-sitter": "file:./packages/symbol-provider-tree-sitter",
     "symbols-view": "file:./packages/symbols-view",

--- a/package.json
+++ b/package.json
@@ -26,8 +26,8 @@
   "electronVersion": "12.2.3",
   "resolutions": {
     "es5-ext": "https://github.com/pulsar-edit/es5-ext#169f6ae9b2675675269a0ba265f83c29c7b56244",
-    "superstring": "https://github.com/savetheclocktower/superstring.git#3175c946282943411605daaa65dc2b5a8d6a145a",
-    "text-buffer/superstring": "https://github.com/savetheclocktower/superstring.git#3175c946282943411605daaa65dc2b5a8d6a145a"
+    "superstring": "https://github.com/savetheclocktower/superstring.git#1171e881619a2b4a5a4b20f47a9b66285b54bf24",
+    "text-buffer/superstring": "https://github.com/savetheclocktower/superstring.git#1171e881619a2b4a5a4b20f47a9b66285b54bf24"
   },
   "dependencies": {
     "@atom/source-map-support": "^0.3.4",
@@ -167,7 +167,7 @@
     "spell-check": "file:packages/spell-check",
     "status-bar": "file:packages/status-bar",
     "styleguide": "file:./packages/styleguide",
-    "superstring": "https://github.com/savetheclocktower/superstring.git#3175c946282943411605daaa65dc2b5a8d6a145a",
+    "superstring": "https://github.com/savetheclocktower/superstring.git#1171e881619a2b4a5a4b20f47a9b66285b54bf24",
     "symbol-provider-ctags": "file:./packages/symbol-provider-ctags",
     "symbol-provider-tree-sitter": "file:./packages/symbol-provider-tree-sitter",
     "symbols-view": "file:./packages/symbols-view",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9027,10 +9027,10 @@ superagent@^8.0.9:
     qs "^6.11.0"
     semver "^7.3.8"
 
-superstring@^2.4.4:
+superstring@^2.4.4, "superstring@https://github.com/savetheclocktower/superstring.git#9466a42018e197668a185b0b456a9e414720b331":
   version "2.4.4"
-  resolved "https://registry.yarnpkg.com/superstring/-/superstring-2.4.4.tgz#d5df5b080deb5605ffd88b6cdbaf17a0b30d5f0e"
-  integrity sha512-41LWIGzy6tkUM6jUwbXTeGOLui3gGBxgV6m8gIWRzv1WdW0HV6oANHdGanRrM04mwFXXExII9OQ/XxaqU+Ft9w==
+  uid "9466a42018e197668a185b0b456a9e414720b331"
+  resolved "https://github.com/savetheclocktower/superstring.git#9466a42018e197668a185b0b456a9e414720b331"
   dependencies:
     nan "^2.14.2"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -9027,10 +9027,10 @@ superagent@^8.0.9:
     qs "^6.11.0"
     semver "^7.3.8"
 
-superstring@^2.4.4, "superstring@https://github.com/savetheclocktower/superstring.git#873a2ea88d9f699ba1767636c548ceb58e5715cc":
+superstring@^2.4.4, "superstring@https://github.com/savetheclocktower/superstring.git#3175c946282943411605daaa65dc2b5a8d6a145a":
   version "2.4.4"
-  uid "873a2ea88d9f699ba1767636c548ceb58e5715cc"
-  resolved "https://github.com/savetheclocktower/superstring.git#873a2ea88d9f699ba1767636c548ceb58e5715cc"
+  uid "3175c946282943411605daaa65dc2b5a8d6a145a"
+  resolved "https://github.com/savetheclocktower/superstring.git#3175c946282943411605daaa65dc2b5a8d6a145a"
   dependencies:
     nan "^2.14.2"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -9027,10 +9027,9 @@ superagent@^8.0.9:
     qs "^6.11.0"
     semver "^7.3.8"
 
-superstring@^2.4.4, "superstring@https://github.com/savetheclocktower/superstring.git#77b9a673c969e935aeac977d9debb7566011921c":
+superstring@^2.4.4, "superstring@https://github.com/savetheclocktower/superstring.git#16e353d2cfc1b4eedd42059623040bd198811b4a":
   version "2.4.4"
-  uid "77b9a673c969e935aeac977d9debb7566011921c"
-  resolved "https://github.com/savetheclocktower/superstring.git#77b9a673c969e935aeac977d9debb7566011921c"
+  resolved "https://github.com/savetheclocktower/superstring.git#16e353d2cfc1b4eedd42059623040bd198811b4a"
   dependencies:
     nan "^2.14.2"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -9027,10 +9027,10 @@ superagent@^8.0.9:
     qs "^6.11.0"
     semver "^7.3.8"
 
-superstring@^2.4.4, "superstring@https://github.com/savetheclocktower/superstring.git#1171e881619a2b4a5a4b20f47a9b66285b54bf24":
+superstring@^2.4.4, "superstring@https://github.com/savetheclocktower/superstring.git#77b9a673c969e935aeac977d9debb7566011921c":
   version "2.4.4"
-  uid "1171e881619a2b4a5a4b20f47a9b66285b54bf24"
-  resolved "https://github.com/savetheclocktower/superstring.git#1171e881619a2b4a5a4b20f47a9b66285b54bf24"
+  uid "77b9a673c969e935aeac977d9debb7566011921c"
+  resolved "https://github.com/savetheclocktower/superstring.git#77b9a673c969e935aeac977d9debb7566011921c"
   dependencies:
     nan "^2.14.2"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -9027,10 +9027,10 @@ superagent@^8.0.9:
     qs "^6.11.0"
     semver "^7.3.8"
 
-superstring@^2.4.4, "superstring@https://github.com/savetheclocktower/superstring.git#3175c946282943411605daaa65dc2b5a8d6a145a":
+superstring@^2.4.4, "superstring@https://github.com/savetheclocktower/superstring.git#1171e881619a2b4a5a4b20f47a9b66285b54bf24":
   version "2.4.4"
-  uid "3175c946282943411605daaa65dc2b5a8d6a145a"
-  resolved "https://github.com/savetheclocktower/superstring.git#3175c946282943411605daaa65dc2b5a8d6a145a"
+  uid "1171e881619a2b4a5a4b20f47a9b66285b54bf24"
+  resolved "https://github.com/savetheclocktower/superstring.git#1171e881619a2b4a5a4b20f47a9b66285b54bf24"
   dependencies:
     nan "^2.14.2"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -9027,10 +9027,10 @@ superagent@^8.0.9:
     qs "^6.11.0"
     semver "^7.3.8"
 
-superstring@^2.4.4, "superstring@https://github.com/savetheclocktower/superstring.git#9466a42018e197668a185b0b456a9e414720b331":
+superstring@^2.4.4, "superstring@https://github.com/savetheclocktower/superstring.git#6f2232cc14b9c3de9357c2d51273f909e1dd1881":
   version "2.4.4"
-  uid "9466a42018e197668a185b0b456a9e414720b331"
-  resolved "https://github.com/savetheclocktower/superstring.git#9466a42018e197668a185b0b456a9e414720b331"
+  uid "6f2232cc14b9c3de9357c2d51273f909e1dd1881"
+  resolved "https://github.com/savetheclocktower/superstring.git#6f2232cc14b9c3de9357c2d51273f909e1dd1881"
   dependencies:
     nan "^2.14.2"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -9027,10 +9027,10 @@ superagent@^8.0.9:
     qs "^6.11.0"
     semver "^7.3.8"
 
-superstring@^2.4.4, "superstring@https://github.com/savetheclocktower/superstring.git#6f2232cc14b9c3de9357c2d51273f909e1dd1881":
+superstring@^2.4.4, "superstring@https://github.com/savetheclocktower/superstring.git#873a2ea88d9f699ba1767636c548ceb58e5715cc":
   version "2.4.4"
-  uid "6f2232cc14b9c3de9357c2d51273f909e1dd1881"
-  resolved "https://github.com/savetheclocktower/superstring.git#6f2232cc14b9c3de9357c2d51273f909e1dd1881"
+  uid "873a2ea88d9f699ba1767636c548ceb58e5715cc"
+  resolved "https://github.com/savetheclocktower/superstring.git#873a2ea88d9f699ba1767636c548ceb58e5715cc"
   dependencies:
     nan "^2.14.2"
 


### PR DESCRIPTION
This is just a test...

Basically this is branched from https://github.com/pulsar-edit/pulsar/pull/1048, but reverting to the same SHA of `superstring` as we are using on `master`, just delivered in a different way from `master`. Delivered as a git repo URL (which behaves differently, a local clone into a temp dir + cd there and `yarn install` (with devDependencies and all, potentially running different [lifecycle scripts](https://docs.npmjs.com/cli/v6/using-npm/scripts#life-cycle-scripts)) then copy the result out to `node_modules`, vs fetching a tarball, extracting into `node_modules` and installing in-situ.)

See the commit message of this commit: https://github.com/pulsar-edit/pulsar/pull/1049/commits/02e2908a1ae25a379fc59ac922b34fe5c0f6ae3f

```
deps: Try testing the last upstream superstring release (2.4.4) as a git repo URL

Just controlling some variables...
```