### PR TITLE
Rework command parsing to support `--package` better

### DIFF
--- a/spec/main-process/parse-command-line.test.js
+++ b/spec/main-process/parse-command-line.test.js
@@ -129,4 +129,29 @@ describe('parseCommandLine', () => {
       ]);
     });
   });
+
+  describe('when --package or -p is passed', () => {
+    it('returns only data relevant to ppm', () => {
+      let args = parseCommandLine([
+        '-d',
+        '--package',
+        'foo',
+        'bar',
+        '--version'
+      ]);
+
+      assert.deepEqual(
+        args,
+        {
+          packageMode: true,
+          ppmArgs: ['foo', 'bar', '--version']
+        }
+      );
+
+      assert.deepEqual(
+        args,
+        parseCommandLine(['-d', '-p', 'foo', 'bar', '--version'])
+      );
+    });
+  });
 });

--- a/src/main-process/parse-command-line.js
+++ b/src/main-process/parse-command-line.js
@@ -11,8 +11,8 @@ module.exports = function parseCommandLine(processArgs) {
   const filteredArgs = processArgs.filter(arg => !arg.startsWith('-psn_'));
 
   // Disable the yargs behavior that exits early if `--help` or `--version` is
-  // detected. This prevents `pulsar -p --version` from working properly. We'll
-  // handle `--version` and `--help` manually.
+  // detected, since it prevents `pulsar -p --version` from working properly.
+  // We'll handle `--version` and `--help` manually.
   const options = yargs(filteredArgs)
     .exitProcess(false)
     .wrap(yargs.terminalWidth());

--- a/src/main-process/start.js
+++ b/src/main-process/start.js
@@ -4,7 +4,6 @@ const temp = require('temp');
 const parseCommandLine = require('./parse-command-line');
 const { getReleaseChannel, getConfigFilePath } = require('../get-app-details.js');
 const atomPaths = require('../atom-paths');
-const fs = require('fs');
 const CSON = require('season');
 const Config = require('../config');
 const StartupTime = require('../startup-time');

--- a/src/main-process/start.js
+++ b/src/main-process/start.js
@@ -131,8 +131,10 @@ async function ppmCommand(ppmArgs) {
     let child = cp.spawn(
       ppmPath,
       ppmArgs,
-      { stdio: 'inherit', encoding: 'utf-8' }
+      { stdio: 'pipe' }
     );
+    child.stdout.pipe(process.stdout);
+    child.stderr.pipe(process.stderr);
     child.on('close', resolve);
   });
 }


### PR DESCRIPTION
This is a concept for how we'd rewrite argument parsing to make `--package` work better and fix the issues detailed in #1053.

I haven't tried any of this on Windows yet — nor have I written new specs or tried to run existing specs — but this passes some sanity tests on my macOS machine:

* `--version` is handled properly; `pulsar --version` does what it always did, whereas `pulsar --package --version` properly forwards to `ppm --version`.
* Handling of forwarding to `ppm` is moved to `start.js` so that it can use `spawn` instead of `spawnSync`. This might be enough on its own to fix our issues with `{ stdio: 'inherit' }` on Windows; but if it isn't, then it at least gives us more flexibility with using `{ stdio: 'pipe' }` to produce the same effect.

If I take this out of draft, it means that I've confirmed that these techniques fix our Windows issues, ensured existing specs pass, and written new specs for `--package` behavior. 