### PR TITLE
Bump version to 1.121.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "pulsar",
   "author": "Pulsar-Edit <admin@pulsar-edit.dev>",
   "productName": "Pulsar",
-  "version": "1.120.0-dev",
+  "version": "1.121.0",
   "description": "A Community-led Hyper-Hackable Text Editor",
   "branding": {
     "id": "pulsar",

--- a/packages/welcome/lib/changelog-view.js
+++ b/packages/welcome/lib/changelog-view.js
@@ -86,7 +86,7 @@ export default class ChangeLogView {
                 Added options to the Windows installer to add Pulsar and PPM to the PATH
               </li>
               <li>
-                Fixed <code>ppm rebuild<code> command on ARM (Apple Silicon) Macs
+                Fixed <code>ppm rebuild</code> command on ARM (Apple Silicon) Macs
               </li>
             </ul>
 


### PR DESCRIPTION
Bumping Pulsar's version to 1.121.0, in preparation for a new Regular release.