### PR TITLE
[Experimental] Add `atom.textEditors.add` to TE constructor

### DIFF
--- a/src/text-editor.js
+++ b/src/text-editor.js
@@ -314,6 +314,10 @@ module.exports = class TextEditor {
       priority: 0,
       visible: params.lineNumberGutterVisible
     });
+
+    if (atom & atom.textEditors) {
+      this.disposables.add(atom.textEditors.add(this))
+    }
   }
 
   get element() {

--- a/src/workspace.js
+++ b/src/workspace.js
@@ -609,7 +609,6 @@ module.exports = class Workspace extends Model {
     this.onDidAddPaneItem(({ item, pane, index }) => {
       if (item instanceof TextEditor) {
         const subscriptions = new CompositeDisposable(
-          this.textEditorRegistry.add(item),
           this.textEditorRegistry.maintainConfig(item)
         );
         if (!this.project.findBufferForId(item.buffer.id)) {


### PR DESCRIPTION
# Problem

Hi, I want make a package that works with mini text-editors of find-and-replace package (and others mini text-editors). The problem is that mini text-editors are not a part of workspace, so atom.workspace.getActiveTextEditor() doesn't work. A package doesn't register it to `atom.textEditors` too. A mini text-editors can be added to `atom.textEditors` by hand , but no one use it, built-in packages included.

# Alternatives

I'm using a little hacky method to do it by now, but It has many cons, e.g. I cannot detect mini text-editor before user send event to it, cannot observe it etc.

```js
function getEditor(event) {
    const element = event.target.closest('atom-text-editor')
    if (!element) { return }
    const editor = element.getModel()
    if (!editor) { return }
    return editor
}
```