### PR TITLE
[tree-view] Use common comparator function by sort methods

### DIFF
--- a/packages/tree-view/lib/directory.js
+++ b/packages/tree-view/lib/directory.js
@@ -301,7 +301,7 @@ class Directory {
     } catch (error) {
       names = []
     }
-    names.sort(new Intl.Collator(undefined, {numeric: true, sensitivity: 'base'}).compare)
+    names.sort(this.compareEntries)
 
     const files = []
     const directories = []
@@ -352,16 +352,12 @@ class Directory {
     return this.sortEntries(directories.concat(files))
   }
 
-  normalizeEntryName(value) {
-    let normalizedValue = value.name
-    if (normalizedValue == null) {
-      normalizedValue = value
-    }
+  compareEntries(firstName, secondName) {
+    return compareFn(firstName, secondName)
+  }
 
-    if (normalizedValue != null) {
-      normalizedValue = normalizedValue.toLowerCase()
-    }
-    return normalizedValue
+  normalizeEntryName(value) {
+    return value.name ? value.name : value
   }
 
   sortEntries(combinedEntries) {
@@ -371,7 +367,7 @@ class Directory {
       return combinedEntries.sort((first, second) => {
         const firstName = this.normalizeEntryName(first)
         const secondName = this.normalizeEntryName(second)
-        return firstName.localeCompare(secondName)
+        return this.compareEntries(firstName, secondName)
       })
     }
   }
@@ -478,3 +474,5 @@ class Directory {
     return this.path === dirname || this.realPath === dirname
   }
 }
+
+const compareFn = new Intl.Collator(undefined, {numeric: true, sensitivity: 'base'}).compare


### PR DESCRIPTION
The sorting methods of `getEntries` and `sortEntries` have used a different approach. Now:
- They use the same approach, 
- `Intl.Collator` is created once instead of every `getEntries` call.
- `normalizeEntryName` is simplified.