### PR TITLE
welcome: Resolve merge conflict markers in changelog-view.js

### DIFF
--- a/packages/welcome/lib/changelog-view.js
+++ b/packages/welcome/lib/changelog-view.js
@@ -50,45 +50,6 @@ export default class ChangeLogView {
             <p>Feel free to read our <a href="https://github.com/pulsar-edit/pulsar/blob/master/CHANGELOG.md">Full Change Log</a>.</p>
             <ul>
               <li>
-<<<<<<< HEAD
-                Updated <code>web-tree-sitter</code> to version 0.23.0.
-              </li>
-              <li>
-                [language-css] Updated <code>tree-sitter-css</code> to the latest version
-              </li>
-              <li>
-                [language-gfm] Updated <code>tree-sitter-markdown</code> to the latest version.
-              </li>
-              <li>
-                [language-html] Updated <code>tree-sitter-html</code> and <code>tree-sitter-embedded-template</code> to their latest versions.
-              </li>
-              <li>
-                [language-javascript] Updated <code>tree-sitter-javascript</code> to the latest version.
-              </li>
-              <li>
-                [language-typescript] Updated <code>tree-sitter-typescript</code> to the latest version.
-              </li>
-              <li>
-                Added a new <code>@match.next</code> capture for advanced control of how indentation should change from one line to the next.
-              </li>
-              <li>
-                Added new indentation-specific query predicates <code>indent.matchesComparisonRow</code> and <code>indent.matchesCurrentRow</code> for comparing arbitrary positions in a Tree-sitter node tree to the operative rows in an indentation suggestion query. Makes it possible to say things like “decrease the indent on line 10 if a statement ends on line 9.”
-              </li>
-              <li>
-                Renamed indentation directives <code>indent.matchIndentOf</code> and <code>indent.offsetIndent</code> to <code>indent.match</code> and <code>indent.offset</code>, respectively. The old names still work as aliases.
-              </li>
-              <li>
-                Improved the command-line <code>pulsar</code> script’s ability to find the user’s Pulsar installation location on Linux.
-              </li>
-              <li>
-                On macOS and Linux, <code>pulsar -p</code> now invokes <code>ppm</code> without having to launch Pulsar itself.
-              </li>
-              <li>
-                Added options to the Windows installer to add Pulsar and PPM to the PATH
-              </li>
-              <li>
-                Fixed <code>ppm rebuild</code> command on ARM (Apple Silicon) Macs
-=======
                 Added a SQL State Storage alternative to IndexedDB (opt-in, off by default).
               </li>
               <li>
@@ -117,7 +78,6 @@ export default class ChangeLogView {
               </li>
               <li>
                 [tree-view] Moved to a more modern API for file removal in preparation for an Electron upgrade.
->>>>>>> bce72212de5f12f4846b065f9379151dc23fc515
               </li>
             </ul>
 


### PR DESCRIPTION
## Summary

Resolved some merge conflict notation that was committed verbatim in `packages/welcome/lib/changelog-view.js` (see PR "Files changed" (diff) for details).

Fixes a syntax error when parsing the JSX of the welcome package's changelog view. Changelog view should work again!

## Verification Process

Not tested. Just looks like valid JSX (HTML-ish) syntax now to my eyes.

I can test a PR binary if desired to confirm the Changelog view from the welcome package will display without syntax errors in the console, once binaries build in CI.

### Note

Thanks for working on this stuff, I'm sure a few necessary but gnarly merges may have been encountered throughout this process...! Figured this was an easy drive-by fix, so here it is!