### PR TITLE
[image-view] Add scroll support to zoom-in and zoom-out

### DIFF
--- a/packages/image-view/spec/image-editor-view-spec.js
+++ b/packages/image-view/spec/image-editor-view-spec.js
@@ -101,13 +101,6 @@ describe('ImageEditorView', () => {
     })
   })
 
-  describe('.adjustSize(factor)', () => {
-    it('does not allow a zoom percentage lower than 10%', () => {
-      view.adjustSize(0)
-      expect(view.refs.resetZoomButton.textContent).toBe('10%')
-    })
-  })
-
   describe('when special characters are used in the file name', () => {
     describe("when '?' exists in the file name", () => {
       it('is replaced with %3F', () => {

--- a/packages/image-view/styles/image-view.less
+++ b/packages/image-view/styles/image-view.less
@@ -61,12 +61,6 @@
     .reset-zoom-button {
       min-width: 5em;
     }
-
-    // disabled once the button is selected
-    .zoom-to-fit-button.selected {
-      pointer-events: none;
-      cursor: default;
-    }
   }
 
 
@@ -78,7 +72,7 @@
     overflow: auto;
 
     img {
-      display: block !important;
+      display: block;
       flex: none;
       margin: auto;
     }
@@ -92,27 +86,6 @@
   [background="black"] {
     background-color: black;
     background-image: url(@transparent-background-image);
-  }
-
-
-
-  // Zoom to fit -------------------
-  // Scales the image to fit the available space.
-
-  .zoom-to-fit {
-    &.image-container {
-      padding: @component-padding;
-
-      img {
-        flex: 1 1 0;
-        min-width: 0;
-        margin: 0;
-
-        // Alternative: object-fit: contain;
-        // then it would also scale larger than its original size
-        object-fit: scale-down;
-      }
-    }
   }
 
 }


### PR DESCRIPTION
It's natural to zoom-in and zoom-out images by `Ctrl-Scroll`. It was required to change how `zoom-to-fit` works.