### PR TITLE
[pulsar-updater] Don't prompt to update on non-default release channels

### DIFF
--- a/packages/pulsar-updater/README.md
+++ b/packages/pulsar-updater/README.md
@@ -30,7 +30,7 @@ Since a major part of the functionality of this package is attempting to determi
 * Universal: Developer Mode
 * Universal: Safe Mode
 * Universal: Spec Mode
-* Universal: Developer Instance
+* Universal: Custom Release Channel
 * Windows: Chocolatey Installation
 * Windows: winget Installation
 * Windows: User Installation

--- a/packages/pulsar-updater/spec/find-install-method-spec.js
+++ b/packages/pulsar-updater/spec/find-install-method-spec.js
@@ -5,13 +5,13 @@ describe("find-install-method main", async () => {
   const platform = process.platform;
   const arch = process.arch;
 
-  it("Returns developer instance if applicable", async () => {
+  it("Returns custom release channel if applicable", async () => {
     // We can't mock the atom api return from a package,
     // So we will just know that if tests are running, it's in the Atom SpecMode
 
     let method = await findInstallMethod();
 
-    expect(method.installMethod).toBe("Developer Instance");
+    expect(method.installMethod).toBe("Custom Release Channel");
     expect(method.platform).toBe(platform);
     expect(method.arch).toBe(arch);
   });

--- a/packages/pulsar-updater/src/find-install-method.js
+++ b/packages/pulsar-updater/src/find-install-method.js
@@ -77,11 +77,14 @@ async function main() {
     returnValue = "Spec Mode";
   }
 
-  if (atom.getVersion().endsWith("-dev")) {
+  if (atom.getReleaseChannel() !== 'stable') {
     // This would only be the case if
-    // 1. `yarn start` was used by a developer
-    // 2. Someone built a local binary without removing `-dev` from the version
-    returnValue = "Developer Instance";
+    //
+    // * `yarn start` was used by a developer,
+    // * someone built a local binary without removing `-dev` from the version,
+    //   or
+    // * someone was using a preview build of PulsarNext.
+    returnValue = 'Custom Release Channel';
   }
 
   if (returnValue.length > 0) {

--- a/packages/pulsar-updater/src/main.js
+++ b/packages/pulsar-updater/src/main.js
@@ -162,13 +162,10 @@ class PulsarUpdater {
         break;
       case "Safe Mode":
         return null;
-        break;
       case "Spec Mode":
         return null;
-        break;
-      case "Developer Instance":
+      case "Custom Release Channel":
         return null;
-        break;
       case "Flatpak Installation":
         returnText += "Install the latest version by running `flatpak update`.";
         break;


### PR DESCRIPTION
For PulsarNext I had tied myself in knots trying to guarantee that Pulsar would always know which release channel it was running in — e.g., that PulsarNext would never try to use `~/.pulsar` as `ATOM_HOME`, and Pulsar would never think that `ppm-next` was the binary it should run to find out which packages the user had installed.

I should've done the simplest thing first and leaned into the release channel infrastructure that was already in place from the Atom days. If your version number ends in `-foo`, then you're in the `-foo` release channel. So the version `1.124.12345678-next` is recognized as belonging to the `next` release channel, and the existing `atom.getReleaseChannel()` method makes this easy to inspect from anywhere in the core or in package code.

But once I did this and rebuilt PulsarNext, `pulsar-updater` pushed me to upgrade! That's because it only checked for the `-dev` string at the end of the version, rather than any non-standard release channels.

The default return value is `stable` — that's the release channel you'll receive when the version number is something like `1.124.0` and you call `atom.getReleaseChannel()`. So that's the change I made. It should work equally well in the `-dev` case, since that makes Pulsar think we're in a release channel called `dev`.