### PR TITLE
Remove `core.allowWindowTransparency` from the config schema…

### DIFF
--- a/src/config-schema.js
+++ b/src/config-schema.js
@@ -410,12 +410,6 @@ const configSchema = {
         description: 'When changing the theme within Pulsar also change the theme of the window on the operating system.',
         type: 'boolean',
         default: false
-      },
-      allowWindowTransparency: {
-        type: 'boolean',
-        default: false,
-        title: 'Allow Window Transparency',
-        description: `Allows editor windows to be see-through. When this setting is enabled, UI themes and user stylesheets can use background colors with an alpha channel to make editor windows translucent. Takes effect after a restart of Pulsar.`
       }
     }
   },

--- a/src/main-process/atom-window.js
+++ b/src/main-process/atom-window.js
@@ -80,7 +80,13 @@ module.exports = class AtomWindow extends EventEmitter {
       options.titleBarStyle = 'hiddenInset';
     if (this.shouldHideTitleBar()) options.frame = false;
 
-    if(this.atomApplication.config.get('core.allowWindowTransparency')){
+    // Enabling window transparency creates several downstream issues relating
+    // to management of window size and maximixed state.
+    //
+    // Hence this option was removed from the config schema because it's a
+    // footgun, but we've left it in for those users who really know what
+    // they're doing.
+    if (this.atomApplication.config.get('core.allowWindowTransparency')){
       options.transparent = true;
     }
 


### PR DESCRIPTION
…so that it's not listed among the core settings in `settings-view`.

We'll leave the feature in, but users will have to opt into it by editing their `config.cson` or setting it via the dev tools console. This means the setting will remain at its current value for anyone who upgrades.

This is a half-baked setting that leads to bad experiences for new Pulsar users. It can stay in for power users who've figured out how to mitigate the bad side effects.

Fixes #1046. (At least as well as we can fix it, short of removing the setting altogether.)