### PR TITLE
Attempt to install dependency on new Ubuntu CI images

### DIFF
--- a/.github/workflows/validate-wasm-grammar-prs.yml
+++ b/.github/workflows/validate-wasm-grammar-prs.yml
@@ -5,8 +5,8 @@ name: Validate WASM Grammar PR Changes
 
 on:
   pull_request:
-    # paths:
-    #   - '**.wasm'
+    paths:
+      - '**.wasm'
 
 jobs:
   validate:

--- a/.github/workflows/validate-wasm-grammar-prs.yml
+++ b/.github/workflows/validate-wasm-grammar-prs.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Install build dependencies
-      run: apt-get update && apt-get install -y libx11-dev
+      run: sudo apt-get update && sudo apt-get install -y libx11-dev
     - name: Checkout the Latest Code
       uses: actions/checkout@v4
       with:

--- a/.github/workflows/validate-wasm-grammar-prs.yml
+++ b/.github/workflows/validate-wasm-grammar-prs.yml
@@ -14,7 +14,6 @@ jobs:
     steps:
     - name: Install build dependencies
       run: apt-get update && apt-get install -y git python3 python3-pip make gcc g++ libx11-dev libxkbfile-dev pkg-config libsecret-1-dev
-      run: sudo apt-get update && sudo apt-get install -y libx11-dev
     - name: Checkout the Latest Code
       uses: actions/checkout@v4
       with:

--- a/.github/workflows/validate-wasm-grammar-prs.yml
+++ b/.github/workflows/validate-wasm-grammar-prs.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Install build dependencies
-      run: apt-get update && apt-get install -y git python3 python3-pip make gcc g++ libx11-dev libxkbfile-dev pkg-config libsecret-1-dev
+      run: sudo apt-get update && sudo apt-get install -y git python3 python3-pip make gcc g++ libx11-dev libxkbfile-dev pkg-config libsecret-1-dev
     - name: Checkout the Latest Code
       uses: actions/checkout@v4
       with:

--- a/.github/workflows/validate-wasm-grammar-prs.yml
+++ b/.github/workflows/validate-wasm-grammar-prs.yml
@@ -13,6 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Install build dependencies
+      run: apt-get update && apt-get install -y git python3 python3-pip make gcc g++ libx11-dev libxkbfile-dev pkg-config libsecret-1-dev
       run: sudo apt-get update && sudo apt-get install -y libx11-dev
     - name: Checkout the Latest Code
       uses: actions/checkout@v4

--- a/.github/workflows/validate-wasm-grammar-prs.yml
+++ b/.github/workflows/validate-wasm-grammar-prs.yml
@@ -5,8 +5,8 @@ name: Validate WASM Grammar PR Changes
 
 on:
   pull_request:
-    paths:
-      - '**.wasm'
+    # paths:
+    #   - '**.wasm'
 
 jobs:
   validate:

--- a/.github/workflows/validate-wasm-grammar-prs.yml
+++ b/.github/workflows/validate-wasm-grammar-prs.yml
@@ -12,6 +12,8 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
+    - name: Install build dependencies
+      run: apt-get update && apt-get install -y libx11-dev
     - name: Checkout the Latest Code
       uses: actions/checkout@v4
       with:


### PR DESCRIPTION
Some CI jobs are complaining about X11…

```
make: Entering directory '/home/runner/work/pulsar/pulsar/node_modules/keyboard-layout/build'
  CXX(target) Release/obj.target/keyboard-layout-manager/src/keyboard-layout-manager.o
In file included from ../src/keyboard-layout-manager.cc:1:
../src/keyboard-layout-manager.h:7:10: fatal error: X11/Xlib.h: No such file or directory
    7 | #include <X11/Xlib.h>
      |          ^~~~~~~~~~~~
compilation terminated.
```

…so let's make sure it's installed.

Hoping it's just this easy!