### PR TITLE
Fix Linux trash error message

### DIFF
--- a/packages/tree-view/lib/tree-view.js
+++ b/packages/tree-view/lib/tree-view.js
@@ -954,7 +954,7 @@ class TreeView {
   formatTrashEnabledMessage() {
     switch (process.platform) {
       case 'linux':
-        return 'Is `gvfs-trash` installed?';
+        return 'Do you have permission to delete, and Trash is enabled on the volume where the files are stored?';
       case 'darwin':
         return 'Is Trash enabled on the volume where the files are stored?';
       case 'win32':


### PR DESCRIPTION
`gvfs-trash` is deprecated and removed a long time ago. I think it's a good idea to fix this message so that users won't have the wrong idea on what might be wrong