### PR TITLE
Fix: preserve /usr/bin/pulsar and /usr/bin/ppm on RPM updates

### DIFF
--- a/script/electron-builder.js
+++ b/script/electron-builder.js
@@ -149,7 +149,7 @@ let options = {
   },
   rpm: {
     afterInstall: "script/post-install.sh",
-    afterRemove: "script/post-uninstall.sh",
+    afterRemove: "script/post-uninstall-rpm.sh",
     compression: 'xz',
     fpm: ['--rpm-rpmbuild-define=_build_id_links none']
   },

--- a/script/post-uninstall-rpm.sh
+++ b/script/post-uninstall-rpm.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+# https://github.com/pulsar-edit/pulsar/issues/544
+# This check works only for RPMs
+if [ $1 -ge 1 ]; then
+    # Package upgrade, do not uninstall
+    exit 0
+fi
+
+PULSAR_SCRIPT_PATH='/usr/bin/pulsar'
+
+if [ -f "$PULSAR_SCRIPT_PATH" ]
+then
+  rm "$PULSAR_SCRIPT_PATH"
+fi
+
+PPM_SYMLINK_PATH='/usr/bin/ppm'
+
+if [ -L "$PPM_SYMLINK_PATH" ]
+then
+  rm "$PPM_SYMLINK_PATH"
+fi


### PR DESCRIPTION
### Identify the Bug

Fixes #544

### Description of the Change

Currently, when pulsar rpm is upgraded, the `post-uninstall.sh` script is run _after_ `post-install.sh`.

Inspecting the RPM for the current release with `rpm -qp Linux.pulsar-1.120.0.x86_64.rpm --scripts` shows that electron-builder placed the scripts in the `%post` and `%postun` sections, described here: https://docs.fedoraproject.org/en-US/packaging-guidelines/Scriptlets/#ordering

As you can see, `%postun` is there also on upgrades (as the old package is uninstalled). There's a method that a scriptlet in `%postun` can use to check if we're doing an upgrade or a removal, which relies on the first argument supplied to the scriptlet (`$1`). Check for example the output for the Caddy package on my system (`rpm -q caddy --scripts`): 
[caddy_rpm_scripts.log](https://github.com/user-attachments/files/16981844/caddy_rpm_scripts.log)

This PR adds a separate `post-uninstall-rpm.sh` script which terminates early if we're performing an upgrade. I did not include the check on `post-uninstall.sh` as other package managers may pass different kind of args to the scripts.

### Alternate Designs

Keep a single `post-uninstall.sh` script and add extra checks to determine if we are in a RPM, however that would add more complexity.

### Possible Drawbacks

Different post-uninstall scripts to keep in sync

### Verification Process

* Installed v120 RPM
* Installed my locally built RPM
* `/usr/bin/pulsar` missing, as the `post-uninstall.sh` from the old package was used
* Installed again my locally built RPM
* `/usr/bin/pulsar` exists this time !

### Release Notes

- Fix: preserve /usr/bin/pulsar and /usr/bin/ppm on RPM updates