### PR TITLE
electron-builder: Disable .zip build target on macOS

### DIFF
--- a/script/electron-builder.js
+++ b/script/electron-builder.js
@@ -197,6 +197,9 @@ let options = {
         { "CFBundleURLName": "Atom Shared Session Protocol" }
       ]
     },
+    "target": [
+      { "target": "dmg" }
+    ],
   },
   "dmg": {
     "sign": false,


### PR DESCRIPTION
### Background context

The macOS .zip build target for electron-builder is very computationally intensive (seemingly due to heavy use of 7-zip?) and timing out for us in CI...

### Solution

So... disable the .zip build target on macOS entirely.

Note: The `.dmg` and `.zip` targets are the default targets enabled by electron-builder on macOS. (See: https://www.electron.build/cli#target again to confirm.) So, by explicitly specifying only the `.dmg` target, we can effectively disable the `.zip` target in that way.

### Verification process

On my local macOS machine, I did a clean `yarn install && yarn build && yarn build:apm && yarn dist` run (key part being the `yarn dist`), and the only binary produced was the `.dmg`. The `.zip` target was not built, confirming that the change had the intended effect.

May observe CI to further confirm it does not build the `.zip` build target. UPDATE: Worked as intended, only the `.dmg` was made, not the `.zip`. Logs show this, and furthermore, the "macos-13 Binaries.zip" CI asset only contained a `.dmg` not a `.zip`.

### Potential downsides

Might want to look into the various third-party not-maintained-by-us things (Homebrew?) that might possibly rely on the macOS `.zip` build target and give them a heads-up about this. Or... see alternative approaches:

### Alternative approaches / Potential ToDo

We could make our own `.zip` of the `Pulsar.app` fairly easily, I suppose. I have not done so at this time, so as to make the CI fix available for review as fast as I could. But it wouldn't be too hard to figure out how to zip the `.app` locally, and then write the equivalent steps into the "build pulsar binaries" GitHub Actions workflow file?

May need to bug GitHub Actions Runners team with  bug report as well, as this really shouldn't be timing out (stalling, flaking) IMO, and it didn't used to.