### PR TITLE
CI: No dpkg shenanigans for package tests workflow

### DIFF
--- a/.github/workflows/package-tests-linux.yml
+++ b/.github/workflows/package-tests-linux.yml
@@ -194,7 +194,7 @@ jobs:
         key: pulsar-${{ github.sha }}
 
     - name: Install Pulsar
-      run: sudo dpkg -i pulsar.deb && sudo apt-get -f install -y
+      run: sudo apt-get install ./pulsar.deb
 
     - name: Install xvfb
       run: sudo apt-get install -y xvfb


### PR DESCRIPTION
CI: No dpkg shenanigans for package tests workflow

Seems unreliable and not the right tool when we have apt-get.

Also, our "package tests" CI recently stopped working with an error
about broken/unsatisfiable package dependencies. This fixes it.

---

For those who are curious...

Passing (older image) details:

> Image: ubuntu-20.04
> Version: 20241215.1.0
> Included Software: https://github.com/actions/runner-images/blob/ubuntu20/20241215.1/images/ubuntu/Ubuntu2004-Readme.md
> Image Release: https://github.com/actions/runner-images/releases/tag/ubuntu20%2F20241215.1

Vs failing (newer image) details:

> Image: ubuntu-20.04
> Version: 20250105.1.0
> Included Software: https://github.com/actions/runner-images/blob/ubuntu20/20250105.1/images/ubuntu/Ubuntu2004-Readme.md
> Image Release: https://github.com/actions/runner-images/releases/tag/ubuntu20%2F20250105.1

(But now the tests pass even on the newer runner image, as of this fix.)