### PR TITLE
CI: Bump macOS runner images from macos-12 to macos-13

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ ubuntu-latest, macos-12, windows-latest ]
+        os: [ ubuntu-latest, macos-13, windows-latest ]
         include:
           - os: ubuntu-latest
             image: "debian:10"

--- a/.github/workflows/editor-tests.yml
+++ b/.github/workflows/editor-tests.yml
@@ -15,8 +15,8 @@ jobs:
       !startsWith(github.event.pull_request.title, '[skip-editor-ci]')
     strategy:
       matrix:
-        # os: [ubuntu-20.04, macos-12, windows-2019]
-        os: [ubuntu-20.04, macos-12]
+        # os: [ubuntu-20.04, macos-13, windows-2019]
+        os: [ubuntu-20.04, macos-13]
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
## Summary

The macOS 12 runner image will be end-of-life for GitHub Actions by early December 2024. Switch to the macOS 13 image now, ahead of when we would be voluntold to.

> We are beginning the deprecation process for the macOS 12 runner image
> [ . . . ] This image will be fully retired by the December 3rd, 2024.

https://github.blog/changelog/2024-08-19-notice-of-upcoming-deprecations-and-breaking-changes-in-github-actions-runners/

## Verification Process

CI will run, hopefully it will pass right away, if not, this PR will let me test fixes until something works.