### PR TITLE
[symbols-view] Allow project-wide symbol searches to consider multiple providers

### DIFF
--- a/packages/symbols-view/lib/project-view.js
+++ b/packages/symbols-view/lib/project-view.js
@@ -143,7 +143,11 @@ module.exports = class ProjectView extends SymbolsView {
     // longer need the symbols we asked for.
     let signal = this.abortController.signal;
 
-    let providers = await this.broker.select(meta);
+    // A user would probably expect this search to return symbols from all
+    // files in the project, regardless of their language. Instead of picking a
+    // “winning” provider as we usually do, we should instead consult _all_
+    // providers that consider themselves up to the task.
+    let providers = await this.broker.select(meta, { enforceExclusivity: false });
     if (providers?.length === 0) {
       console.warn('No providers found!');
       return null;

--- a/packages/symbols-view/lib/provider-broker.js
+++ b/packages/symbols-view/lib/provider-broker.js
@@ -175,7 +175,7 @@ module.exports = class ProviderBroker {
    * @returns {Promise<SymbolProvider[]>} A promise that resolves with a list
    *   of symbol providers.
    */
-  async select(meta) {
+  async select(meta, { enforceExclusivity = true } = {}) {
     let shouldLog = Config.get('enableDebugLogging');
     let exclusivesByScore = [];
     let results = [];
@@ -210,7 +210,14 @@ module.exports = class ProviderBroker {
       let { value: score } = outcome;
       let name = provider.name ?? 'unknown';
       let packageName = provider?.packageName ?? 'unknown';
-      let isExclusive = provider?.isExclusive ?? false;
+
+      // When `enforceExclusivity` is `false`, we'll treat all providers as
+      // non-exclusive, even the ones that indicate otherwise.
+      //
+      // It still falls on a provider to know whether to provide symbols or
+      // not. Any provider is free to inspect the metadata and return an empty
+      // set if it thinks it's inappropriate for its results to be considered.
+      let isExclusive = enforceExclusivity ? (provider?.isExclusive ?? false) : false;
 
       if (shouldLog)
         console.debug('Score for', provider.name, 'is:', score);

--- a/packages/symbols-view/spec/fixtures/providers/second-dummy-provider.js
+++ b/packages/symbols-view/spec/fixtures/providers/second-dummy-provider.js
@@ -1,0 +1,51 @@
+const { Point } = require('atom');
+
+function last(arr) {
+  return arr[arr.length - 1];
+}
+
+const ICONS = [
+  'icon-package',
+  'icon-key',
+  'icon-gear',
+  'icon-tag',
+  null
+];
+
+module.exports = {
+  packageName: 'symbol-provider-dummy-second',
+  name: 'Dummy (Second)',
+  isExclusive: true,
+  canProvideSymbols() {
+    return true;
+  },
+  getSymbols(meta) {
+    let { editor, type } = meta;
+    let results = [];
+    if (type === 'file') {
+      let count = editor.getLineCount();
+      // Put a symbol on every third line.
+      for (let i = 0; i < count; i += 3) {
+        results.push({
+          position: new Point(i, 0),
+          name: `(Second) Symbol on Row ${i + 1}`,
+          icon: ICONS[(i / 3) % (ICONS.length + 1)]
+        });
+      }
+    } else if (type === 'project') {
+      let root = last(atom.project.getPaths());
+      let count = editor.getLineCount();
+      // Put a symbol on every third line.
+      for (let i = 0; i < count; i += 3) {
+        results.push({
+          position: new Point(i, 0),
+          name: `(Second) Symbol on Row ${i + 1}`,
+          directory: root,
+          file: 'other-file.js',
+          icon: ICONS[i % (ICONS.length + 1)]
+        });
+      }
+    }
+    return results;
+  }
+};


### PR DESCRIPTION
Fixes #1117.

### Identify the Bug

Described in #1117. You should be able to get project-wide symbol search results no matter which sort of file is open in your active editor. For instance, you should be able to get JavaScript results even if you're currently editing a `package.json` file.



### Description of the Change

We usually pick a single winner among providers (unless they mark themselves as “non-exclusive” so that they can supplement the result set) in an effort to reduce duplication of effort. When we ask providers for project-wide results, though, we won't enforce exclusivity; there are lots of polyglot projects and we're interested in all possible results.

This removes the artificial narrowing of the result set on our end. But half of this needs to be done in the providers. For instance, `pulsar-ide-typescript` should sometimes consider metadata about the active editor, but sometimes shouldn't. If the metadata indicates that we're trying to resolve a “go to declaration” command, then it should decline to act as a provider unless the user is in a TS or JS file; but if we're doing project-wide symbol search, then the active editor is far less relevant, and it should be willing to contribute TS/JS symbols to the full result set along with other providers.

I'll be making this change in `@savetheclocktower/atom-languageclient` so that IDE provider packages do the right thing out of the box.

### Alternate Designs

This is the only solution that works here; even some other design would've needed us to explicitly remove this constraint on the symbol result set.

### Possible Drawbacks

We're lucky that neither of the built-in providers is able to resolve project-wide symbol searches, or else this change could potentially introduce lots more noise to the result set. It's rare, but possible, that the user would have two different IDE packages installed that are able to supply symbol information for the same language — and if both are active, then both will end up in the result set.

The workaround for the user would theoretically be to configure one of those packages not to try to provide symbols; this may or may not be present in that package's settings, but we could handle these situations when they occur in real life instead of just existing as theoreticals.

### Verification Process

Specs should pass.

### Release Notes

- [symbols-view] Allow project-wide symbol search to consider results from more than one provider.