### PR TITLE
Install dependencies for CI documentation job

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -19,6 +19,9 @@ jobs:
         node-version: [16.x]
 
     steps:
+    - name: Install build dependencies
+      run: sudo apt-get update && sudo apt-get install -y git python3 python3-pip make gcc g++ libx11-dev libxkbfile-dev pkg-config libsecret-1-dev
+
     - name: Checkout the Latest Code
       uses: actions/checkout@v4
 


### PR DESCRIPTION
This applies the same fix to the “documentation” job that I did for #1192. (Should've done both in the same PR!)

I could uncomment the constraint on the job to prove it passes, but the fact that we proved this fixed the job in #1192 should probably be enough.