### PR TITLE
CI: Add build dependencies for Linux 'test bins' job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -238,6 +238,10 @@ jobs:
     needs: build
 
     steps:
+    - name: Install build dependencies - Linux
+      if: ${{ runner.os == 'Linux' }}
+      run: sudo apt-get update && sudo apt-get install -y git python3 python3-pip make gcc g++ libx11-dev libxkbfile-dev pkg-config libsecret-1-dev rpm xvfb ffmpeg zstd wget squashfs-tools
+
     - name: Checkout the latest code
       uses: actions/checkout@v4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 ### Pulsar
 
+- CI: Add build dependencies for Linux 'test bins' job [@DeeDeeG](https://github.com/pulsar-edit/pulsar/pull/1165)
 - Tree-sitter rolling fixes, 1.124 edition [@savetheclocktower](https://github.com/pulsar-edit/pulsar/pull/1148)
 - Fix Linux trash error message [@mauricioszabo](https://github.com/pulsar-edit/pulsar/pull/1151)
 - electron-builder: Don't create differential update blockmaps [@DeeDeeG](https://github.com/pulsar-edit/pulsar/pull/1139)


### PR DESCRIPTION
### Issue

There is a compilation error in the `test-and-upload-Linux` job of the "Build Pulsar binaries" workflow:

```
gyp info spawn args [ 'BUILDTYPE=Release', '-C', 'build' ]
make: Entering directory '/home/runner/work/pulsar/pulsar/node_modules/keyboard-layout/build'
  CXX(target) Release/obj.target/keyboard-layout-manager/src/keyboard-layout-manager.o
In file included from ../src/keyboard-layout-manager.cc:1:
../src/keyboard-layout-manager.h:7:10: fatal error: X11/Xlib.h: No such file or directory
    7 | #include <X11/Xlib.h>
      |          ^~~~~~~~~~~~
compilation terminated.
make: *** [keyboard-layout-manager.target.mk:116: Release/obj.target/keyboard-layout-manager/src/keyboard-layout-manager.o] Error 1
make: Leaving directory '/home/runner/work/pulsar/pulsar/node_modules/keyboard-layout/build'
gyp ERR! build error 
```

(Thank you to @savetheclocktower for noticing and reporting this!!)

### Context

Some of these dependencies presumably have been removed or changed in the recent "ubuntu-latest means Ubuntu 24.04" change.

See this tracking issue about the runner migration for details, maybe: github[dot]com/actions/runner-images/issues/10636

### Fix

Add the same various `apt` dependencies to the `upload-and-test-Linux` job as we install in the main "Build binaries" job on Linux, for this workflow.

### Verification Process

Kinda need to see the "Build pulsar binaries" CI job pass to the point of the `test-and-upload-Linux` job running (and hopefully, passing).