### PR TITLE
Use a different strategy for `pulsar -p` on Windows…

### DIFF
--- a/resources/win/pulsar.cmd
+++ b/resources/win/pulsar.cmd
@@ -52,7 +52,6 @@ if "%PACKAGE_MODE%"=="YES" (
   goto :trim_args_for_package_mode
 
 :package_mode_return
-  REM echo "shelling out to ppm with args" "%PACKAGE_MODE_ARGS%"
   "%~dp0\app\ppm\bin\ppm.cmd" %PACKAGE_MODE_ARGS%
   exit 0
 )

--- a/resources/win/pulsar.cmd
+++ b/resources/win/pulsar.cmd
@@ -75,9 +75,10 @@ REM First we trim any arguments that appear previous to `-p` or `--package` on
 REM the line.
 :trim_args_for_package_mode
 if not "%1"=="--package" (
-  if not "%1" == "-p" (
-REM Roughly the same as `ARGV.shift`. Everything except the initial argument
-REM moves forward, and the second argument is removed from the list.
+  if not "%1"=="-p" (
+    REM Roughly the same as `ARGV.shift`. Everything except the initial
+    REM argument moves forward, and the second argument is removed from the
+    REM list.
     SHIFT /1
     goto :trim_args_for_package_mode
   )
@@ -92,7 +93,7 @@ REM shifting we did above affected %*, that'd be perfect. But since it doesn't,
 REM we'll loop through the remaining arguments and concatenate them into a
 REM variable.
 if not "%1"=="" (
-  SET PACKAGE_MODE_ARGS=%PACKAGE_MODE_ARGS%%1%
+  SET PACKAGE_MODE_ARGS=%PACKAGE_MODE_ARGS% %1%
   SHIFT /1
   goto :build_args_for_package_mode
 )

--- a/resources/win/pulsar.cmd
+++ b/resources/win/pulsar.cmd
@@ -6,6 +6,8 @@ SET PSARGS=%*
 SET ELECTRON_ENABLE_LOGGING=
 SET ATOM_ADD=
 SET ATOM_NEW_WINDOW=
+SET PACKAGE_MODE=
+SET PACKAGE_MODE_ARGS=
 
 FOR %%a IN (%*) DO (
   IF /I "%%a"=="-f"                         SET EXPECT_OUTPUT=YES
@@ -16,8 +18,6 @@ FOR %%a IN (%*) DO (
   IF /I "%%a"=="--test"                     SET EXPECT_OUTPUT=YES
   IF /I "%%a"=="--benchmark"                SET EXPECT_OUTPUT=YES
   IF /I "%%a"=="--benchmark-test"           SET EXPECT_OUTPUT=YES
-  IF /I "%%a"=="-p"                         SET EXPECT_OUTPUT=YES
-  IF /I "%%a"=="--package"                  SET EXPECT_OUTPUT=YES
   IF /I "%%a"=="-v"                         SET EXPECT_OUTPUT=YES
   IF /I "%%a"=="--version"                  SET EXPECT_OUTPUT=YES
   IF /I "%%a"=="--enable-electron-logging"  SET ELECTRON_ENABLE_LOGGING=YES
@@ -25,6 +25,8 @@ FOR %%a IN (%*) DO (
   IF /I "%%a"=="--add"                      SET ATOM_ADD=YES
   IF /I "%%a"=="-n"                         SET ATOM_NEW_WINDOW=YES
   IF /I "%%a"=="--new-window"               SET ATOM_NEW_WINDOW=YES
+  IF /I "%%a"=="-p"                         SET PACKAGE_MODE=YES
+  IF /I "%%a"=="--package"                  SET PACKAGE_MODE=YES
   IF /I "%%a"=="-w"           (
     SET EXPECT_OUTPUT=YES
     SET WAIT=YES
@@ -40,6 +42,20 @@ IF "%ATOM_ADD%"=="YES" (
     SET EXPECT_OUTPUT=YES
   )
 )
+if "%PACKAGE_MODE%"=="YES" (
+  REM In package mode, we should shell out directly to `ppm` instead of
+  REM invoking `Pulsar.exe` at all. But first we need to assemble a list of
+  REM arguments that `ppm.cmd` will understand.
+
+  REM Since batch files don't have `while` loops, we've got to fake them with
+  REM labels and GOTO.
+  goto :trim_args_for_package_mode
+
+:package_mode_return
+  REM echo "shelling out to ppm with args" "%PACKAGE_MODE_ARGS%"
+  "%~dp0\app\ppm\bin\ppm.cmd" %PACKAGE_MODE_ARGS%
+  exit 0
+)
 
 IF "%EXPECT_OUTPUT%"=="YES" (
   IF "%WAIT%"=="YES" (
@@ -51,3 +67,35 @@ IF "%EXPECT_OUTPUT%"=="YES" (
 ) ELSE (
   "%~dp0\app\ppm\bin\node.exe" "%~dp0\pulsar.js" "Pulsar.exe" %*
 )
+
+REM Jump past the subroutines below.
+goto :eof
+
+REM The subroutine for assembling a list of arguments to pass to `ppm`.
+REM First we trim any arguments that appear previous to `-p` or `--package` on
+REM the line.
+:trim_args_for_package_mode
+if not "%1"=="--package" (
+  if not "%1" == "-p" (
+REM Roughly the same as `ARGV.shift`. Everything except the initial argument
+REM moves forward, and the second argument is removed from the list.
+    SHIFT /1
+    goto :trim_args_for_package_mode
+  )
+)
+REM When we reach this point, `-p`/`--package` is the argument in the %1
+REM position. Now we'll call `shift` once more to remove it from the list.
+SHIFT /1
+
+:build_args_for_package_mode
+REM We need to pass all the remaining arguments to `ppm.cmd`. If all the
+REM shifting we did above affected %*, that'd be perfect. But since it doesn't,
+REM we'll loop through the remaining arguments and concatenate them into a
+REM variable.
+if not "%1"=="" (
+  SET PACKAGE_MODE_ARGS=%PACKAGE_MODE_ARGS%%1%
+  SHIFT /1
+  goto :build_args_for_package_mode
+)
+REM Return from our subroutines so we can finally call `ppm.cmd`.
+goto :package_mode_return


### PR DESCRIPTION
…by handling the argument processing in the batch file.

This one is a bit ridiculous, but somehow _less_ ridiculous than what I was doing in #1054.

We opt into a bunch of headaches by trying to use the Electron app itself to handle command-line output. Most of the features of `pulsar` in the terminal are necessary evils, but for the reason discovered in #1054 (Electron can't do magical encoding conversion on its output the way Node can) we should try to minimize the stuff we ask `pulsar` to write to STDOUT. (Windows especially, since that's the platform least likely to have terminal output rendered as UTF-8; but it's a theoretical concern on other platforms as well.)

If we could intercept `-p`/`--package` at the _script_ level, we could redirect those calls to `ppm` before they hit Electron. Then we wouldn't be creating any new encoding issues for ourselves.

Luckily, we already have some wrapper scripts meant to handle calls to `pulsar`. On Windows, it's `pulsar.cmd`, a file written in ancient [batch file](https://en.wikipedia.org/wiki/Batch_file) syntax. Imagine all the things you'd want from a scripting language if you were inventing one in the year 2024; batch files seem like they were intentionally designed to have _none of those features_. But there are lots of masochists online! Stack Overflow and [SS64.com](https://ss64.com/nt/) were quite useful in figuring out how to do this.

The idea is to behave identically in the batch file as we already do in `parse-command-line.js` when we see a `-p` or `--package` flag:

* ignore all arguments _prior to_ `-p`/`--package`, then
* assemble all the arguments _after_ `-p`/`--package`, then
* pass them as arguments to `ppm`.

This is convoluted in batch files because they don't have loops or array methods, but it's possible nonetheless.

### Testing

This is **very important** to test **thoroughly** on Windows, since we can't really write automated tests for this. Here's what I did, and it all seemed to work great:

* Verify all these commands produce the same output:
  * `pulsar --package --version`
  * `pulsar -p -v`
  * `ppm --version`
  * `pulsar --wait --package --version` (testing that any arguments before `--package` are ignored
* Verify these commands produce the same output, and that it's not weird-looking or garbled:
  * `pulsar --package list`
  * `pulsar -p list`
  * `ppm list`
  * `pulsar -v --package list`
* Verify that commands which _don't_ use `--package`/`-p` behave like they always did:
  * `pulsar .`
  * `pulsar --dev .`
  * `pulsar --wait foo.js`
  * `pulsar --test spec/*-spec.js`

### Should we do this on all platforms?

Yes! But Windows is the most salient because of the extant bugs with `pulsar -p` on that platform.

Right now, `pulsar --package list` on my macOS machine starts the Pulsar icon bouncing in the dock for a brief second before we get output. That's because we're launching a GUI app just to launch a command-line app. It'll be faster if we cut out the middle man.

### Once we do this on all platforms, should we remove the equivalent functionality from Pulsar?

**No.** Because we do handle lots of command-line stuff via the main process, most of the command-line switches will still work if you invoke `Pulsar.exe` or the actual `pulsar` Electron executable. And we should keep handling those for these reasons:

* Some Windows users might have needed to add Pulsar to their `PATH` manually and incorrectly assumed that they should add the folder that holds `Pulsar.exe`, rather than the one that holds `pulsar.cmd`.
* Some Linux users are using the AppImage version. As far as I can tell, invoking the `AppImage` file from the terminal is much like invoking the actual `pulsar` executable (instead of `pulsar.sh`). (And as I understand it, the `-p` flag was basically invented for this use case!) If we can change the AppImage so that invoking it somehow hits the logic in `pulsar.sh`, then that'd be grand; failing that, handling `-p`/`--package` redundantly in the main process is a fallback that helps AppImage users not to be second-class citizens.

For the same reasons, this PR is a _companion_ to #1054, not a replacement.