### PR TITLE
[tree-view] Remove deprecated usage of `shell.moveItemToTrash`

### DIFF
--- a/packages/tree-view/lib/tree-view.js
+++ b/packages/tree-view/lib/tree-view.js
@@ -904,6 +904,17 @@ class TreeView {
       if (response === 0) { // Move to Trash
         let failedDeletions = [];
         let deletionPromises = [];
+
+        // Since this goes async, all entries that correspond to paths we're
+        // about to delete will soon detach from the tree. So we should figure
+        // out ahead of time which element we're going to select when we're
+        // done.
+        let newSelectedEntry;
+        let firstSelectedEntry = selectedEntries[0];
+        if (firstSelectedEntry) {
+          newSelectedEntry = firstSelectedEntry.closest('.directory:not(.selected)');
+        }
+
         for (let selectedPath of selectedPaths) {
           // Don't delete entries which no longer exist. This can happen, for
           // example, when
@@ -943,10 +954,10 @@ class TreeView {
           );
         }
 
-        let firstSelectedEntry = selectedEntries[0];
-        if (firstSelectedEntry) {
-          this.selectEntry(firstSelectedEntry.closest('.directory:not(.selected)'));
+        if (newSelectedEntry) {
+          this.selectEntry(newSelectedEntry);
         }
+
         if (atom.config.get('tree-view.squashDirectoryNames')) {
           return this.updateRoots();
         }

--- a/packages/tree-view/lib/tree-view.js
+++ b/packages/tree-view/lib/tree-view.js
@@ -874,7 +874,7 @@ class TreeView {
     return dialog.attach();
   }
 
-  removeSelectedEntries() {
+  async removeSelectedEntries() {
     let activePath = this.getActivePath();
     let selectedPaths, selectedEntries;
     if (this.hasFocus()) {
@@ -896,13 +896,14 @@ class TreeView {
       }
     }
 
-    return atom.confirm({
+    atom.confirm({
       message: `Are you sure you want to delete the selected ${selectedPaths.length > 1 ? 'items' : 'item'}?`,
       detailedMessage: `You are deleting:\n${selectedPaths.join('\n')}`,
       buttons: ['Move to Trash', 'Cancel']
-    }, (response) => {
+    }, async (response) => {
       if (response === 0) { // Move to Trash
         let failedDeletions = [];
+        let deletionPromises = [];
         for (let selectedPath of selectedPaths) {
           // Don't delete entries which no longer exist. This can happen, for
           // example, when
@@ -913,17 +914,24 @@ class TreeView {
           //   but the parent folder is deleted first.
           if (!fs.existsSync(selectedPath)) continue;
 
-          this.emitter.emit('will-delete-entry', { pathToDelete: selectedPath });
+          let meta = { pathToDelete: selectedPath };
 
-          // TODO: `shell.trashItem` is the favored way to do this.
-          if (shell.moveItemToTrash(selectedPath)) {
-            this.emitter.emit('entry-deleted', { pathToDelete: selectedPath });
-          } else {
-            this.emitter.emit('delete-entry-failed', { pathToDelete: selectedPath });
+          this.emitter.emit('will-delete-entry', meta);
+
+          let promise = shell.trashItem(selectedPath).then(() => {
+            this.emitter.emit('entry-deleted', meta);
+          }).catch(() => {
+            this.emitter.emit('delete-entry-failed', meta);
             failedDeletions.push(selectedPath);
-          }
-          repoForPath(selectedPath)?.getPathStatus(selectedPath);
+          }).finally(() => {
+            repoForPath(selectedPath)?.getPathStatus(selectedPath);
+          });
+
+          deletionPromises.push(promise);
         }
+
+        await Promise.allSettled(deletionPromises);
+
         if (failedDeletions.length > 0) {
           atom.notifications.addError(
             this.formatTrashFailureMessage(failedDeletions),
@@ -934,6 +942,7 @@ class TreeView {
             }
           );
         }
+
         let firstSelectedEntry = selectedEntries[0];
         if (firstSelectedEntry) {
           this.selectEntry(firstSelectedEntry.closest('.directory:not(.selected)'));

--- a/packages/tree-view/package.json
+++ b/packages/tree-view/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "engines": {
     "atom": "*",
-    "node": ">=12"
+    "node": ">=14"
   },
   "private": true,
   "dependencies": {

--- a/packages/tree-view/spec/tree-view-package-spec.js
+++ b/packages/tree-view/spec/tree-view-package-spec.js
@@ -3210,7 +3210,6 @@ describe("TreeView", function () {
           jasmine.useRealClock();
           const callback = jasmine.createSpy('onEntryDeleted');
           treeView.onEntryDeleted(callback);
-          console.log('hoping', root1, 'will be selected');
           dirView2.dispatchEvent(new MouseEvent('click', {bubbles: true, detail: 1}));
           treeView.focus();
 

--- a/packages/tree-view/spec/tree-view-package-spec.js
+++ b/packages/tree-view/spec/tree-view-package-spec.js
@@ -3042,7 +3042,10 @@ describe("TreeView", function () {
         fileView.dispatchEvent(new MouseEvent('click', {bubbles: true, detail: 1}));
         treeView.focus();
 
-        spyOn(shell, 'moveItemToTrash').andReturn(false);
+        spyOn(shell, 'trashItem').andCallFake(() => {
+          return Promise.reject(false);
+        })
+
         spyOn(atom, 'confirm').andCallFake((options, callback) => callback(0));
 
         atom.commands.dispatch(treeView.element, 'tree-view:remove');
@@ -3093,7 +3096,9 @@ describe("TreeView", function () {
             return atom.commands.dispatch(treeView.element, 'tree-view:remove');
           });
 
-          waitsFor('directory to be deleted', () => callback.mostRecentCall.args[0].pathToDelete === dirPath2);
+          waitsFor('directory to be deleted', () =>
+            callback.mostRecentCall?.args?.[0].pathToDelete === dirPath2
+          );
 
           return runs(function () {
             const openFilePaths = atom.workspace.getTextEditors().map(editor => editor.getPath());
@@ -3122,7 +3127,9 @@ describe("TreeView", function () {
             return atom.commands.dispatch(treeView.element, 'tree-view:remove');
           });
 
-          waitsFor('directory to be deleted', () => callback.mostRecentCall.args[0].pathToDelete === dirPath2);
+          waitsFor('directory to be deleted', () =>
+            callback.mostRecentCall?.args?.[0].pathToDelete === dirPath2
+          );
 
           return runs(function () {
             const openFilePaths = atom.workspace.getTextEditors().map(editor => editor.getPath());
@@ -3156,7 +3163,9 @@ describe("TreeView", function () {
             return atom.commands.dispatch(treeView.element, 'tree-view:remove');
           });
 
-          waitsFor('directory to be deleted', () => callback.mostRecentCall.args[0].pathToDelete === dirPath2);
+          waitsFor('directory to be deleted', () =>
+            callback.mostRecentCall?.args?.[0].pathToDelete === dirPath2
+          );
 
           return runs(function () {
             const openFilePaths = atom.workspace.getTextEditors().map(editor => editor.getPath());
@@ -3187,7 +3196,9 @@ describe("TreeView", function () {
             return atom.commands.dispatch(treeView.element, 'tree-view:remove');
           });
 
-          waitsFor('directory to be deleted', () => callback.mostRecentCall.args[0].pathToDelete === dirPath2);
+          waitsFor('directory to be deleted', () =>
+            callback.mostRecentCall?.args?.[0].pathToDelete === dirPath2
+          );
 
           return runs(function () {
             const openFilePaths = atom.workspace.getTextEditors().map(editor => editor.getPath());
@@ -3195,10 +3206,11 @@ describe("TreeView", function () {
           });
         });
 
-        it("focuses the directory's parent folder", function () {
+        it("focuses the directory's parent folder", async function () {
+          jasmine.useRealClock();
           const callback = jasmine.createSpy('onEntryDeleted');
           treeView.onEntryDeleted(callback);
-
+          console.log('hoping', root1, 'will be selected');
           dirView2.dispatchEvent(new MouseEvent('click', {bubbles: true, detail: 1}));
           treeView.focus();
 
@@ -3206,11 +3218,12 @@ describe("TreeView", function () {
 
           atom.commands.dispatch(treeView.element, 'tree-view:remove');
 
-          waitsFor('directory to be deleted', () => callback.mostRecentCall.args[0].pathToDelete === dirPath2);
+          waitsFor('directory to be deleted', () =>
+            callback.mostRecentCall?.args?.[0].pathToDelete === dirPath2
+          );
 
           runs(() => {
-            console.log('most recent', callback.mostRecentCall);
-            expect(root1).toHaveClass('selected')
+            expect(root1).toHaveClass('selected');
           });
         });
       });
@@ -3764,14 +3777,20 @@ describe("TreeView", function () {
         treeView.onEntryDeleted(callback);
 
         const pathToDelete = treeView.selectedEntry().getPath();
-        expect(treeView.selectedEntry().getPath()).toContain(path.join('dir2', 'new2'));
+        expect(
+          treeView.selectedEntry().getPath()
+        ).toContain(path.join('dir2', 'new2'));
+
         const dirView = findDirectoryContainingText(treeView.roots[0], 'dir2');
         expect(dirView).not.toBeNull();
         spyOn(dirView.directory, 'updateStatus');
+
         spyOn(atom, 'confirm').andCallFake((options, callback) => callback(0));
         atom.commands.dispatch(treeView.element, 'tree-view:remove');
 
-        waitsFor('onEntryDeleted to be called', () => callback.mostRecentCall.args[0].pathToDelete === pathToDelete);
+        waitsFor('onEntryDeleted to be called', () =>
+          callback.mostRecentCall?.args?.[0].pathToDelete === pathToDelete
+        );
 
         return runs(() => expect(dirView.directory.updateStatus).toHaveBeenCalled());
       }));


### PR DESCRIPTION
### Identify the Bug

To delete files, `tree-view` uses Electron’s `shell.moveItemToTrash` method. That’s a synchronous method that was already deprecated in Electron 12 and is completely missing from Electron 30.

This can be fixed when we actually move to Electron 30, but there’s no reason not to backport it and fix it ahead of time.

### Description of the Change

The asynchronous `shell.trashItem` is its replacement. Some small amount of rearrangement is needed to keep the logic working identically, but otherwise this was an easy fix.

### Alternate Designs

None! This was the clear alternative.

### Possible Drawbacks

In my estimation, the only things that could be affected here are things that aren’t covered by specs.

### Verification Process

Specs should pass.

If you want to verify manually, try

* deleting a file or directory in `tree-view`,
* having it succeed, 
* ensuring the deleted item is removed from the tree, and
* verifying that its parent folder becomes the new selected item.


### Release Notes

* [tree-view] Moved to a more modern API for file removal in preparation for an Electron upgrade.