### PR TITLE
[find-and-replace] Fix some bugs in the spec suite

### DIFF
--- a/packages/find-and-replace/lib/project/results-pane.js
+++ b/packages/find-and-replace/lib/project/results-pane.js
@@ -73,8 +73,9 @@ class ResultsPaneView {
   destroy() {
     this.model.setActive(false);
     this.subscriptions.dispose();
-    if(this.separatePane)
+    if (this.separatePane) {
       this.model = null;
+    }
   }
 
   render() {
@@ -115,7 +116,7 @@ class ResultsPaneView {
                 $.button(
                   {
                     ref: 'decrementLeadingContextLines',
-                    className: 'btn' + (this.model.getFindOptions().leadingContextLineCount === 0 ? ' disabled' : '')
+                    className: 'btn' + (this.model && this.model.getFindOptions().leadingContextLineCount === 0 ? ' disabled' : '')
                   }, '-'),
                 $.button(
                   {
@@ -132,7 +133,7 @@ class ResultsPaneView {
                 $.button(
                   {
                     ref: 'incrementLeadingContextLines',
-                    className: 'btn' + (this.model.getFindOptions().leadingContextLineCount >= this.searchContextLineCountBefore ? ' disabled' : '')
+                    className: 'btn' + (this.model && this.model.getFindOptions().leadingContextLineCount >= this.searchContextLineCountBefore ? ' disabled' : '')
                   }, '+')
               ) : null,
 
@@ -141,7 +142,7 @@ class ResultsPaneView {
                 $.button(
                   {
                     ref: 'decrementTrailingContextLines',
-                    className: 'btn' + (this.model.getFindOptions().trailingContextLineCount === 0 ? ' disabled' : '')
+                    className: 'btn' + (this.model && this.model.getFindOptions().trailingContextLineCount === 0 ? ' disabled' : '')
                   }, '-'),
                 $.button(
                   {
@@ -352,10 +353,10 @@ class ResultsPaneView {
     this.uri = ResultsPaneView.URI + "/" + this.model.getLastFindPattern();
     this.refs.dontOverrideTab.classList.add('disabled');
 
-    view.modelSupbscriptions.dispose();
+    view.modelSubscriptions.dispose();
     view.handleEvents.addModelHandlers();
     view.handleEventsForReplace.addReplaceModelHandlers();
-    this.separatePane=true;
+    this.separatePane = true;
   }
 }
 

--- a/packages/find-and-replace/spec/.eslintrc.js
+++ b/packages/find-and-replace/spec/.eslintrc.js
@@ -1,0 +1,15 @@
+module.exports = {
+  env: { jasmine: true },
+  globals: {
+    waitsForPromise: true,
+    runGrammarTests: true,
+    runFoldsTests: true,
+    advanceClock: true
+  },
+  rules: {
+    "node/no-unpublished-require": "off",
+    "node/no-extraneous-require": "off",
+    "no-unused-vars": "off",
+    "no-empty": "off"
+  }
+};

--- a/packages/find-and-replace/spec/buffer-search-spec.js
+++ b/packages/find-and-replace/spec/buffer-search-spec.js
@@ -66,7 +66,7 @@ describe('BufferSearch', () => {
     return ranges
       .sort((a, b) => a.compare(b))
       .map(range => range.serialize());
-  };
+  }
 
   function expectUpdateEvent() {
     expect(markersListener.callCount).toBe(1);
@@ -75,7 +75,7 @@ describe('BufferSearch', () => {
       .map(marker => marker.getBufferRange().serialize());
     expect(emittedMarkerRanges).toEqual(getHighlightedRanges());
     markersListener.reset();
-  };
+  }
 
   function expectNoUpdateEvent() {
     expect(markersListener).not.toHaveBeenCalled();

--- a/packages/find-and-replace/spec/find-view-spec.js
+++ b/packages/find-and-replace/spec/find-view-spec.js
@@ -2,7 +2,7 @@
 
 const path = require("path");
 
-const { genPromiseToCheck } = require('./helpers')
+const { waitForCondition } = require('./helpers')
 
 describe("FindView", () => {
   let workspaceElement, editorView, editor, findView, activationPromise;
@@ -37,7 +37,7 @@ describe("FindView", () => {
     editor = atom.workspace.getCenter().getActiveTextEditor();
     editorView = editor.element;
 
-    activationPromise = atom.packages.activatePackage("find-and-replace").then(function({mainModule}) {
+    activationPromise = atom.packages.activatePackage("find-and-replace").then(function ({mainModule}) {
       mainModule.createViews();
       ({findView} = mainModule);
     });
@@ -277,7 +277,7 @@ describe("FindView", () => {
       findView.findNext(false);
 
       await atom.packages.deactivatePackage("find-and-replace");
-      activationPromise = atom.packages.activatePackage("find-and-replace").then(function({mainModule}) {
+      activationPromise = atom.packages.activatePackage("find-and-replace").then(function ({mainModule}) {
         mainModule.createViews();
         ({findView} = mainModule);
       });
@@ -315,7 +315,7 @@ describe("FindView", () => {
       expect(findView.refs.wholeWordOptionButton).toHaveClass("selected");
 
       await atom.packages.deactivatePackage("find-and-replace");
-      activationPromise = atom.packages.activatePackage("find-and-replace").then(function({mainModule}) {
+      activationPromise = atom.packages.activatePackage("find-and-replace").then(function ({mainModule}) {
         mainModule.createViews();
         ({findView} = mainModule);
       });
@@ -942,7 +942,7 @@ describe("FindView", () => {
         let openerDisposable;
 
         beforeEach(() => {
-          openerDisposable = atom.workspace.addOpener(function(pathToOpen, options) {
+          openerDisposable = atom.workspace.addOpener(function (pathToOpen, options) {
             return document.createElement("div");
           });
         });
@@ -1018,11 +1018,11 @@ describe("FindView", () => {
       it("re-runs the search", async () => {
         editor.setSelectedBufferRange([[1, 26], [1, 27]]);
         editor.insertText("");
-        await genPromiseToCheck(() => findView.refs.resultCounter.textContent.match(/5/))
+        await waitForCondition(() => findView.refs.resultCounter.textContent.match(/5/))
         expect(findView.refs.resultCounter.textContent).toEqual("5 found");
 
         editor.insertText("s");
-        await genPromiseToCheck(() => findView.refs.resultCounter.textContent.match(/6/))
+        await waitForCondition(() => findView.refs.resultCounter.textContent.match(/6/))
         expect(findView.refs.resultCounter.textContent).toEqual("6 found");
       });
 
@@ -1357,17 +1357,17 @@ describe("FindView", () => {
         expect(findView.refs.descriptionLabel.textContent).toContain("6 results");
 
         findView.findEditor.setText("");
-        await genPromiseToCheck(() => findView.refs.descriptionLabel.textContent.match(/Find in/))
+        await waitForCondition(() => findView.refs.descriptionLabel.textContent.match(/Find in/))
         expect(findView.refs.descriptionLabel.textContent).toContain("Find in Current Buffer");
         expect(findView.element).toHaveFocus();
 
         findView.findEditor.setText("sort");
-        await genPromiseToCheck(() => findView.refs.descriptionLabel.textContent.match(/5/))
+        await waitForCondition(() => findView.refs.descriptionLabel.textContent.match(/5/))
         expect(findView.refs.descriptionLabel.textContent).toContain("5 results");
         expect(findView.element).toHaveFocus();
 
         findView.findEditor.setText("items");
-        await genPromiseToCheck(() => findView.refs.descriptionLabel.textContent.match(/6/))
+        await waitForCondition(() => findView.refs.descriptionLabel.textContent.match(/6/))
         expect(findView.refs.descriptionLabel.textContent).toContain("6 results");
         expect(findView.element).toHaveFocus();
       });
@@ -1377,12 +1377,12 @@ describe("FindView", () => {
         atom.config.set("find-and-replace.liveSearchMinimumCharacters", 3);
 
         findView.findEditor.setText("");
-        await genPromiseToCheck(() => findView.refs.descriptionLabel.textContent.match(/Find in/))
+        await waitForCondition(() => findView.refs.descriptionLabel.textContent.match(/Find in/))
         expect(findView.refs.descriptionLabel.textContent).toContain("Find in Current Buffer");
         expect(findView.element).toHaveFocus();
 
         findView.findEditor.setText("ite");
-        await genPromiseToCheck(() => findView.refs.descriptionLabel.textContent.match(/6/))
+        await waitForCondition(() => findView.refs.descriptionLabel.textContent.match(/6/))
         expect(findView.refs.descriptionLabel.textContent).toContain("6 results");
         expect(findView.element).toHaveFocus();
 
@@ -1393,13 +1393,13 @@ describe("FindView", () => {
         expect(findView.element).toHaveFocus();
 
         findView.findEditor.setText("");
-        await genPromiseToCheck(() => findView.refs.descriptionLabel.textContent.match(/Find in/))
+        await waitForCondition(() => findView.refs.descriptionLabel.textContent.match(/Find in/))
         expect(findView.refs.descriptionLabel.textContent).toContain("Find in Current Buffer");
         expect(findView.element).toHaveFocus();
 
         atom.config.set("find-and-replace.liveSearchMinimumCharacters", 0);
         findView.findEditor.setText("i");
-        await genPromiseToCheck(() => findView.refs.descriptionLabel.textContent.match(/20/))
+        await waitForCondition(() => findView.refs.descriptionLabel.textContent.match(/20/))
         expect(findView.refs.descriptionLabel.textContent).toContain("20 results");
         expect(findView.element).toHaveFocus();
       });
@@ -1419,7 +1419,7 @@ describe("FindView", () => {
 
         atom.commands.dispatch(findView.findEditor.element, "find-and-replace:toggle-regex-option");
         findView.findEditor.setText("\\(.*)");
-        await genPromiseToCheck(() => findView.refs.descriptionLabel.textContent.match(/Invalid/));
+        await waitForCondition(() => findView.refs.descriptionLabel.textContent.match(/Invalid/));
         expect(findView.refs.descriptionLabel).toHaveClass("text-error");
         expect(findView.refs.descriptionLabel.textContent).toContain("Invalid regular expression");
       });
@@ -1738,11 +1738,11 @@ describe("FindView", () => {
           expect(findView.refs.descriptionLabel.textContent).toContain("1 result");
 
           findView.findEditor.setText("nope");
-          await genPromiseToCheck(() => findView.refs.descriptionLabel.textContent.match(/nope/))
+          await waitForCondition(() => findView.refs.descriptionLabel.textContent.match(/nope/))
           expect(findView.refs.descriptionLabel.textContent).toContain("nope");
 
           findView.findEditor.setText("zero");
-          await genPromiseToCheck(() => findView.refs.descriptionLabel.textContent.match(/zero/))
+          await waitForCondition(() => findView.refs.descriptionLabel.textContent.match(/zero/))
           expect(findView.refs.descriptionLabel.textContent).toContain("zero");
 
           atom.commands.dispatch(findView.findEditor.element, "core:move-up");

--- a/packages/find-and-replace/spec/helpers.js
+++ b/packages/find-and-replace/spec/helpers.js
@@ -1,9 +1,24 @@
-const genPromiseToCheck = fn => new Promise(resolve => {
-  const interval = setInterval(() => { if(fn()) resolve() }, 100)
-  setTimeout(() => {
-    resolve()
-    clearInterval(interval)
-  }, 4000)
-})
+function waitForCondition(fn) {
+  return new Promise((resolve, reject) => {
+    const interval = setInterval(() => {
+      if (fn()) {
+        requestAnimationFrame(resolve);
+        // resolve();
+        clearInterval(interval);
+        clearTimeout(timeout);
+      }
+    }, 100);
+    let timeout = setTimeout(() => {
+      requestAnimationFrame(() => {
+        reject(new Error(`Timeout waiting for condition`));
+      })
+      clearInterval(interval);
+    }, 4000);
+  });
+}
 
-module.exports = { genPromiseToCheck }
+async function wait(ms) {
+  return new Promise(r => setTimeout(r, ms));
+}
+
+module.exports = { waitForCondition, wait };

--- a/packages/find-and-replace/spec/helpers.js
+++ b/packages/find-and-replace/spec/helpers.js
@@ -2,16 +2,13 @@ function waitForCondition(fn) {
   return new Promise((resolve, reject) => {
     const interval = setInterval(() => {
       if (fn()) {
-        requestAnimationFrame(resolve);
-        // resolve();
+        resolve();
         clearInterval(interval);
         clearTimeout(timeout);
       }
     }, 100);
     let timeout = setTimeout(() => {
-      requestAnimationFrame(() => {
-        reject(new Error(`Timeout waiting for condition`));
-      })
+      reject(new Error(`Timeout waiting for condition`));
       clearInterval(interval);
     }, 4000);
   });

--- a/packages/find-and-replace/spec/project-find-view-spec.js
+++ b/packages/find-and-replace/spec/project-find-view-spec.js
@@ -773,6 +773,7 @@ describe(`ProjectFindView (ripgrep=${ripgrep})`, () => {
           await waitForCondition(() => {
             return (getResultsView()?.resultRows.length ?? 0) >= 13;
           });
+          await wait(2000);
 
           const resultsView = getResultsView();
           const resultsPaneView = getExistingResultsPane();

--- a/packages/find-and-replace/spec/project-find-view-spec.js
+++ b/packages/find-and-replace/spec/project-find-view-spec.js
@@ -7,7 +7,7 @@ const dedent = require('dedent');
 const {TextBuffer} = require('atom');
 const ResultsPaneView = require('../lib/project/results-pane');
 const etch = require('etch');
-const { genPromiseToCheck } = require('./helpers')
+const { waitForCondition, wait } = require('./helpers')
 
 for (const ripgrep of [false, true]) {
 describe(`ProjectFindView (ripgrep=${ripgrep})`, () => {
@@ -31,7 +31,7 @@ describe(`ProjectFindView (ripgrep=${ripgrep})`, () => {
   }
 
   function waitForSearchResults() {
-    return genPromiseToCheck(
+    return waitForCondition(
       () => projectFindView.refs.descriptionLabel.textContent.includes('results found')
     )
   }
@@ -46,7 +46,7 @@ describe(`ProjectFindView (ripgrep=${ripgrep})`, () => {
     atom.project.setPaths([path.join(__dirname,   'fixtures')]);
     jasmine.attachToDOM(workspaceElement);
 
-    activationPromise = atom.packages.activatePackage("find-and-replace").then(function({mainModule}) {
+    activationPromise = atom.packages.activatePackage("find-and-replace").then(function ({mainModule}) {
       mainModule.createViews();
       ({findView, projectFindView} = mainModule);
     });
@@ -57,9 +57,9 @@ describe(`ProjectFindView (ripgrep=${ripgrep})`, () => {
   })
 
   function resultsPromise() {
-    return genPromiseToCheck( () =>
-      getExistingResultsPane()?.refs?.resultsView?.refs?.resultsView
-    );
+    return waitForCondition(() => {
+      return getExistingResultsPane()?.refs?.resultsView
+    });
   }
 
   describe("when project-find:show is triggered", () => {
@@ -304,10 +304,10 @@ describe(`ProjectFindView (ripgrep=${ripgrep})`, () => {
           projectFindView.findEditor.setText('\\t');
 
           atom.commands.dispatch(projectFindView.element, 'core:confirm');
-          await resultsPromise();
+          await waitForSearchResults();
 
           const resultsView = getResultsView();
-          await genPromiseToCheck(() => resultsView.refs.listView.element.querySelector(".match-row") );
+          await waitForCondition(() => resultsView.refs.listView.element.querySelector(".match-row"));
           expect(resultsView.element).toBeVisible();
           expect(resultsView.refs.listView.element.querySelectorAll(".match-row")).toHaveLength(2);
         })
@@ -322,7 +322,7 @@ describe(`ProjectFindView (ripgrep=${ripgrep})`, () => {
 
           const resultsView = getResultsView();
           expect(resultsView.element).toBeVisible();
-          await genPromiseToCheck(() => resultsView.refs.listView.element.querySelector(".match-row") );
+          await waitForCondition(() => resultsView.refs.listView.element.querySelector(".match-row") );
           expect(resultsView.refs.listView.element.querySelectorAll(".match-row")).toHaveLength(1);
         });
 
@@ -334,7 +334,7 @@ describe(`ProjectFindView (ripgrep=${ripgrep})`, () => {
 
           const resultsView = getResultsView();
           expect(resultsView.element).toBeVisible();
-          await genPromiseToCheck(() => resultsView.refs.listView.element.querySelector(".match-row") );
+          await waitForCondition(() => resultsView.refs.listView.element.querySelector(".match-row") );
           expect(resultsView.refs.listView.element.querySelectorAll(".match-row")).toHaveLength(2);
           expect(resultsView.refs.listView.element.querySelectorAll(".match.highlight-info")).toHaveLength(3);
         });
@@ -346,7 +346,7 @@ describe(`ProjectFindView (ripgrep=${ripgrep})`, () => {
           await resultsPromise();
 
           const resultsView = getResultsView();
-          await genPromiseToCheck(() => resultsView.refs.listView.element.querySelector(".match-row") );
+          await waitForCondition(() => resultsView.refs.listView.element.querySelector(".match-row") );
           expect(resultsView.element).toBeVisible();
           expect(resultsView.refs.listView.element.querySelectorAll(".match-row")).toHaveLength(1);
         });
@@ -370,7 +370,7 @@ describe(`ProjectFindView (ripgrep=${ripgrep})`, () => {
       it("closes the panel after search", async () => {
         projectFindView.findEditor.setText('something');
         atom.commands.dispatch(projectFindView.element, 'core:confirm');
-        await resultsPromise();
+        await waitForSearchResults();
 
         expect(getAtomPanel()).not.toBeVisible();
       });
@@ -378,7 +378,7 @@ describe(`ProjectFindView (ripgrep=${ripgrep})`, () => {
       it("leaves the panel open after an empty search", async () => {
         projectFindView.findEditor.setText('');
         atom.commands.dispatch(projectFindView.element, 'core:confirm');
-        await resultsPromise();
+        await wait(500);
 
         expect(getAtomPanel()).toBeVisible();
       });
@@ -386,7 +386,8 @@ describe(`ProjectFindView (ripgrep=${ripgrep})`, () => {
       it("closes the panel after a no-op search", async () => {
         projectFindView.findEditor.setText('something');
         atom.commands.dispatch(projectFindView.element, 'core:confirm');
-        await resultsPromise();
+        await waitForSearchResults();
+        expect(getAtomPanel()).not.toBeVisible();
 
         atom.commands.dispatch(workspaceElement, 'project-find:show');
         await activationPromise;
@@ -394,7 +395,7 @@ describe(`ProjectFindView (ripgrep=${ripgrep})`, () => {
         expect(getAtomPanel()).toBeVisible();
 
         atom.commands.dispatch(projectFindView.element, 'core:confirm');
-        await resultsPromise();
+        await wait(500);
 
         expect(getAtomPanel()).not.toBeVisible();
       });
@@ -418,7 +419,7 @@ describe(`ProjectFindView (ripgrep=${ripgrep})`, () => {
         projectFindView.findEditor.setText('items');
 
         atom.commands.dispatch(projectFindView.element, 'core:confirm');
-        await resultsPromise();
+        await waitForSearchResults();
 
         expect(atom.workspace.getCenter().getActivePane()).not.toBe(initialPane);
       });
@@ -429,7 +430,7 @@ describe(`ProjectFindView (ripgrep=${ripgrep})`, () => {
         projectFindView.findEditor.setText('items');
 
         atom.commands.dispatch(projectFindView.element, 'core:confirm');
-        await resultsPromise();
+        await waitForSearchResults();
 
         expect(atom.workspace.getCenter().getActivePane()).not.toBe(initialPane);
       });
@@ -449,7 +450,7 @@ describe(`ProjectFindView (ripgrep=${ripgrep})`, () => {
         projectFindView.findEditor.setText('items');
 
         atom.commands.dispatch(projectFindView.element, 'core:confirm');
-        await genPromiseToCheck( () =>
+        await waitForCondition( () =>
           atom.workspace.getCenter().getActivePane().getItems()[0]?.refs?.resultsView
         );
 
@@ -465,7 +466,7 @@ describe(`ProjectFindView (ripgrep=${ripgrep})`, () => {
         expect(resultsPaneView1).not.toBe(resultsPaneView2);
         simulateResizeEvent(resultsView2.element);
 
-        await genPromiseToCheck(() => resultsView.refs.listView.element.querySelector(".match-row") );
+        await waitForCondition(() => resultsView1.refs.listView.element.querySelector(".match-row"));
         const resultCount = resultsPaneView1.querySelectorAll('.match-row').length;
         expect(resultCount).toBeGreaterThan(0);
         expect(resultsPaneView2.querySelectorAll('.match-row')).toHaveLength(resultCount);
@@ -477,7 +478,7 @@ describe(`ProjectFindView (ripgrep=${ripgrep})`, () => {
         projectFindView.findEditor.setText('items');
 
         atom.commands.dispatch(projectFindView.element, 'core:confirm');
-        await resultsPromise();
+        await waitForSearchResults();
 
         const resultsPaneView1 = atom.views.getView(getExistingResultsPane());
         const pane1 = atom.workspace.getCenter().getActivePane();
@@ -514,7 +515,7 @@ describe(`ProjectFindView (ripgrep=${ripgrep})`, () => {
 
         await atom.packages.deactivatePackage("find-and-replace");
 
-        activationPromise = atom.packages.activatePackage("find-and-replace").then(function({mainModule}) {
+        activationPromise = atom.packages.activatePackage("find-and-replace").then(function ({mainModule}) {
           mainModule.createViews();
           return {projectFindView} = mainModule;
         });
@@ -541,7 +542,7 @@ describe(`ProjectFindView (ripgrep=${ripgrep})`, () => {
 
         expect(projectFindView.refs.descriptionLabel.textContent).toContain('Searching...');
 
-        await resultsPromise();
+        await waitForSearchResults();
 
         expect(projectFindView.refs.descriptionLabel.textContent).toContain('13 results found in 2 files');
         atom.commands.dispatch(projectFindView.element, 'core:confirm');
@@ -676,7 +677,7 @@ describe(`ProjectFindView (ripgrep=${ripgrep})`, () => {
         projectFindView.findEditor.setText('wholeword');
 
         atom.commands.dispatch(projectFindView.element, 'core:confirm');
-        await resultsPromise();
+        await waitForSearchResults();
       });
 
       it("does not run whole word search by default", () => {
@@ -696,7 +697,7 @@ describe(`ProjectFindView (ripgrep=${ripgrep})`, () => {
         expect(projectFindView.refs.wholeWordOptionButton).not.toHaveClass('selected');
 
         projectFindView.refs.wholeWordOptionButton.click();
-        await resultsPromise();
+        await waitForSearchResults();
 
         expect(projectFindView.refs.wholeWordOptionButton).toHaveClass('selected');
         expect(atom.workspace.scan.mostRecentCall.args[0]).toEqual(/\bwholeword\b/gim);
@@ -708,7 +709,6 @@ describe(`ProjectFindView (ripgrep=${ripgrep})`, () => {
         projectFindView.findEditor.setText('items');
         atom.commands.dispatch(projectFindView.element, 'project-find:confirm');
 
-        await resultsPromise();
         await waitForSearchResults();
 
         const resultsView = getResultsView();
@@ -767,7 +767,7 @@ describe(`ProjectFindView (ripgrep=${ripgrep})`, () => {
 
         it("displays the results and no errors", async () => {
           atom.commands.dispatch(projectFindView.element, 'core:confirm');
-          await resultsPromise();
+          await waitForSearchResults();
 
           const resultsView = getResultsView();
           const resultsPaneView = getExistingResultsPane();
@@ -785,7 +785,7 @@ describe(`ProjectFindView (ripgrep=${ripgrep})`, () => {
           projectFindView.pathsEditor.setText('*.js');
 
           atom.commands.dispatch(projectFindView.element, 'core:confirm');
-          await resultsPromise();
+          await waitForSearchResults();
 
           expect(atom.workspace.scan.argsForCall[0][1].paths).toEqual(['*.js']);
         });
@@ -794,7 +794,7 @@ describe(`ProjectFindView (ripgrep=${ripgrep})`, () => {
           const editor = await atom.workspace.open('sample.js')
 
           atom.commands.dispatch(projectFindView.element, 'core:confirm');
-          await resultsPromise();
+          await waitForSearchResults();
 
           const resultsView = getResultsView();
           const listView = resultsView.refs.listView;
@@ -811,7 +811,7 @@ describe(`ProjectFindView (ripgrep=${ripgrep})`, () => {
           expect(listView.element.querySelectorAll(".path-row")[1].parentElement).toHaveClass('selected');
 
           editor.setText('there is one "items" in this file');
-          await genPromiseToCheck(
+          await waitForCondition(
             () => resultsPaneView.refs.previewCount.textContent === "8 results found in 2 files for items"
           )
           expect(listView.element.querySelectorAll(".path-row")[1].parentElement).toHaveClass('selected');
@@ -819,13 +819,13 @@ describe(`ProjectFindView (ripgrep=${ripgrep})`, () => {
           // Ensure the newly added item can be opened.
           await resultsView.moveDown()
           atom.commands.dispatch(resultsView.element, 'core:confirm');
-          await genPromiseToCheck(
+          await waitForCondition(
             () => editor.getSelectedText() === "items"
           )
 
           editor.setText('no matches in this file');
 
-          await genPromiseToCheck(
+          await waitForCondition(
             () => resultsPaneView.refs.previewCount.textContent === "7 results found in 1 file for items"
           )
           expect(resultsPaneView.refs.previewCount.textContent).toEqual("7 results found in 1 file for items")
@@ -835,14 +835,14 @@ describe(`ProjectFindView (ripgrep=${ripgrep})`, () => {
           const editor = await atom.workspace.open('../sample.js')
 
           atom.commands.dispatch(projectFindView.element, 'core:confirm');
-          await resultsPromise();
+          await wait(500)
 
           const resultsView = getResultsView();
           const resultsPaneView = getExistingResultsPane();
 
-          await genPromiseToCheck(() =>
-            resultsView.refs.listView.element.querySelectorAll.length === 13
-          );
+          await waitForCondition(() => {
+            return resultsView.refs.listView.element.querySelectorAll('.list-item').length === 13
+          });
           expect(resultsView.refs.listView.element.querySelectorAll(".list-item")).toHaveLength(13);
           expect(resultsPaneView.refs.previewCount.textContent).toBe("13 results found in 2 files for items");
 
@@ -1213,7 +1213,7 @@ describe(`ProjectFindView (ripgrep=${ripgrep})`, () => {
           atom.commands.dispatch(projectFindView.element, 'project-find:toggle-regex-option');
           projectFindView.findEditor.setText('a');
           atom.commands.dispatch(projectFindView.element, 'project-find:confirm');
-          await resultsPromise();
+          await waitForSearchResults();
         });
 
         it("finds the escape char", async () => {
@@ -1239,14 +1239,15 @@ describe(`ProjectFindView (ripgrep=${ripgrep})`, () => {
         beforeEach(async () => {
           projectFindView.findEditor.setText('a');
           atom.commands.dispatch(projectFindView.element, 'project-find:confirm');
-          await resultsPromise();
+          await waitForSearchResults();
         });
 
         it("finds the escape char", async () => {
           projectFindView.replaceEditor.setText('\\t');
 
           atom.commands.dispatch(projectFindView.element, 'project-find:replace-all');
-          await replacePromise;
+          await wait(500);
+          // await replacePromise;
 
           expect(fs.readFileSync(filePath, 'utf8')).toBe("\\t\nb\n\\t");
         });
@@ -1263,13 +1264,13 @@ describe(`ProjectFindView (ripgrep=${ripgrep})`, () => {
       it("is disabled when a search returns no results", async () => {
         projectFindView.findEditor.setText('items');
         atom.commands.dispatch(projectFindView.element, 'project-find:confirm');
-        await resultsPromise();
+        await wait(500);
 
         expect(projectFindView.refs.replaceAllButton).not.toHaveClass('disabled');
 
         projectFindView.findEditor.setText('nopenotinthefile');
         atom.commands.dispatch(projectFindView.element, 'project-find:confirm');
-        await genPromiseToCheck( () =>
+        await waitForCondition(() =>
           projectFindView.refs.replaceAllButton?.classList.contains('disabled')
         );
         expect(projectFindView.refs.replaceAllButton).toHaveClass('disabled');
@@ -1279,7 +1280,7 @@ describe(`ProjectFindView (ripgrep=${ripgrep})`, () => {
         projectFindView.findEditor.setText('items');
         atom.commands.dispatch(projectFindView.element, 'project-find:confirm');
 
-        await resultsPromise();
+        await waitForSearchResults();
 
         disposable = projectFindView.replaceTooltipSubscriptions;
         spyOn(disposable, 'dispose');
@@ -1306,7 +1307,7 @@ describe(`ProjectFindView (ripgrep=${ripgrep})`, () => {
         projectFindView.findEditor.setText('');
         atom.commands.dispatch(projectFindView.element, 'project-find:confirm');
 
-        await genPromiseToCheck( () =>
+        await waitForCondition(() =>
           projectFindView.refs.replaceAllButton?.classList.contains('disabled')
         );
         expect(projectFindView.refs.replaceAllButton).toHaveClass('disabled');
@@ -1321,7 +1322,7 @@ describe(`ProjectFindView (ripgrep=${ripgrep})`, () => {
       it("runs the search, and replaces all the matches", async () => {
         projectFindView.findEditor.setText('items');
         atom.commands.dispatch(projectFindView.element, 'core:confirm');
-        await resultsPromise();
+        await waitForSearchResults();
 
         projectFindView.replaceEditor.setText('sunshine');
         projectFindView.refs.replaceAllButton.click();
@@ -1343,7 +1344,7 @@ describe(`ProjectFindView (ripgrep=${ripgrep})`, () => {
         it("runs the search after the replace", async () => {
           projectFindView.findEditor.setText('items');
           atom.commands.dispatch(projectFindView.element, 'core:confirm');
-          await resultsPromise();
+          await waitForSearchResults();
 
           projectFindView.replaceEditor.setText('items-123');
           projectFindView.refs.replaceAllButton.click();
@@ -1389,7 +1390,7 @@ describe(`ProjectFindView (ripgrep=${ripgrep})`, () => {
           projectFindView.findEditor.setText('nopenotinthefile');
           atom.commands.dispatch(projectFindView.element, 'core:confirm');
 
-          await resultsPromise();
+          await wait(500);
         });
 
         it("doesnt replace anything", () => {
@@ -1404,7 +1405,7 @@ describe(`ProjectFindView (ripgrep=${ripgrep})`, () => {
 
           expect(atom.workspace.scan).not.toHaveBeenCalled();
           expect(atom.beep).toHaveBeenCalled();
-          expect(projectFindView.refs.descriptionLabel.textContent.replace(/(  )/g, ' ')).toContain("No results");
+          expect(projectFindView.refs.descriptionLabel.textContent.replace(/( {2})/g, ' ')).toContain("No results");
         });
       });
 
@@ -1413,7 +1414,7 @@ describe(`ProjectFindView (ripgrep=${ripgrep})`, () => {
           projectFindView.findEditor.setText('items');
           atom.commands.dispatch(projectFindView.element, 'core:confirm');
 
-          await resultsPromise();
+          await waitForSearchResults();
         });
 
         it("messages the user when the search text has changed since that last search", () => {
@@ -1438,8 +1439,7 @@ describe(`ProjectFindView (ripgrep=${ripgrep})`, () => {
 
           expect(projectFindView.errorMessages).not.toBeVisible();
           atom.commands.dispatch(projectFindView.element, 'project-find:replace-all');
-          await resultsPromise();
-          await replacePromise;
+          await wait(1000);
 
           const resultsView = getResultsView();
           expect(resultsView.element).toBeVisible();
@@ -1474,15 +1474,10 @@ describe(`ProjectFindView (ripgrep=${ripgrep})`, () => {
 
       describe("when the find field contains a ^ or a $ and the regex option is enabled", () => {
         it("correctly replaces all matches", async () => {
-          // TODO: Remove version check when Atom 1.21 reaches stable
-          if (parseFloat(atom.getVersion()) < 1.21) {
-            return;
-          }
-
           atom.commands.dispatch(projectFindView.element, 'project-find:toggle-regex-option');
           projectFindView.findEditor.setText(';$');
           atom.commands.dispatch(projectFindView.element, 'core:confirm');
-          await resultsPromise();
+          await waitForSearchResults();
 
           spyOn(atom, 'confirm').andReturn(0);
           projectFindView.replaceEditor.setText('sunshine');
@@ -1505,7 +1500,7 @@ describe(`ProjectFindView (ripgrep=${ripgrep})`, () => {
         spyOn(atom, 'confirm').andReturn(0);
         projectFindView.findEditor.setText('items');
         atom.commands.dispatch(projectFindView.element, 'project-find:confirm');
-        await resultsPromise();
+        await waitForSearchResults();
       });
 
       it("displays the errors in the results pane", async () => {
@@ -1584,7 +1579,7 @@ describe(`ProjectFindView (ripgrep=${ripgrep})`, () => {
 
         projectFindView.findEditor.setText('items');
         atom.commands.dispatch(projectFindView.element, 'core:confirm');
-        await resultsPromise();
+        await waitForSearchResults();
       });
 
       it("doesn't open another panel even if the active pane is vertically split", async () => {
@@ -1592,7 +1587,7 @@ describe(`ProjectFindView (ripgrep=${ripgrep})`, () => {
         projectFindView.findEditor.setText('items');
 
         atom.commands.dispatch(projectFindView.element, 'core:confirm');
-        await resultsPromise();
+        await waitForSearchResults();
 
         expect(workspaceElement.querySelectorAll('.preview-pane').length).toBe(1);
       });
@@ -1610,7 +1605,7 @@ describe(`ProjectFindView (ripgrep=${ripgrep})`, () => {
 
         projectFindView.findEditor.setText('items');
         atom.commands.dispatch(projectFindView.element, 'core:confirm');
-        await resultsPromise();
+        await waitForSearchResults();
       });
 
       it("doesn't open another panel even if the active pane is horizontally split", async () => {
@@ -1618,7 +1613,7 @@ describe(`ProjectFindView (ripgrep=${ripgrep})`, () => {
         projectFindView.findEditor.setText('items');
 
         atom.commands.dispatch(projectFindView.element, 'core:confirm');
-        await resultsPromise();
+        await waitForSearchResults();
 
         expect(workspaceElement.querySelectorAll('.preview-pane').length).toBe(1);
       });
@@ -1634,7 +1629,7 @@ describe(`ProjectFindView (ripgrep=${ripgrep})`, () => {
       atom.config.set('find-and-replace.useRegex', true);
 
       atom.commands.dispatch(workspaceElement, 'project-find:show');
-      await resultsPromise();
+      await wait(50);
 
       expect(projectFindView.model.getFindOptions().useRegex).toBe(true);
       expect(projectFindView.findEditor.getGrammar().scopeName).toBe('source.js.regexp');
@@ -1644,7 +1639,7 @@ describe(`ProjectFindView (ripgrep=${ripgrep})`, () => {
     describe("when panel is active", () => {
       beforeEach(async () => {
         atom.commands.dispatch(workspaceElement, 'project-find:show');
-        await resultsPromise();
+        await wait(50);
       });
 
       it("does not use regexp grammar when in non-regex mode", () => {

--- a/packages/find-and-replace/spec/project-find-view-spec.js
+++ b/packages/find-and-replace/spec/project-find-view-spec.js
@@ -1123,8 +1123,10 @@ describe(`ProjectFindView (ripgrep=${ripgrep})`, () => {
 
         projectFindView.findEditor.setText('item');
         atom.commands.dispatch(projectFindView.element, 'core:confirm');
-        await resultsPromise();
-        await waitForSearchResults();
+
+        await waitForCondition(() => {
+          return (getResultsView()?.refs.listView.element.querySelectorAll(".match-row").length ?? 0) >= 11
+        });
 
         const resultsView = getResultsView();
         resultsView.scrollToBottom(); // To load ALL the results

--- a/packages/find-and-replace/spec/project-find-view-spec.js
+++ b/packages/find-and-replace/spec/project-find-view-spec.js
@@ -709,7 +709,10 @@ describe(`ProjectFindView (ripgrep=${ripgrep})`, () => {
         projectFindView.findEditor.setText('items');
         atom.commands.dispatch(projectFindView.element, 'project-find:confirm');
 
-        await waitForSearchResults();
+        // await waitForSearchResults();
+        // TEMP: Diagnosing test failure
+        await wait(1000);
+
 
         const resultsView = getResultsView();
         expect(resultsView.element).toBeVisible();
@@ -720,7 +723,7 @@ describe(`ProjectFindView (ripgrep=${ripgrep})`, () => {
 
     describe("when core:confirm is triggered", () => {
       beforeEach(() => {
-        atom.commands.dispatch(workspaceElement, 'project-find:show')
+        atom.commands.dispatch(workspaceElement, 'project-find:show');
       });
 
       describe("when the there search field is empty", () => {
@@ -767,7 +770,9 @@ describe(`ProjectFindView (ripgrep=${ripgrep})`, () => {
 
         it("displays the results and no errors", async () => {
           atom.commands.dispatch(projectFindView.element, 'core:confirm');
-          await waitForSearchResults();
+          // TEMP: Diagnosing test failure
+          await wait(1000);
+          // await waitForSearchResults();
 
           const resultsView = getResultsView();
           const resultsPaneView = getExistingResultsPane();

--- a/packages/find-and-replace/spec/project-find-view-spec.js
+++ b/packages/find-and-replace/spec/project-find-view-spec.js
@@ -771,7 +771,7 @@ describe(`ProjectFindView (ripgrep=${ripgrep})`, () => {
           atom.commands.dispatch(projectFindView.element, 'core:confirm');
 
           await waitForCondition(() => {
-            return getExistingResultsPane()?.refs.previewCount.textContent.includes('13 results')
+            return (getResultsView()?.resultRows.length ?? 0) >= 13;
           });
 
           const resultsView = getResultsView();
@@ -805,8 +805,9 @@ describe(`ProjectFindView (ripgrep=${ripgrep})`, () => {
           const listView = resultsView.refs.listView;
           const resultsPaneView = getExistingResultsPane();
 
+          await wait(1000);
           await waitForCondition(() => {
-            return getExistingResultsPane()?.refs.previewCount.textContent.includes('13 results')
+            return (getResultsView()?.resultRows.length ?? 0) >= 13;
           });
 
           expect(listView.element.querySelectorAll(".match-row")).toHaveLength(11);

--- a/packages/find-and-replace/spec/project-find-view-spec.js
+++ b/packages/find-and-replace/spec/project-find-view-spec.js
@@ -709,10 +709,9 @@ describe(`ProjectFindView (ripgrep=${ripgrep})`, () => {
         projectFindView.findEditor.setText('items');
         atom.commands.dispatch(projectFindView.element, 'project-find:confirm');
 
-        // await waitForSearchResults();
-        // TEMP: Diagnosing test failure
-        await wait(1000);
-
+        await waitForCondition(() => {
+          return (getResultsView()?.refs.listView.element.querySelectorAll(".match-row").length ?? 0) >= 11
+        });
 
         const resultsView = getResultsView();
         expect(resultsView.element).toBeVisible();
@@ -765,14 +764,15 @@ describe(`ProjectFindView (ripgrep=${ripgrep})`, () => {
 
       describe("when results exist", () => {
         beforeEach(() => {
-          projectFindView.findEditor.setText('items')
+          projectFindView.findEditor.setText('items');
         });
 
         it("displays the results and no errors", async () => {
           atom.commands.dispatch(projectFindView.element, 'core:confirm');
-          // TEMP: Diagnosing test failure
-          await wait(1000);
-          // await waitForSearchResults();
+
+          await waitForCondition(() => {
+            return getExistingResultsPane()?.refs.previewCount.textContent.includes('13 results')
+          });
 
           const resultsView = getResultsView();
           const resultsPaneView = getExistingResultsPane();
@@ -796,14 +796,18 @@ describe(`ProjectFindView (ripgrep=${ripgrep})`, () => {
         });
 
         it("updates the results list when a buffer changes", async () => {
-          const editor = await atom.workspace.open('sample.js')
-
+          const editor = await atom.workspace.open('sample.js');
           atom.commands.dispatch(projectFindView.element, 'core:confirm');
-          await waitForSearchResults();
+
+          await waitForCondition(() => !!getExistingResultsPane());
 
           const resultsView = getResultsView();
           const listView = resultsView.refs.listView;
           const resultsPaneView = getExistingResultsPane();
+
+          await waitForCondition(() => {
+            return getExistingResultsPane()?.refs.previewCount.textContent.includes('13 results')
+          });
 
           expect(listView.element.querySelectorAll(".match-row")).toHaveLength(11);
           expect(listView.element.querySelectorAll(".match.highlight-info")).toHaveLength(13);

--- a/packages/find-and-replace/spec/setup-spec.js
+++ b/packages/find-and-replace/spec/setup-spec.js
@@ -15,5 +15,8 @@ require('etch').setScheduler({
 //
 // See more in https://github.com/atom/atom/pull/21335
 global.beforeEach(() => {
-  spyOn(atom, 'openDevTools').andReturn((console.error("ERROR: Dev tools attempted to open"), Promise.resolve()));
+  spyOn(atom, 'openDevTools').andCallFake(() => {
+    console.error("ERROR: Dev tools attempted to open");
+    return Promise.resolve();
+  });
 });


### PR DESCRIPTION
When `find-and-replace` had a flaky failure in CI earlier today, I looked at its output and found it… perplexing.

I saw a lot of this output:

```
FindView > when find-and-replace:toggle is triggered > it toggles the visibility of the FindView ERROR: Dev tools attempted to open
[pass]
FindView > when the find-view is focused and window:focus-next-pane is triggered > it attaches FindView to the root view ERROR: Dev tools attempted to open
[pass]
FindView > find-and-replace:show-replace > it focuses the replace editor ERROR: Dev tools attempted to open
[pass]
FindView > find-and-replace:show-replace > it places the current selection in the replace editor ERROR: Dev tools attempted to open
[pass]
```

It unnerved me that the opening of dev tools claimed to be triggered on every test, since that typically suggests an error. And the fact that all the tests were passing anyway told me that an error was being _suppressed_ incorrectly.

Even worse: each test was taking several seconds to pass. The suite crawled along at a glacial pace. I figured something weird was going on.

In truth, there were two root causes, neither of which was quite as alarming as it seemed:

- The `Dev tools attempted to open` message was a false positive. We were incorrectly mocking `atom.openDevTools` (the function which opens the dev tools imperatively) and immediately logging this message instead of the intended behavior of logging the message when `atom.openDevTools()` is called.

  (The purpose of mocking this function in order to suppress the opening of developer tools is simply that it prevents the test suite from losing focus, since that would cause further failures on specs that test the focus behavior. The errors still get logged to the console, so no actual failures are being suppressed.)

- The slowness of the suite was the result of `genPromiseToCheck` (the equivalent of what we call `waitsFor` in the pre-async tests) and some hastily written predicates with bugs in them. `genPromiseToCheck` (which I’ve renamed `waitForCondition` here for clarity and consistency) waited up to 4000ms for a given condition to be met; but it _resolved_ if it hit that timeout limit. Hence the test suite would proceed after four seconds.

  If the predicate was correctly written, this didn’t have any real effect — the next assertion would fail. If the predicate was incorrectly written in a way that caused test failures, then that would already have been noticed and fixed. But some of the predicates were incorrectly written in such a way that _did not_ cause test failures — just slowed them down by waiting for something that was never going to happen. In these cases, `await genPromiseToCheck()` was acting as the equivalent of `await wait(4000)`; it explains why all these tests passed anyway, but also why the suite was so slow.

  I rewrote `waitForCondition` so that it _rejects_ after four seconds; if the condition is never met, the spec is automatically failed. This matches the behavior of `waitsFor`. And fixing it caused a number of other test failures, all of which were _by definition_ failures in the logic of `waitForCondition` predicate functions.

  One of the faulty predicates was called from `resultsPromise()` in the project view specs file. This was regrettable because `await resultsPromise()` was present in practically every spec. I replaced it with a function that I could reason about; in a couple cases where that function’s logic wasn’t sufficient, I threw in an `await wait(500)` or the like just so I could move on without devoting a whole lot of time to this.

  Other failures were mainly the results of typos in predicates, like typing `querySelectorAll` instead of `querySelector`. They were easily fixed.

- In some places I noticed errors in the console that seemed not to affect the tests at all, probably because they were side effects that happened during async operations. I think I found the root cause of all of them:

  On some views, we destroy the model when the `destroy` method is called, but other code can still run that assumes `this.model` is present. In some cases, this bug is the result of incomplete disposal (retaining subscriptions that should not be retained), so the fix was straightforward. In other cases, the cause was not clear, so I put guards around them and moved on.


### Testing

The `find-and-replace` package test suite should pass in CI and should pass a lot faster than before. You also shouldn’t see any `ERROR: Dev tools attempted to open` messages unless and until actual errors occur.