### PR TITLE
[line-ending-selector] Fix status-bar if empty

### DIFF
--- a/packages/line-ending-selector/lib/status-bar-item.js
+++ b/packages/line-ending-selector/lib/status-bar-item.js
@@ -11,7 +11,7 @@ module.exports = class StatusBarItem {
   setLineEndings(lineEndings) {
     this.lineEndings = lineEndings;
     this.element.textContent = lineEndingName(lineEndings);
-    this.element.style.display = lineEndingblockStyle(lineEndings);
+    this.element.style.display = lineEndingBlockStyle(lineEndings);
     this.emitter.emit('did-change');
   }
 

--- a/packages/line-ending-selector/lib/status-bar-item.js
+++ b/packages/line-ending-selector/lib/status-bar-item.js
@@ -57,7 +57,7 @@ function lineEndingDescription(lineEndings) {
   }
 }
 
-function lineEndingblockStyle(lineEndings) {
+function lineEndingBlockStyle(lineEndings) {
   switch (lineEndingName(lineEndings)) {
     case '':
       return 'none';

--- a/packages/line-ending-selector/lib/status-bar-item.js
+++ b/packages/line-ending-selector/lib/status-bar-item.js
@@ -11,6 +11,7 @@ module.exports = class StatusBarItem {
   setLineEndings(lineEndings) {
     this.lineEndings = lineEndings;
     this.element.textContent = lineEndingName(lineEndings);
+    this.element.style.display = lineEndingblockStyle(lineEndings);
     this.emitter.emit('did-change');
   }
 
@@ -53,5 +54,14 @@ function lineEndingDescription(lineEndings) {
       return 'CRLF (Windows)';
     default:
       return 'unknown';
+  }
+}
+
+function lineEndingblockStyle(lineEndings) {
+  switch (lineEndingName(lineEndings)) {
+    case '':
+      return 'none';
+    default:
+      return 'inline-block';
   }
 }


### PR DESCRIPTION
If text-editor is not the active item, the status bar item is set to blank text, but the item is still displayed. The fix add switch to change block display style to `none' when empty text is set.

![image](https://github.com/user-attachments/assets/6baef653-7417-4709-a2da-f5c75f32bafb)
