### PR TITLE
ppm: Bump ppm to commit 6981ce79e0efdd9bae1fac9bd1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,37 @@ jobs:
     steps:
     - name: Install build dependencies - Linux
       if: ${{ runner.os == 'Linux' }}
-      run: apt-get update && apt-get install -y git python3 python3-pip make gcc g++ libx11-dev libxkbfile-dev pkg-config libsecret-1-dev rpm xvfb ffmpeg zstd wget squashfs-tools
+      run: apt-get update && apt-get install -y git make gcc g++ libx11-dev libxkbfile-dev pkg-config libsecret-1-dev rpm xvfb ffmpeg zstd wget squashfs-tools
+        libncursesw5-dev libssl-dev libsqlite3-dev tk-dev libgdbm-dev libc6-dev libbz2-dev libffi-dev zlib1g-dev # <-- Python-related stuff on this line
+
+    - name: Restore Compiled Python from Cache - Linux
+      if: ${{ runner.os == 'Linux' }}
+      id: compiled-python-restore
+      uses: actions/cache/restore@v4
+      with:
+        key: ${{ runner.os }}-${{ matrix.image }}-Python-${{ env.PYTHON_VERSION }}.9
+        path: Python-${{ env.PYTHON_VERSION }}.9
+
+    - name: Compile Python - Linux
+      if: ${{ runner.os == 'Linux' && steps.compiled-python-restore.outputs.cache-hit != 'true' }}
+      run: |
+        wget "https://www.python.org/ftp/python/${PYTHON_VERSION}.9/Python-${PYTHON_VERSION}.9.tgz"
+        echo "45313e4c5f0e8acdec9580161d565cf5fea578e3eabf25df7cc6355bf4afa1ee  Python-${PYTHON_VERSION}.9.tgz" | sha256sum --check
+        tar xzf "Python-${PYTHON_VERSION}.9.tgz"
+        cd "Python-${PYTHON_VERSION}.9"
+        ./configure --enable-optimizations
+        make
+
+    - name: Save Compiled Python to Cache - Linux
+      if: ${{ runner.os == 'Linux' && steps.compiled-python-restore.outputs.cache-hit != 'true' }}
+      uses: actions/cache/save@v4
+      with:
+        key: ${{ runner.os }}-${{ matrix.image }}-Python-${{ env.PYTHON_VERSION }}.9
+        path: Python-${{ env.PYTHON_VERSION }}.9
+
+    - name: Install Compiled Python - Linux
+      if: ${{ runner.os == 'Linux' }}
+      run: cd "Python-${PYTHON_VERSION}.9" && make install
 
     - name: Checkout the latest code
       uses: actions/checkout@v4


### PR DESCRIPTION
Contains the following PR's from the ppm repository:

- 142 -- chore(deps): update dependency express to v4.20.0 [security]
  - https://github.com/pulsar-edit/ppm/pull/142
- 147 -- Eliminate trivial underscore
  - https://github.com/pulsar-edit/ppm/pull/147
- 137 -- deps: Bump node-gyp to latest ^10.2.0 for Python 3.12 compat
  - https://github.com/pulsar-edit/ppm/pull/137
- 149 -- Remove dependency on "request" package
  - https://github.com/pulsar-edit/ppm/pull/149