### PR TITLE
CI: Simplify run-tests.js and use it in editor tests workflow

### DIFF
--- a/.github/workflows/editor-tests.yml
+++ b/.github/workflows/editor-tests.yml
@@ -42,7 +42,7 @@ jobs:
 
     - name: Run Tests
       if: runner.os != 'Linux'
-      run: yarn start --test spec
+      run: node script/run-tests.js spec
 
     - name: Run Tests with xvfb-run (Linux)
       if: runner.os == 'Linux'

--- a/script/run-tests.js
+++ b/script/run-tests.js
@@ -1,23 +1,14 @@
 const cp = require('child_process')
 
-function runAllSpecs(files) {
-  runSpecs(files, [])
-}
-
-function runSpecs(files, retries) {
+function runSpecs(files) {
   let env = process.env
   env.ATOM_JASMINE_REPORTER='list'
-  if(retries.length > 0) {
-    // Escape possible tests that can generate a regexp that will not match...
-    const escaped = retries.map(str => str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'));
-    env.SPEC_FILTER = escaped.join("|")
-  }
+
   const res = cp.spawn('yarn', ['start', '--test', ...files], {
     cwd: process.cwd(),
     env: env
   })
 
-  let out;
   res.stdout.on('data', data => {
      process.stdout.write(data.toString());
   });
@@ -25,46 +16,11 @@ function runSpecs(files, retries) {
   res.stderr.on('data', data => {
      const strData = data.toString();
      process.stderr.write(strData);
-
-     if(strData.match(/ALL TESTS THAT FAILED:/)) {
-       out = '';
-     } else if(out !== undefined) {
-       out += strData;
-     }
   });
 
   res.on('close', code => {
-    if(code !== 0 && retries.length === 0) {
-      const failed = filterSpecs(out)
-
-      console.log(`*********************
-Tests failed. Retrying failed tests...
-*********************
-
-`)
-      runSpecs(files, failed)
-    } else {
       process.exit(code)
-    }
   });
-}
-
-function filterSpecs(output) {
-  if(!output) return ''
-  let descriptions = []
-  let start = true
-  for(let out of output.split("\n")) {
-    if(start) {
-      if(out !== '') {
-        start = false
-        descriptions.push(out)
-      }
-    } else if(out !== '') {
-      descriptions.push(out)
-    } else {
-      return descriptions
-    }
-  }
 }
 
 if(process.argv[0] === __filename) {


### PR DESCRIPTION
### Summary

Hopefully avoids an odd test failure we see in CI.

This issue started to show itself after https://github.com/pulsar-edit/pulsar/pull/917 was merged, despite not being an issue in that PR itself. I confirmed that specifically this commit can be reverted to make the issue go away on `master` branch: https://github.com/pulsar-edit/pulsar/pull/917/commits/58cdd5f6c36ae42ce3b4117421b932ffea42e22a

Not sure what's up with that. Going to see if I can simplify `run-tests.js` without all the "retrying failed specs" stuff. Maybe then we can get CI passing without the false positives seen with the reruns.

### Verification Process

Once again this is one of those CI pull requests where I open the PR itself to run CI and see if it fixes things or not. Will follow-up based on what the first run does.