### PR TITLE
Changelog: Add changelog entries for Pulsar 1.121.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,35 @@
 
 ## [Unreleased]
 
+## 1.121.0
+
+- Updated `web-tree-sitter` to version 0.23.0.
+- [language-css] Updated `tree-sitter-css` to the latest version.
+- [language-gfm] Updated `tree-sitter-markdown` to the latest version.
+- [language-html] Updated `tree-sitter-html` and `tree-sitter-embedded-template` to their latest versions.
+- [language-javascript] Updated `tree-sitter-javascript` to the latest version.
+- [language-typescript] Updated `tree-sitter-typescript` to the latest version.
+- Added a new `@match.next` capture for advanced control of how indentation should change from one line to the next.
+- Added new indentation-specific query predicates `indent.matchesComparisonRow` and `indent.matchesCurrentRow` for comparing arbitrary positions in a Tree-sitter node tree to the operative rows in an indentation suggestion query. Makes it possible to say things like “decrease the indent on line 10 if a statement ends on line 9.”
+- Renamed indentation directives `indent.matchIndentOf` and `indent.offsetIndent` to `indent.match` and `indent.offset`, respectively. The old names still work as aliases.
+- Improved the command-line `pulsar` script’s ability to find the user’s Pulsar installation location on Linux.
+- On macOS and Linux, `pulsar -p` now invokes `ppm` without having to launch Pulsar itself.
+- Added options to the Windows installer to add Pulsar and PPM to the PATH
+- Fixed `ppm rebuild` command on ARM (Apple Silicon) Macs
+
+### Pulsar
+
+- Fixed: Tree-sitter rolling fixes: 1.121 edition [@savetheclocktower](https://github.com/pulsar-edit/pulsar/pull/1085)
+- Updated: Update ppm to commit 97f4d201be013157756a76008bf0cb55e6a1fe35 [@savetheclocktower](https://github.com/pulsar-edit/pulsar/pull/1094)
+- Fixed: Experiment: Redirect `-p`/`--package` to `ppm` via `pulsar.sh`… [@savetheclocktower](https://github.com/pulsar-edit/pulsar/pull/1066)
+- Added: [windows] Add PATH manipulation to Pulsar installer [@confused-Techie](https://github.com/pulsar-edit/pulsar/pull/1071)
+- Updated: CI: Update Cirrus Rolling upload token [@DeeDeeG](https://github.com/pulsar-edit/pulsar/pull/1086)
+
+### PPM
+
+- Fixed: Remove hard-coded architecture on Mac [@savetheclocktower](https://github.com/pulsar-edit/ppm/pull/141)
+- Updated: Begin less reliance on `async` package: Await as we go [@confused-Techie](https://github.com/pulsar-edit/ppm/pull/134)
+
 ## 1.120.0
 
 - Resolved some issues of using `pulsar -p` to access `ppm` in the command line on Windows.
@@ -24,7 +53,6 @@
 - Fixed: CONTRIBUTING.MD link to section fixed [@gsabatini2016](https://github.com/pulsar-edit/pulsar/pull/1067)
 
 ### PPM
-- Updated: Begin less reliance on `async` package: Await as we go [@confused-Techie](https://github.com/pulsar-edit/ppm/pull/134)
 - Fixed: Fix incorrect behavior on package rename [@savetheclocktower](https://github.com/pulsar-edit/ppm/pull/135)
 - Updated: Update many dependencies [@DeeDeeG](https://github.com/pulsar-edit/ppm/pull/133)
 - Revert: Revert "CI: Work around a weird bug in Yarn v1.x" [@DeeDeeG](https://github.com/pulsar-edit/ppm/pull/131)

--- a/packages/welcome/lib/changelog-view.js
+++ b/packages/welcome/lib/changelog-view.js
@@ -50,22 +50,43 @@ export default class ChangeLogView {
             <p>Feel free to read our <a href="https://github.com/pulsar-edit/pulsar/blob/master/CHANGELOG.md">Full Change Log</a>.</p>
             <ul>
               <li>
-                Resolved some issues of using <code>pulsar -p</code> to access <code>ppm</code> in the command line on Windows.
+                Updated <code>web-tree-sitter</code> to version 0.23.0.
               </li>
               <li>
-                Added a new icon for Pulsar on Windows, increasing it's visual fidelity in most locations.
+                [language-css] Updated <code>tree-sitter-css</code> to the latest version
               </li>
               <li>
-                [snippets] Fixed an issue with expanding snippet variables in certain scenarios if the snippet inserted new lines into the buffer.
+                [language-gfm] Updated <code>tree-sitter-markdown</code> to the latest version.
               </li>
               <li>
-                Updated misconfigured links in the <code>CONTRIBUTING.md</code> file.
+                [language-html] Updated <code>tree-sitter-html</code> and <code>tree-sitter-embedded-template</code> to their latest versions.
               </li>
               <li>
-                [ppm] Resolved an issue that could prevent renaming an existing package.
+                [language-javascript] Updated <code>tree-sitter-javascript</code> to the latest version.
               </li>
               <li>
-                Various Tree-sitter improvements (folds, indents, custom queries, grammar updates...)
+                [language-typescript] Updated <code>tree-sitter-typescript</code> to the latest version.
+              </li>
+              <li>
+                Added a new <code>@match.next</code> capture for advanced control of how indentation should change from one line to the next.
+              </li>
+              <li>
+                Added new indentation-specific query predicates <code>indent.matchesComparisonRow</code> and <code>indent.matchesCurrentRow</code> for comparing arbitrary positions in a Tree-sitter node tree to the operative rows in an indentation suggestion query. Makes it possible to say things like “decrease the indent on line 10 if a statement ends on line 9.”
+              </li>
+              <li>
+                Renamed indentation directives <code>indent.matchIndentOf</code> and <code>indent.offsetIndent</code> to <code>indent.match</code> and <code>indent.offset</code>, respectively. The old names still work as aliases.
+              </li>
+              <li>
+                Improved the command-line <code>pulsar</code> script’s ability to find the user’s Pulsar installation location on Linux.
+              </li>
+              <li>
+                On macOS and Linux, <code>pulsar -p</code> now invokes <code>ppm</code> without having to launch Pulsar itself.
+              </li>
+              <li>
+                Added options to the Windows installer to add Pulsar and PPM to the PATH
+              </li>
+              <li>
+                Fixed <code>ppm rebuild<code> command on ARM (Apple Silicon) Macs
               </li>
             </ul>
 


### PR DESCRIPTION
Adds Changelog entries for a bunch of PRs, specifically the ones which we have landed in core repo since Pulsar Regular release 1.120.0 was tagged.

Note: https://github.com/pulsar-edit/ppm/pull/134 was included in error in the 1.120.0 changelog, despite not being present in the ppm bump to core repo that time around. I have rectified this oversight by moving the entry to this release's notes. So, there is the rare change to a prior release's <kbd>CHANGELOG.md</kbd> notes in this PR. It serves the purpose of accuracy in documentation, even if said accuracy is late in arriving.