### PR TITLE
CONTRIBUTING.MD link to section fixed

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ The following is a set of guidelines for contributing to Pulsar and its packages
 [I don't want to read this whole thing, I just have a question!!!](#i-dont-want-to-read-this-whole-thing-i-just-have-a-question)
 
 [What should I know before I get started?](#what-should-i-know-before-i-get-started)
-  * [Pulsar and Packages](#atom-and-packages)
+  * [Pulsar and Packages](#pulsar-and-packages)
   * [Pulsar Design Decisions](#design-decisions)
 
 [How Can I Contribute?](#how-can-i-contribute)


### PR DESCRIPTION
### Description of the Change

Update the CONTRIBUTING.md file changing the reference "Pulsar and Packages" to the correspondent section.

### Release Notes

- In the old version of this file, the "Pulsar and Packages" reference was misconfigured and pointed to nowhere because the person who updated this file has changed the reference name from Atom to Pulsar but the reference still pointing to the section with the old name.