### PR TITLE
electron-builder: Don't create differential update blockmaps

### DIFF
--- a/script/electron-builder.js
+++ b/script/electron-builder.js
@@ -199,7 +199,8 @@ let options = {
     },
   },
   "dmg": {
-    "sign": false
+    "sign": false,
+    "writeUpdateInfo": false
   },
   "win": {
     "icon": icoIcon,
@@ -236,7 +237,8 @@ let options = {
     // the AppID 'dev.pulsar-edit.pulsar'. If this value ever changes,
     // A PR to GitHub Desktop must be made with the updated value
     "include": "resources/win/installer.nsh",
-    "warningsAsErrors": false
+    "warningsAsErrors": false,
+    "differentialPackage": false
   },
   "extraMetadata": {
   },


### PR DESCRIPTION
They are *extremely* computationally intensive to make, and we don't even use them. Use these undocumented config options to skip making them entirely.

Source (where I learned about these config options): github[dot]com/electron-userland/electron-builder/issues/2900#issuecomment-730571696

**By the way, the impetus for disabling these is that macOS 13 CI keeps failing at the blockmap creation step. We want successful binary builds in CI!**

Note: There apparently is no way to disable blockmaps for the .zip target on macOS. Only for the macOS .dmg and the Windows NSIS targets.