### PR TITLE
meta: Change version back to ending with `-dev`

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "pulsar",
   "author": "Pulsar-Edit <admin@pulsar-edit.dev>",
   "productName": "Pulsar",
-  "version": "1.121.0",
+  "version": "1.121.0-dev",
   "description": "A Community-led Hyper-Hackable Text Editor",
   "branding": {
     "id": "pulsar",


### PR DESCRIPTION
Forgot to change the version back to ending in `-dev` before merging #1097. Whoops! Fixing that now...