### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # VERSION:        0.2
 # DESCRIPTION:    Image to build Pulsar
 
-FROM ubuntu:20.04
+FROM node:16-bookworm-slim
 
 # Install dependencies
 RUN apt-get update && \
@@ -13,19 +13,10 @@ RUN apt-get update && \
         fakeroot \
         rpm \
         libx11-dev \
-        libxkbfile-dev \
-        libgdk-pixbuf2.0-dev \
-        libgtk-3-dev \
-        libxss-dev \
-        libasound2-dev \
-        npm && \
+        libxkbfile-dev && \
     rm -rf /var/lib/apt/lists/*
 
-COPY . /pulsar
-WORKDIR /pulsar
-
-# Use python2 by default
-RUN npm config set python /usr/bin/python2 -g
+USER node
 
 ENTRYPOINT ["/usr/bin/env", "sh", "-c"]
 CMD ["bash"]


### PR DESCRIPTION
- Node 16 is the current version used to build Pulsar.
- Remove libs that seem no longer necessary
- Do not install npm as it's already included in new base image
- Python 2 is no longer supported. Build and packaging run fine with Python 3
- Instead of copying the repo to the image, it's more efficient to do a bind mount when using the image, it's quicker and doesn't require a rebuild
- Use a non-root user, it's a security best-pratice, and fixes an error when running 'yarn build:apm': "EACCES: permission denied, scandir '/root/.npm/_logs'"

## Tests

After cloning the pulsar repo and updating submodules, I run the image with `docker run --rm -it -v /path/to/pulsar:/repo -w /repo my_image`. The following commands are working correctly inside the image:

* `yarn install`
* `yarn build`
* `yarn build:apm`
*  `yarn dist appimage`
* `yarn dist deb`
* `yarn dist rpm`
* `yarn dist targz`
