### PR TITLE
Feature: reloadable init scripts

### DIFF
--- a/spec/atom-environment-spec.js
+++ b/spec/atom-environment-spec.js
@@ -497,16 +497,49 @@ describe('AtomEnvironment', () => {
       }
     })
 
-    it('loads the init script and applies the configurations', async () => {
-      pulsar = new AtomEnvironment({
-        applicationDelegate: atom.applicationDelegate
-      });
-      const initPath = path.join(__dirname, 'fixtures', 'init-script.js')
-      pulsar.getUserInitScriptPath = () => initPath
-      await pulsar.requireUserInitScript();
-      const commands = atom.commands.findCommands({target: window})
-      const command = commands.find(({name}) => name === 'test-case')
-      expect(command).toEqual({name: 'test-case', displayName: 'Test Case'})
+    describe('when the config to reload init scripts is not set', () => {
+      it('loads the script and requires it, but will not reload the init script', () => {
+        pulsar = new AtomEnvironment({
+          applicationDelegate: atom.applicationDelegate
+        });
+        pulsar.config.set('core.autoReloadInitScript', false)
+
+        let initPath = path.join(__dirname, 'fixtures', 'init-script.js')
+        pulsar.getUserInitScriptPath = () => initPath
+        pulsar.requireUserInitScript();
+        let commands = atom.commands.findCommands({target: window})
+          .filter(({name}) => name.match(/test-case/))
+        expect(commands).toEqual([{name: 'test-case', displayName: 'Test Case'}])
+
+        initPath = path.join(__dirname, 'fixtures', 'different-init-script.js')
+        pulsar.requireUserInitScript();
+        commands = atom.commands.findCommands({target: window})
+          .filter(({name}) => name.match(/test-case/))
+        expect(commands).toEqual([{name: 'test-case', displayName: 'Test Case'}])
+      })
+    })
+
+    describe('when the config to reload init scripts is set', () => {
+      it('allows for the init script to be reloaded', () => {
+        pulsar = new AtomEnvironment({
+          applicationDelegate: atom.applicationDelegate
+        });
+        pulsar.config.set('core.autoReloadInitScript', true)
+
+        let initPath = path.join(__dirname, 'fixtures', 'reloadable-init-script.js')
+        pulsar.getUserInitScriptPath = () => initPath
+        pulsar.requireUserInitScript();
+        let commands = atom.commands.findCommands({target: window})
+          .filter(({name}) => name.match(/test-case/))
+        expect(commands).toEqual([{name: 'test-case', displayName: 'Test Case'}])
+
+        initPath = path.join(__dirname, 'fixtures', 'different-init-script.js')
+        pulsar.getUserInitScriptPath = () => initPath
+        pulsar.requireUserInitScript();
+        commands = atom.commands.findCommands({target: window})
+          .filter(({name}) => name.match(/test-case/))
+        expect(commands).toEqual([{name: 'test-case-2', displayName: 'Test Case 2'}])
+      })
     })
   })
 

--- a/spec/atom-environment-spec.js
+++ b/spec/atom-environment-spec.js
@@ -488,6 +488,28 @@ describe('AtomEnvironment', () => {
     });
   });
 
+  describe('init script handling', () => {
+    let pulsar
+    afterEach(() => {
+      if(pulsar) {
+        pulsar.unloadEditorWindow();
+        pulsar.destroy();
+      }
+    })
+
+    it('loads the init script and applies the configurations', async () => {
+      pulsar = new AtomEnvironment({
+        applicationDelegate: atom.applicationDelegate
+      });
+      const initPath = path.join(__dirname, 'fixtures', 'init-script.js')
+      pulsar.getUserInitScriptPath = () => initPath
+      await pulsar.requireUserInitScript();
+      const commands = atom.commands.findCommands({target: window})
+      const command = commands.find(({name}) => name === 'test-case')
+      expect(command).toEqual({name: 'test-case', displayName: 'Test Case'})
+    })
+  })
+
   describe('attemptRestoreProjectStateForPaths(state, projectPaths, filesToOpen)', () => {
     describe('when the window is clean (empty or has only unnamed, unmodified buffers)', () => {
       beforeEach(async () => {

--- a/spec/fixtures/different-init-script.js
+++ b/spec/fixtures/different-init-script.js
@@ -1,0 +1,3 @@
+disposable.add(atom.commands.add(window, 'test-case-2', () => {
+  atom.notifications.addInfo("Hello!")
+}))

--- a/spec/fixtures/init-script.js
+++ b/spec/fixtures/init-script.js
@@ -1,0 +1,3 @@
+atom.commands.add(window, 'test-case', () => {
+  atom.notifications.addInfo("Hello!")
+})

--- a/spec/fixtures/reloadable-init-script.js
+++ b/spec/fixtures/reloadable-init-script.js
@@ -1,0 +1,3 @@
+disposable.add(atom.commands.add(window, 'test-case', () => {
+  atom.notifications.addInfo("Hello!")
+}))

--- a/src/config-schema.js
+++ b/src/config-schema.js
@@ -410,7 +410,13 @@ const configSchema = {
         default: false,
         title: 'Allow Window Transparency',
         description: `Allows editor windows to be see-through. When this setting is enabled, UI themes and user stylesheets can use background colors with an alpha channel to make editor windows translucent. Takes effect after a restart of Pulsar.`
-      }
+      },
+      autoReloadInitScript: {
+        type: 'boolean',
+        default: false,
+        description:
+          'Automatically reloads the init script when the file was changed. Adds a global `disposable` object that can be used at the init script to dispose old commands, old callbacks, etc. DO NOT enable this without using `disposable` in your init script, otherwise you will have duplicated commands.'
+      },
     }
   },
   editor: {


### PR DESCRIPTION
Currently, init scripts are a very powerful feature that I feel are sometimes underused. The fact we need to reload the editor to apply the changes, together with the fact that if we have _any error_ in the init script we will have it applied partially, or even have undesirable results, is also a problem

This PR adds a config "auto reload init script", which will basically do four things:

1. Change the way we load init script - instead of using `require`, we will use `eval`, which will also allow us to reload the script _and_ pass a new parameter - `disposable` - which will be used to dispose old commands from previous scripts
2. Watch the init script with Pathwatcher or any other mechanism - so when the user saves the init script, it'll dispose the old commands, and apply the new script
3. Add an error treatment - when the script have some failure, we'll dispose everything so that the script won't be partially applied, possibly causing unpredictable results
4. Keep **everything the same** if the config is not changed

I'm drafting this PR to request for comments, and also to ask for opinions on:

1. Should we keep the option to load `.coffee` init scripts? If so, we need to transpile `.coffee` files before running `eval`
2. Where should we watch the init script? Supposedly, we need to watch for changes in the config, so we can decide if we want to watch the file, or if we want to "unwatch" it (if the "auto reload" changes from `true` to `false`)
3. How should we watch? In the keymaps config, we watch using `pathwatcher`. We also have the `nsfw` watcher that is built-in into Pulsar, I'm unsure why Atom originally had these two options so I don't really know which one should we use

Missing in this PR:
* [ ] Actually watch the config
* [ ] Check if we need to transpile CoffeeScript files
