### PR TITLE
Fix hydrogen plots e.g. plotly, altair

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-  <meta http-equiv="Content-Security-Policy" content="default-src * atom://*; img-src blob: data: * atom://*; script-src 'self' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; media-src blob: data: mediastream: * atom://*;">
+  <meta http-equiv="Content-Security-Policy" content="default-src * atom://*; img-src blob: data: * atom://*; script-src * 'unsafe-eval' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; media-src blob: data: mediastream: * atom://*;">
   <script src="index.js"></script>
 </head>
 <body tabindex="-1">


### PR DESCRIPTION
The Content Security Policy block `hydrogen-next` interactive elements generated by e.g. `plotly`, `altair`. It's old issue inherited from old days of `hydrogen` https://github.com/nteract/hydrogen/issues/1896#issuecomment-600388705.

![image](https://github.com/user-attachments/assets/491b3e02-7ce3-45ea-9940-1673b999b5ec)

Reproduce steps:
1. Install `hydrogen` or `hydrogen-next`
2. Install Python, IPython & kernel
3. Create Python file
4. Paste example code
    ```python
    import altair as alt
    import numpy as np
    import pandas as pd
    
    x = np.arange(100)
    source = pd.DataFrame({
      'x': x,
      'f(x)': np.sin(x / 5)
    })
    
    alt.Chart(source).mark_line().encode(
        x='x',
        y='f(x)'
    )
    ```
5. Start kernel & run all

Tested in dev build.