### PR TITLE
feat: Implement editor.convertLineEndingOnCopy and editor:paste-without-reindenting

### DIFF
--- a/menus/darwin.cson
+++ b/menus/darwin.cson
@@ -66,6 +66,7 @@
       { label: 'Copy Path', command: 'editor:copy-path' }
       { label: 'Paste', command: 'core:paste' }
       { label: 'Paste Without Reformatting', command: 'editor:paste-without-reformatting' }
+      { label: 'Paste Without Reindenting', command: 'editor:paste-without-reindenting' }
       { label: 'Select All', command: 'core:select-all' }
       { type: 'separator' }
       { label: 'Toggle Comments', command: 'editor:toggle-line-comments' }

--- a/menus/linux.cson
+++ b/menus/linux.cson
@@ -39,6 +39,7 @@
       { label: 'Copy Pat&h', command: 'editor:copy-path' }
       { label: '&Paste', command: 'core:paste' }
       { label: 'Paste Without Reformatting', command: 'editor:paste-without-reformatting' }
+      { label: 'Paste Without Reindenting', command: 'editor:paste-without-reindenting' }
       { label: 'Select &All', command: 'core:select-all' }
       { type: 'separator' }
       { label: '&Toggle Comments', command: 'editor:toggle-line-comments' }

--- a/menus/win32.cson
+++ b/menus/win32.cson
@@ -47,6 +47,7 @@
       { label: 'Copy Pat&h', command: 'editor:copy-path' }
       { label: '&Paste', command: 'core:paste' }
       { label: 'Paste Without Reformatting', command: 'editor:paste-without-reformatting' }
+      { label: 'Paste Without Reindenting', command: 'editor:paste-without-reindenting' }
       { label: 'Select &All', command: 'core:select-all' }
       { type: 'separator' }
       { label: '&Toggle Comments', command: 'editor:toggle-line-comments' }

--- a/spec/clipboard-spec.js
+++ b/spec/clipboard-spec.js
@@ -38,25 +38,25 @@ describe('Clipboard', () => {
       });
     }
 
-    atom.config.set('editor.convertLineEndingOnCopy', 'off');
     it('does not convert line endings when the setting is off', () => {
+      atom.config.set('editor.convertLineEndingOnCopy', 'off');
       atom.clipboard.write('next\ndone\r\n\n');
       expect(atom.clipboard.read()).toEqual('next\ndone\r\n\n');
     });
 
-    atom.config.set('editor.convertLineEndingOnCopy', 'LF');
     it('converts line endings to LF when the setting is LF', () => {
+      atom.config.set('editor.convertLineEndingOnCopy', 'LF');
       atom.clipboard.write('next\ndone\r\n\n');
       expect(atom.clipboard.read()).toEqual('next\ndone\n\n');
     });
 
-    atom.config.set('editor.convertLineEndingOnCopy', 'CRLF');
     it('converts line endings to CRLF when the setting is CRLF', () => {
+      atom.config.set('editor.convertLineEndingOnCopy', 'CRLF');
       atom.clipboard.write('next\ndone\r\n\n');
       expect(atom.clipboard.read()).toEqual('next\r\ndone\r\n\r\n');
-    });
 
-    // Cleanup: Back to the default setting
-    atom.config.set('editor.convertLineEndingOnCopy', 'system');
+      // Cleanup: Back to the default setting
+      atom.config.set('editor.convertLineEndingOnCopy', 'system');
+    });
   });
 });

--- a/spec/clipboard-spec.js
+++ b/spec/clipboard-spec.js
@@ -37,5 +37,26 @@ describe('Clipboard', () => {
         Object.defineProperty(process, 'platform', { value: originalPlatform });
       });
     }
+
+    atom.config.set('editor.convertLineEndingOnCopy', 'off');
+    it('does not convert line endings when the setting is off', () => {
+      atom.clipboard.write('next\ndone\r\n\n');
+      expect(atom.clipboard.read()).toEqual('next\ndone\r\n\n');
+    });
+
+    atom.config.set('editor.convertLineEndingOnCopy', 'LF');
+    it('converts line endings to LF when the setting is LF', () => {
+      atom.clipboard.write('next\ndone\r\n\n');
+      expect(atom.clipboard.read()).toEqual('next\ndone\n\n');
+    });
+
+    atom.config.set('editor.convertLineEndingOnCopy', 'CRLF');
+    it('converts line endings to CRLF when the setting is CRLF', () => {
+      atom.clipboard.write('next\ndone\r\n\n');
+      expect(atom.clipboard.read()).toEqual('next\r\ndone\r\n\r\n');
+    });
+
+    // Cleanup: Back to the default setting
+    atom.config.set('editor.convertLineEndingOnCopy', 'system');
   });
 });

--- a/src/clipboard.js
+++ b/src/clipboard.js
@@ -53,7 +53,16 @@ module.exports = class Clipboard {
   // * `text` The {String} to store.
   // * `metadata` (optional) The additional info to associate with the text.
   write(text, metadata) {
-    text = text.replace(/\r?\n/g, process.platform === 'win32' ? '\r\n' : '\n');
+    const lineEndingOption = atom.config.get('editor.convertLineEndingOnCopy');
+    if (lineEndingOption !== "off") {
+      text = text.replace(
+        /\r?\n/g,
+        lineEndingOption === "CRLF" ||
+          (lineEndingOption === "system" && process.platform === 'win32')
+          ? '\r\n'
+          : '\n'
+      );
+    }
 
     this.signatureForMetadata = this.md5(text);
     this.metadata = metadata;

--- a/src/config-schema.js
+++ b/src/config-schema.js
@@ -1,6 +1,6 @@
-// This is loaded by atom-environment.coffee. See
-// https://atom.io/docs/api/latest/Config for more information about config TODO: Link to Pulsar API site when documented
-// schemas.
+// This is loaded by atom-environment.js.
+// See https://atom.io/docs/api/latest/Config for more information about config schemas.
+// TODO: Link to Pulsar API site when documented
 const configSchema = {
   core: {
     type: 'object',
@@ -495,6 +495,13 @@ const configSchema = {
         default: true,
         description:
           'Automatically indent pasted text based on the indentation of the previous line.'
+      },
+      convertLineEndingOnCopy: {
+        type: 'string',
+        default: 'system',
+        enum: ['system', 'off', 'LF', 'CRLF'],
+        description:
+          'Changes how newlines are converted when text is copied. When set to "system", newlines are changed to CRLF on Windows and LF on Unix. When set to "off", newlines are copied as-is.'
       },
       nonWordCharacters: {
         type: 'string',

--- a/src/pane-element.js
+++ b/src/pane-element.js
@@ -1,6 +1,7 @@
 const path = require('path');
 const { CompositeDisposable } = require('event-kit');
 
+// The HTMLElement corresponding to a {Pane}.
 class PaneElement extends HTMLElement {
   constructor() {
     super();
@@ -72,6 +73,16 @@ class PaneElement extends HTMLElement {
     this.addEventListener('drop', handleDrop);
   }
 
+  // Sets up callbacks when PaneElement initializes
+  //
+  // Only called in {Pane::getElement} as of February 2025.
+  //
+  // * `model` The container {Pane}.
+  // * An {Object} with the following keys:
+  //   * `views` A {ViewRegistry} used to hide and show pane items.
+  //   * `applicationDelegate` An {ApplicationDelegate} used to open file paths.
+  //
+  // Returns this {PaneElement}.
   initialize(model, { views, applicationDelegate }) {
     this.model = model;
     this.views = views;

--- a/src/register-default-commands.js
+++ b/src/register-default-commands.js
@@ -449,6 +449,11 @@ module.exports = function({commandRegistry, commandInstaller, config, notificati
     'core:paste': function() {
       return this.pasteText();
     },
+    'editor:paste-without-reindenting': function() {
+      return this.pasteText({
+        autoIndent: false
+      });
+    },
     'editor:paste-without-reformatting': function() {
       return this.pasteText({
         normalizeLineEndings: false,

--- a/src/view-registry.js
+++ b/src/view-registry.js
@@ -5,8 +5,8 @@ const AnyConstructor = Symbol('any-constructor');
 
 // Essential: `ViewRegistry` handles the association between model and view
 // types in Pulsar. We call this association a View Provider. As in, for a given
-// model, this class can provide a view via {::getView}, as long as the
-// model/view association was registered via {::addViewProvider}
+// model, this class can provide a view (a DOMElement) via {::getView}, as long
+// as the model/view association was registered via {::addViewProvider}
 //
 // If you're adding your own kind of pane item, a good strategy for all but the
 // simplest items is to separate the model and the view. The model handles


### PR DESCRIPTION
Currently, when copying, line endings are converted to the system EOL.

This is useful for copying and pasting into another program, but it has the drawback of copying and `Ctrl+Shift+V` on a `LF` file on Windows causing inconsistent line endings.

Two things are added for this:

+ `editor.convertLineEndingOnCopy`: The "off" option allows to not convert on copy
+ `editor:paste-without-reindenting`: This new command is like `editor:paste-without-reformatting` but just for indenting. So line endings are still converted and trailing white space is still removed

Both of these are potentially useful, but to avoid feature creep ideally others could weigh in.

<details><summary>(note the first commit's message for reviewing)</summary>

```
There aren't any tests for the command `editor:paste-without-reformatting` (just for all the options passed to the `paste` method itself), so I didn't add any for the new command `editor:paste-without-reindenting`

Also some documentation from my investigation of PaneElement a year ago.

The single-line PaneElement description may seem useless, but I first thought it was an entry of a pane (those are pane items).
```

![image](https://github.com/user-attachments/assets/8ab97ebd-d5c2-45a8-93d7-d399aa426b75)

</details>

# Links

Discord conversation: https://canary.discord.com/channels/992103415163396136/992103415163396139/1342613487880376382

Issue and pr for original functionality: https://github.com/atom/atom/issues/8365 and https://github.com/atom/atom/pull/19016

# Release notes

+ Add `editor.convertLineEndingOnCopy` setting.
+ Add `editor:paste-without-reindenting` command.
