### PR TITLE
[core] Expose `dbPromise` in `StateStore`

### DIFF
--- a/spec/state-store-spec.js
+++ b/spec/state-store-spec.js
@@ -50,6 +50,12 @@ describe('StateStore', () => {
         });
     });
 
+    it('returns a database instance via dbPromise', async () => {
+      const store = new StateStore(databaseName, version);
+      const instance = await store.dbPromise;
+      expect(instance instanceof IDBDatabase).toBe(true);
+    });
+
     describe('when there is an error reading from the database', () => {
       it('rejects the promise returned by load', () => {
         const store = new StateStore(databaseName, version);
@@ -118,6 +124,13 @@ describe('StateStore', () => {
         .then(count => {
           expect(count).toBe(0);
         });
+    });
+
+    it('returns a database instance via dbPromise', async () => {
+      const store = new StateStore(databaseName, version);
+      const instance = await store.dbPromise;
+      const Database = require("better-sqlite3");
+      expect(instance instanceof Database).toBe(true);
     });
   });
 });

--- a/src/state-store.js
+++ b/src/state-store.js
@@ -46,7 +46,7 @@ module.exports = class StateStore {
 
   get dbPromise() {
     // Exposed due to usage in [`project-plus`](https://web.pulsar-edit.dev/packages/project-plus)
-    return this._getCorrectImplementation().then(i => i.dbPromise());
+    return this._getCorrectImplementation().then(i => i.dbPromise);
   }
 
   _getCorrectImplementation() {

--- a/src/state-store.js
+++ b/src/state-store.js
@@ -44,6 +44,11 @@ module.exports = class StateStore {
     return this._getCorrectImplementation().then(i => i.count());
   }
 
+  get dbPromise() {
+    // Exposed due to usage in [`project-plus`](https://web.pulsar-edit.dev/packages/project-plus)
+    return this._getCorrectImplementation().then(i => i.dbPromise());
+  }
+
   _getCorrectImplementation() {
     return awaitForAtomGlobal().then(() => {
       if(atom.config.get('core.useLegacySessionStore')) {


### PR DESCRIPTION
The getter method of `dbPromise` within `StateStore` is relied on by the community package [`project-plus`](https://web.pulsar-edit.dev/packages/project-plus), but with the release of Pulsar `v1.122.0` and specifically the introduction of the new StateStore database in #917 that method has been hidden away within each database's own code. 

But because both database's still have this method, it seems entirely possible we could just expose this the same way we expose their other methods.

Closes #1169 