### PR TITLE
Fix macOS binaries by vendorizing `libiconv`

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -137,7 +137,6 @@ silicon_mac_task:
     - brew update
     - brew uninstall node@20
     - brew install git python@$PYTHON_VERSION python-setuptools
-    - brew install libiconv
     - git submodule init
     - git submodule update
     - ln -s /opt/homebrew/bin/python$PYTHON_VERSION /opt/homebrew/bin/python
@@ -151,13 +150,9 @@ silicon_mac_task:
     - sed -i -e "s/[0-9]*-dev/`date -u +%Y%m%d%H`/g" package.json
   install_script:
     - export PATH="/opt/homebrew/bin:$PATH"
-    - export LDFLAGS="-L$(brew --prefix)/opt/libiconv/lib"
-    - export CPPFLAGS="-I$(brew --prefix)/opt/libiconv/include"
     - yarn install --ignore-engines || yarn install --ignore-engines
   build_script:
     - export PATH="/opt/homebrew/bin:$PATH"
-    - export LDFLAGS="-L$(brew --prefix)/opt/libiconv/lib"
-    - export CPPFLAGS="-I$(brew --prefix)/opt/libiconv/include"
     - yarn build
     - yarn run build:apm
   build_binary_script:

--- a/package.json
+++ b/package.json
@@ -25,7 +25,9 @@
   "license": "MIT",
   "electronVersion": "12.2.3",
   "resolutions": {
-    "es5-ext": "https://github.com/pulsar-edit/es5-ext#169f6ae9b2675675269a0ba265f83c29c7b56244"
+    "es5-ext": "https://github.com/pulsar-edit/es5-ext#169f6ae9b2675675269a0ba265f83c29c7b56244",
+    "superstring": "github:pulsar-edit/superstring",
+    "text-buffer/superstring": "github:pulsar-edit/superstring"
   },
   "dependencies": {
     "@atom/source-map-support": "^0.3.4",
@@ -165,7 +167,7 @@
     "spell-check": "file:packages/spell-check",
     "status-bar": "file:packages/status-bar",
     "styleguide": "file:./packages/styleguide",
-    "superstring": "^2.4.4",
+    "superstring": "github:pulsar-edit/superstring",
     "symbol-provider-ctags": "file:./packages/symbol-provider-ctags",
     "symbol-provider-tree-sitter": "file:./packages/symbol-provider-tree-sitter",
     "symbols-view": "file:./packages/symbols-view",

--- a/package.json
+++ b/package.json
@@ -26,8 +26,8 @@
   "electronVersion": "12.2.3",
   "resolutions": {
     "es5-ext": "https://github.com/pulsar-edit/es5-ext#169f6ae9b2675675269a0ba265f83c29c7b56244",
-    "superstring": "github:pulsar-edit/superstring",
-    "text-buffer/superstring": "github:pulsar-edit/superstring"
+    "superstring": "github:pulsar-edit/superstring#de97b496663fce40050bf2d66e1466ccfbd00943",
+    "text-buffer/superstring": "github:pulsar-edit/superstring#de97b496663fce40050bf2d66e1466ccfbd00943"
   },
   "dependencies": {
     "@atom/source-map-support": "^0.3.4",
@@ -167,7 +167,7 @@
     "spell-check": "file:packages/spell-check",
     "status-bar": "file:packages/status-bar",
     "styleguide": "file:./packages/styleguide",
-    "superstring": "github:pulsar-edit/superstring",
+    "superstring": "github:pulsar-edit/superstring#de97b496663fce40050bf2d66e1466ccfbd00943",
     "symbol-provider-ctags": "file:./packages/symbol-provider-ctags",
     "symbol-provider-tree-sitter": "file:./packages/symbol-provider-tree-sitter",
     "symbols-view": "file:./packages/symbols-view",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9027,7 +9027,7 @@ superagent@^8.0.9:
     qs "^6.11.0"
     semver "^7.3.8"
 
-superstring@^2.4.4, "superstring@github:pulsar-edit/superstring":
+superstring@^2.4.4, "superstring@github:pulsar-edit/superstring#de97b496663fce40050bf2d66e1466ccfbd00943":
   version "2.4.4"
   resolved "https://codeload.github.com/pulsar-edit/superstring/tar.gz/de97b496663fce40050bf2d66e1466ccfbd00943"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -9027,10 +9027,9 @@ superagent@^8.0.9:
     qs "^6.11.0"
     semver "^7.3.8"
 
-superstring@^2.4.4:
+superstring@^2.4.4, "superstring@github:pulsar-edit/superstring":
   version "2.4.4"
-  resolved "https://registry.yarnpkg.com/superstring/-/superstring-2.4.4.tgz#d5df5b080deb5605ffd88b6cdbaf17a0b30d5f0e"
-  integrity sha512-41LWIGzy6tkUM6jUwbXTeGOLui3gGBxgV6m8gIWRzv1WdW0HV6oANHdGanRrM04mwFXXExII9OQ/XxaqU+Ft9w==
+  resolved "https://codeload.github.com/pulsar-edit/superstring/tar.gz/de97b496663fce40050bf2d66e1466ccfbd00943"
   dependencies:
     nan "^2.14.2"
 


### PR DESCRIPTION
This is a continuation of the saga described in #1048 and #1045.

The necessary fixes have been applied to the `superstring` repo.

Other than a quick and temporary change to CI — to verify that signed binaries build correctly without triggering Gatekeeper on macOS — this PR will fix our `libiconv` woes for the foreseeable future:

* All macOS versions of `superstring` will be compiled with a known good version of `libiconv`. This should safeguard our builds from further macOS upgrades on the CI machines that automatically build our binaries.
* During the build process of `superstring`, we tell the native module where to find our special version of `libiconv` in a way that **will not** anger macOS or make it show a scary “this app is unsigned” dialog (even though it actually is signed).
* Both the `superstring` we consume as a direct dependency _and_ the `superstring` that is a transitive dependency of `text-buffer` will point to the same place.

This PR will sit in draft until I'm able to verify that it produces a signed Pulsar release that passes Gatekeeper. After all the tests of the past few days, I'm satisfied that a working, signed binary on Intel demonstrates that the binary on Apple Silicon would have the same characteristics, so at that point I'll revert the temporary CI changes and take this PR out of draft.

<sup>I might then owe someone some money for all the CirrusCI minutes I used in the last week, but we can settle that later. ;-)</sup>