### PR TITLE
Tree-sitter fixes, 1.126.0 edition

### DIFF
--- a/packages/language-php/grammars/tree-sitter/queries/folds.scm
+++ b/packages/language-php/grammars/tree-sitter/queries/folds.scm
@@ -8,4 +8,5 @@
   (compound_statement)
   (switch_block)
   (declaration_list)
+  (array_creation_expression)
 ] @fold


### PR DESCRIPTION
We might've actually had a month without a Tree-sitter fixes PR… until someone noticed that we don't fold on PHP array literals! The streak continues.