### PR TITLE
Fix reading error of length property on null

### DIFF
--- a/packages/autocomplete-plus/lib/subsequence-provider.js
+++ b/packages/autocomplete-plus/lib/subsequence-provider.js
@@ -102,8 +102,13 @@ class SubsequenceProvider {
       '(){}[] :;,$@%',
       this.maxResultsPerBuffer
     ).then(matches => {
-      for (let k = 0; k < matches.length; k++) {
-        matches[k].configSuggestion = suggestions[matches[k].positions[0].row]
+      // The findWordsWithSubsequence method will return `null`
+      // if the async work was cancelled due to the buffer being
+      // mutated since it was enqueued.
+      if (matches) {
+        for (let k = 0; k < matches.length; k++) {
+          matches[k].configSuggestion = suggestions[matches[k].positions[0].row]
+        }
       }
       return matches
     })


### PR DESCRIPTION
### Identify the Bug

Related to https://github.com/pulsar-edit/pulsar/issues/876#issuecomment-2232847500

### Description of the Change

Just check if `matches` is not a falsy js value where the read error occurs.

### Alternate Designs

None.

### Possible Drawbacks

None since it's good to check if the argument is not falsy when you have to read its properties.

### Release Notes

In the same file there's the following comment (which I pasted above the changes):

```
// The findWordsWithSubsequence method will return `null`
// if the async work was cancelled due to the buffer being
// mutated since it was enqueued.
```

So the function in `then` may get `null` and that causes the issue. I hope this solves the syntax error explained in the link above.