### PR TITLE
[settings-view] Fix Package keymap compatibility check

### DIFF
--- a/packages/settings-view/lib/package-keymap-view.js
+++ b/packages/settings-view/lib/package-keymap-view.js
@@ -127,7 +127,7 @@ export default class PackageKeymapView {
         continue
       }
 
-      if (this.selectorIsNotCompatibleWithPlatform(selector)) {
+      if (!this.selectorIsCompatibleWithPlatform(selector)) {
         continue;
       }
 
@@ -183,10 +183,10 @@ export default class PackageKeymapView {
     atom.clipboard.write(content)
   }
 
-  selectorIsNotCompatibleWithPlatform(selector, platform = process.platform) {
+  selectorIsCompatibleWithPlatform(selector, platform = process.platform) {
     const otherPlatformPattern = new RegExp(`\\.platform-(?!${_.escapeRegExp(platform)}\\b)`);
     const currentPlatformPattern = new RegExp(`\\.platform-(${_.escapeRegExp(platform)}\\b)`);
 
-    return otherPlatformPattern.test(selector) && !currentPlatformPattern.test(selector);
+    return !(otherPlatformPattern.test(selector) && !currentPlatformPattern.test(selector));
   }
 }

--- a/packages/settings-view/lib/package-keymap-view.js
+++ b/packages/settings-view/lib/package-keymap-view.js
@@ -11,7 +11,6 @@ import KeybindingsPanel from './keybindings-panel'
 export default class PackageKeymapView {
   constructor (pack) {
     this.pack = pack
-    this.otherPlatformPattern = new RegExp(`\\.platform-(?!${_.escapeRegExp(process.platform)}\\b)`)
     this.namespace = this.pack.name
     this.disposables = new CompositeDisposable()
     etch.initialize(this)
@@ -128,8 +127,8 @@ export default class PackageKeymapView {
         continue
       }
 
-      if (this.otherPlatformPattern.test(selector)) {
-        continue
+      if (this.selectorIsNotCompatibleWithPlatform(selector)) {
+        continue;
       }
 
       const keyBindingRow = document.createElement('tr')
@@ -182,5 +181,12 @@ export default class PackageKeymapView {
     }
 
     atom.clipboard.write(content)
+  }
+
+  selectorIsNotCompatibleWithPlatform(selector, platform = process.platform) {
+    const otherPlatformPattern = new RegExp(`\\.platform-(?!${_.escapeRegExp(platform)}\\b)`);
+    const currentPlatformPattern = new RegExp(`\\.platform-(${_.escapeRegExp(platform)}\\b)`);
+
+    return otherPlatformPattern.test(selector) && !currentPlatformPattern.test(selector);
   }
 }

--- a/packages/settings-view/spec/package-keymap-view-spec.js
+++ b/packages/settings-view/spec/package-keymap-view-spec.js
@@ -14,22 +14,22 @@ describe("PackageKeymapView", () => {
   });
 
   it("should say a selector with no platform listed is compatible with the current one", () => {
-    expect(view.selectorIsNotCompatibleWithPlatform("atom-text-editor", "win32")).toBe(false);
+    expect(view.selectorIsCompatibleWithPlatform("atom-text-editor", "win32")).toBe(true);
   });
 
   it("should say a selector with a platform other than the current is not compatible", () => {
-    expect(view.selectorIsNotCompatibleWithPlatform(".platform-darwin", "linux")).toBe(true);
-    expect(view.selectorIsNotCompatibleWithPlatform(".platform-win32", "darwin")).toBe(true);
+    expect(view.selectorIsCompatibleWithPlatform(".platform-darwin", "linux")).toBe(false);
+    expect(view.selectorIsCompatibleWithPlatform(".platform-win32", "darwin")).toBe(false);
   });
 
   it("should say a selector with the current platform listed is compatible", () => {
-    expect(view.selectorIsNotCompatibleWithPlatform(".platform-linux", "linux")).toBe(false);
-    expect(view.selectorIsNotCompatibleWithPlatform(".platform-win32", "win32")).toBe(false);
-    expect(view.selectorIsNotCompatibleWithPlatform(".platform-darwin", "darwin")).toBe(false);
+    expect(view.selectorIsCompatibleWithPlatform(".platform-linux", "linux")).toBe(true);
+    expect(view.selectorIsCompatibleWithPlatform(".platform-win32", "win32")).toBe(true);
+    expect(view.selectorIsCompatibleWithPlatform(".platform-darwin", "darwin")).toBe(true);
   });
 
   it("should say a selector with the current platform and others listed is compatible", () => {
-    expect(view.selectorIsNotCompatibleWithPlatform(".platform-linux, .platform-win32", "win32")).toBe(false);
-    expect(view.selectorIsNotCompatibleWithPlatform(".platform-linux, .platform-win32", "linux")).toBe(false);
+    expect(view.selectorIsCompatibleWithPlatform(".platform-linux, .platform-win32", "win32")).toBe(true);
+    expect(view.selectorIsCompatibleWithPlatform(".platform-linux, .platform-win32", "linux")).toBe(true);
   });
 });

--- a/packages/settings-view/spec/package-keymap-view-spec.js
+++ b/packages/settings-view/spec/package-keymap-view-spec.js
@@ -1,0 +1,35 @@
+
+const PackageKeymapView = require("../lib/package-keymap-view.js");
+let view;
+
+describe("PackageKeymapView", () => {
+
+  beforeEach(() => {
+    // Just prevent this stuff from calling through, it doesn't matter for this test
+    spyOn(atom.packages, "getLoadedPackage").andReturn({ keymaps: [] });
+
+    view = new PackageKeymapView({
+      name: "test-package"
+    });
+  });
+
+  it("should say a selector with no platform listed is compatible with the current one", () => {
+    expect(view.selectorIsNotCompatibleWithPlatform("atom-text-editor", "win32")).toBe(false);
+  });
+
+  it("should say a selector with a platform other than the current is not compatible", () => {
+    expect(view.selectorIsNotCompatibleWithPlatform(".platform-darwin", "linux")).toBe(true);
+    expect(view.selectorIsNotCompatibleWithPlatform(".platform-win32", "darwin")).toBe(true);
+  });
+
+  it("should say a selector with the current platform listed is compatible", () => {
+    expect(view.selectorIsNotCompatibleWithPlatform(".platform-linux", "linux")).toBe(false);
+    expect(view.selectorIsNotCompatibleWithPlatform(".platform-win32", "win32")).toBe(false);
+    expect(view.selectorIsNotCompatibleWithPlatform(".platform-darwin", "darwin")).toBe(false);
+  });
+
+  it("should say a selector with the current platform and others listed is compatible", () => {
+    expect(view.selectorIsNotCompatibleWithPlatform(".platform-linux, .platform-win32", "win32")).toBe(false);
+    expect(view.selectorIsNotCompatibleWithPlatform(".platform-linux, .platform-win32", "linux")).toBe(false);
+  });
+});


### PR DESCRIPTION
It turns out that for quite some time the way the package's keymap section checks for platform compatibility has been broken.

I've detailed the reason why in #1160, but basically, if a keymap listed multiple platforms, such as `linux` and `win32` the compatibility check would just see that it works on a platform other than the current one, and would think it's incompatible and not show it to the user.

So I've gone ahead and fixed this check much in the same way we already check in `settings-view/lib/keybindings-panel.js` except I've expanded out on this functionality a bit, by creating a method for this check.

Also, I've given the ability to pass in a platform rather than going with the current one, which makes it much easier to test this, and means if we wanted to in the future we could purposefully grab incompatible keymaps.

And since it's not testable, of course I've written new tests to be able to test this behavior.

Resolves #1160 