### PR TITLE
Package `tabs`: disable view if clientX or clientY is negative

### DIFF
--- a/packages/tabs/lib/layout.js
+++ b/packages/tabs/lib/layout.js
@@ -14,6 +14,10 @@ module.exports = {
   test: {},
 
   drag (e) {
+    if (e.clientX<0 || e.clientY<0) {
+      this.disableView()
+      return
+    }
     this.lastCoords = e
     const pane = this.getPaneAt(e)
     const itemView = this.getItemViewAt(e)


### PR DESCRIPTION
I'm the author of the [pdf-viewer](https://web.pulsar-edit.dev/packages/pdf-viewer) package. After switching to PulsarNext a strange exception appears. 

Steps to reproduce:
1. open .pdf file in pdf-viewer
2. drag tab over right edge of Pulsar
3. exception occurs because "closest is not a function of undefined".

I have been investigating this a bit and have discovered something strange. Sometimes `clientX` and `clientY` of the drag event are negative, so `document.elementFromPoint` cannot find an element and returns undefined. In Pulsar (old) I never noticed this and the above statement does not throw an exception. Suggested solution has solved the problem, but I'm not sure if it's optimal. Perhaps a better solution would be to diagnose and solve the problem of why clientX and clientY take negative values.