### PR TITLE
electron-builder: Fix race condition when preparing to copy binaries

### DIFF
--- a/script/electron-builder.js
+++ b/script/electron-builder.js
@@ -1,6 +1,7 @@
 const path = require('path')
 const normalizePackageData = require('normalize-package-data');
 const fs = require("fs/promises");
+const {mkdirSync} = require("fs");
 const generateMetadata = require('./generate-metadata-for-builder')
 const macBundleDocumentTypes = require("./mac-bundle-document-types.js");
 
@@ -289,7 +290,13 @@ async function main() {
     config: options
   }).then((result) => {
     console.log("Built binaries")
-    fs.mkdir('binaries').catch(() => "")
+    try {
+      mkdirSync('binaries', {recursive: true})
+    } catch (err) {
+      console.warn("Warning: error encountered when making the 'binaries' dir.")
+      console.warn("(HINT: If the 'binaries' folder already exists, then this error message is probably fine to ignore!)")
+      console.warn(err)
+    }
     Promise.all(result.map(r => fs.copyFile(r, path.join('binaries', path.basename(r)))))
   }).catch((error) => {
     console.error("Error building binaries")


### PR DESCRIPTION
### Problem

There was a race condition where two separate pieces of async code would A) create the 'binaries' folder, and B) copy binaries to that folder. The problem was the lack of a guarantee they would happen in that order! If the attempt to copy files happened before the directory got created, the whole electron-builder run would error and/or stall out from unsuccessful auto-retries failing.

### Stakes

This issue blocks the x64 macOS CI "build Pulsar binaries" job from producing any binaries.

(Optional commentary: For unknown reasons, macOS CI and my local machine seem to be adversely affected by the race condition, whereas at least CI Linux and Windows x64, and possibly both Cirrus (ARM) CI tasks, do not appear affected, again for unknown reasons. But as race conditions are unpredictable and might depend on the minutiae of the system the code runs on, this arguably isn't all that surprising...)

### Solution

To fix the situation:

Ensure the 'binaries' dir exists *before* copying binaries to it.

Do so by making the directory *first* with a *synchronous* function.

(I might usually try to eliminate race conditions while still using asynchronous code, but for simple scripts, I prefer to use synchronous code, for simplicity's sake and for reliability.)

In other words: Can't copy files to a destination dir that doesn't exist! This makes sure the directory exists *first*, then copy.

Also: Log any error we hit while making the dir, but try to continue. (For anyone who has successfully run electorn-builder once in the repo, they already have a 'binaries' folder, so we can ignore any error when trying to "make the dir" that already exists. If it doesn't exist, the copy operation will print another relevant error message. So we don't need to error early here. But logging it should help if this issue needs any troubleshooting on anyone's machines (including CI) any time in the future.)

### Verification Process

Tested extensively on my local machine (macOS 10.15.7). I would like to see a passing "build Pulsar binaries" CI run as well.

Looked up some info to refresh my memory on promise/async execution and the [Node `fs` and `fs/promises` APIs](https://nodejs.org/api/fs.html). Decided to lean into synchronous code for this, but the code seems logically like it should reliably work now, in the intended order. At least to me, review welcome.

### Long writeup, simple and sweet diff!

Review would be much appreciated!

(Sidebar: This is another one of those PRs with a simple fix that I wanted to write up in detail so we can understand the issue quickly if it comes up again. But also because I like going a bit too in-depth fixing and writing up these things, makes me feel like a detective. It's therapeutic. Anyhow, sorry for the delay in getting this out. But I think it's rock solid now! Hopefully!)