### PR TITLE
Experiment: Redirect `-p`/`--package` to `ppm` via `pulsar.sh`…

### DIFF
--- a/.github/workflows/package-tests-linux.yml
+++ b/.github/workflows/package-tests-linux.yml
@@ -200,5 +200,5 @@ jobs:
       run: sudo apt-get install -y xvfb
 
     - name: Run ${{ matrix.package }} Tests
-      run: export PULSAR_PATH="${TMPDIR:=/tmp}/pulsar-build/Pulsar"; Xvfb :1 & cd node_modules/${{ matrix.package }} && if test -d spec; then DISPLAY=:1 pulsar --test spec; fi
+      run: Xvfb :1 & cd node_modules/${{ matrix.package }} && if test -d spec; then DISPLAY=:1 pulsar --test spec; fi
         # run: node -e "require('./script/run-package-tests')(/${{ matrix.package }}/)"

--- a/.github/workflows/package-tests-linux.yml
+++ b/.github/workflows/package-tests-linux.yml
@@ -200,5 +200,5 @@ jobs:
       run: sudo apt-get install -y xvfb
 
     - name: Run ${{ matrix.package }} Tests
-      run: Xvfb :1 & cd node_modules/${{ matrix.package }} && if test -d spec; then DISPLAY=:1 pulsar --test spec; fi
+      run: export PULSAR_PATH="${TMPDIR:=/tmp}/pulsar-build/Pulsar"; Xvfb :1 & cd node_modules/${{ matrix.package }} && if test -d spec; then DISPLAY=:1 pulsar --test spec; fi
         # run: node -e "require('./script/run-package-tests')(/${{ matrix.package }}/)"

--- a/pulsar.sh
+++ b/pulsar.sh
@@ -167,12 +167,6 @@ if [ $OS == 'Mac' ]; then
   fi
 elif [ $OS == 'Linux' ]; then
 
-  if [ -L "$0" ]; then
-    SCRIPT="$(readlink -f "$0")"
-  else
-    SCRIPT="$0"
-  fi
-
   # Set tmpdir only if it's unset.
   : ${TMPDIR:=/tmp}
 
@@ -185,14 +179,18 @@ elif [ $OS == 'Linux' ]; then
     # of this script. When symlinked to a common location like
     # `/usr/local/bin`, this approach should find the true location of the
     # Pulsar installation.
-    SCRIPT="$(readlink -f "$0")"
+    if [ -L "$0" ]; then
+      SCRIPT="$(readlink -f "$0")"
+    else
+      SCRIPT="$0"
+    fi
 
     # The `pulsar.sh` file lives one directory deeper than the root directory
     # that contains the `pulsar` binary.
     ATOM_APP="$(dirname "$(dirname "$SCRIPT")")"
     PULSAR_PATH="$(realpath "$ATOM_APP")"
 
-    if [ ! -d "$PULSAR_PATH/pulsar" ]; then
+    if [ ! -f "$PULSAR_PATH/pulsar" ]; then
       # If that path doesn't contain a `pulsar` executable, then it's not a
       # valid path. We'll try something else.
       unset ATOM_APP

--- a/pulsar.sh
+++ b/pulsar.sh
@@ -200,11 +200,11 @@ elif [ $OS == 'Linux' ]; then
     fi
 
     if [ -z "${PULSAR_PATH}" ]; then
-      if [ -d "/opt/Pulsar/pulsar" ]; then
+      if [ -f "/opt/Pulsar/pulsar" ]; then
         # Check the default installation directory for RPM and DEB
         # distributions.
         PULSAR_PATH="/opt/Pulsar"
-      elif [ -d "$TMPDIR/pulsar-build/Pulsar/pulsar" ]; then
+      elif [ -f "$TMPDIR/pulsar-build/Pulsar/pulsar" ]; then
         # This is where Pulsar can be found during some CI build tasks.
         PULSAR_PATH="$TMPDIR/pulsar-build/Pulsar"
       else


### PR DESCRIPTION
This one is in draft mode until I can get some Linux testers.

### Identify the Bug

There are a handful of issues with `pulsar.sh` on macOS and Linux; they’re largely covered in #1053:

* There’s no reason that `-p`/`--package` need to get all the way to Pulsar before they’re handled. We should redirect them to `ppm` in `pulsar.sh`.
* Error messages generated by `pulsar` go to `stdout` instead of `stderr`.
* On Linux, `pulsar.sh` hard-codes an assumed install location — presumably the place it resides when installed via `rpm` or `deb`. If a user has downloaded the `tar.gz` version, `pulsar.sh` will fail to find their installation automatically, even though `pulsar.sh` _lives within_ that directory.

### Description of the Change

* All error messages now go to `stderr`.
* When `-p` or `--package` is present among the arguments, `pulsar.sh` will now handle them exactly how Pulsar itself does: by ignoring all arguments before `-p`/`--package`, then collecting all arguments _after_ `-p`/`--package` and calling `ppm` instead of Pulsar.
* Linux now has similar detection logic to that of macOS; if `pulsar.sh` is invoked from a symlink, it should now be able to determine its real location, then traverse upward to find a binary called `pulsar`.
* The user should be able to supersede all this location logic (on either platform) by specifying the `PULSAR_PATH` environment variable manually.
* Like #1054, this will also fix the fact that `pulsar -p --version` prints the version information for Pulsar instead of `ppm`.

### Alternate Designs

We already do the main alternative to handling `--package` in `pulsar.sh` — and we should keep it as a fallback.

### Possible Drawbacks

Bash scripts are a bit harder to write and don’t have a great testing situation, so I’d love to get field reports on how well this works on Linux. I was able to test the macOS parts on my local machine, but on Linux I’m mainly flying blind.

### Verification Process

* Verify all these commands produce the same output:
  * `pulsar --package --version`
  * `pulsar -p -v`
  * `ppm --version`
  * `pulsar --wait --package --version` (testing that any arguments before `--package` are ignored
* Verify these commands produce the same output
  * `pulsar --package list`
  * `pulsar -p list`
  * `ppm list`
  * `pulsar -v --package list`
* Verify that commands which _don't_ use `--package`/`-p` behave like they always did:
  * `pulsar .`
  * `pulsar --dev .`
  * `pulsar --wait foo.js`
  * `pulsar --test spec/*-spec.js`

Extra testing for Linux:

* Download the `tar.gz` distribution of Pulsar, extract it somewhere, then symlink its `./resources/pulsar.sh` to (e.g.) `pulsar-test` someplace on your path, like `/usr/local/bin`. Verify that `pulsar-test` passes all the manual tests described above.

### Release Notes

* Improved the command-line `pulsar` script’s ability to find the user’s Pulsar installation location on Linux.
* On macOS and Linux, `pulsar -p` now invokes `ppm` without having to launch Pulsar itself.
