### PR TITLE
[core] Windows: Only remove Pulsar/PPM from PATH during uninstall

### DIFF
--- a/resources/win/installer.nsh
+++ b/resources/win/installer.nsh
@@ -10,8 +10,13 @@ XPStyle on
 !macro customUnInstall ; Macro called by electron-builder
   ; Since adding the PATH occurs during installation, we want to ensure to remove it.
   ; Luckily 'EnvVarUpdate' handles the case of it not being present
-  ${un.EnvVarUpdate} $0 "PATH" "R" "HKCU" "$INSTDIR\resources"
-  ${un.EnvVarUpdate} $0 "PATH" "R" "HKCU" "$INSTDIR\resources\app\ppm\bin"
+  ${ifNot} ${isUpdated}
+    ; Only run uninstall steps if truly uninstalling. Prevents this step from
+    ; running during an upgrade, where it technically runs after the upgrade's
+    ; install steps, ultimately removing Pulsar from the PATH
+    ${un.EnvVarUpdate} $0 "PATH" "R" "HKCU" "$INSTDIR\resources"
+    ${un.EnvVarUpdate} $0 "PATH" "R" "HKCU" "$INSTDIR\resources\app\ppm\bin"
+  ${endIf}
 !macroend
 
 !macro MUI_PAGE_ADD_TO_PATH ; Define our custom macro


### PR DESCRIPTION
Fixes #1157 

When I originally wrote the section of our NSIS that removes Pulsar from the PATH during uninstallation, I was aware that this code would also be run during an upgrade, since the upgrade process uninstalls the old version then installs the new.
But I was under the impression that those steps were linear, running uninstallation steps then running installation steps.

But it seems that isn't the case. Meaning that even though the installation steps would add items to the PATH, our custom uninstallation steps were run afterwards, ultimately removing Pulsar/PPM from the PATH.

Luckily, `electron-builder` makes it easy to check if we are running an upgrade rather than a full uninstall. Meaning we can check how we are running, and only remove items from the PATH during a complete uninstall.