### PR TITLE
CI: Retry on timeout when building macOS bins

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -142,7 +142,7 @@ jobs:
         TEAM_ID: ${{ secrets.TEAM_ID }}
       uses: nick-fields/retry@7152eba30c6575329ac0576536151aca5a72780e
       with:
-        timeout_minutes: 37
+        timeout_minutes: 31
         max_attempts: 7
         command: yarn dist
 
@@ -150,7 +150,7 @@ jobs:
       if: ${{ runner.os == 'macOS' && github.event_name != 'push' }}
       uses: nick-fields/retry@7152eba30c6575329ac0576536151aca5a72780e
       with:
-        timeout_minutes: 37
+        timeout_minutes: 31
         max_attempts: 7
         command: yarn dist
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -142,18 +142,16 @@ jobs:
         TEAM_ID: ${{ secrets.TEAM_ID }}
       uses: nick-fields/retry@7152eba30c6575329ac0576536151aca5a72780e
       with:
-        timeout_minutes: 45
-        max_attempts: 3
-        retry_on: error
+        timeout_minutes: 37
+        max_attempts: 7
         command: yarn dist
 
     - name: Build Pulsar Binaries (macOS) (Unsigned)
       if: ${{ runner.os == 'macOS' && github.event_name != 'push' }}
       uses: nick-fields/retry@7152eba30c6575329ac0576536151aca5a72780e
       with:
-        timeout_minutes: 45
-        max_attempts: 3
-        retry_on: error
+        timeout_minutes: 37
+        max_attempts: 7
         command: yarn dist
 
     - name: Build Pulsar Binaries


### PR DESCRIPTION
CI: Retry on timeout when building macOS bins

(To be clear: The most important part of this PR is removing `retry_on: error` so that we get the default "retry on either error _or_ timeout" behavior -- **we anticipate timeouts due to the particular kind of CI flakiness we are seeing here, on macOS. So we definitely need to retry on timeouts**, unless that flake can be tracked down and extinguished, which I would gladly do if I knew how at the moment... But for now. Retrying on timeouts.)

Hence this PR's title is the most important change: **This PR allows us to retry on timed out (flaky/hung) `electron-builder` runs.**

Also, adjust the timeout duration to be shorter, and adjust the number of retries to be greater.

I figure successful runs usually succeed quickly (~27 minutes or less?). So, get to the retrying faster! But also, let's actually retry, a bunch more times if we have to!

~~[Testing testing, this is a draft to put CI through it's paces, to try and see if this is the right approach. Should be run at busy times of day, such as toward the end of a typical working day in the Americas time zones.]~~

UPDATE: Looks like it's working! The amount of time it takes is now highly variable, up to about 2.5 hours or more, but it is reliably passing so far. In the best-case scenario, it is still possible for it to succeed first-attempt, so this is not a regression from the status quo, it is a more useful response to a CI flakiness than the status quo, IMO.