### PR TITLE
Changelog: Add changelog entries for 1.126.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,30 @@
 
 ## [Unreleased]
 
+## 1.126.0
+
+- Python 3.12+ compatibility in ppm (installing packages with native C/C++ modules with Python 3.12+ on your system should "just work"TM). (Python 3.7 and older no-longer supported for installing Pulsar packages with native C/C++ modules with ppm. Does not affect anything other than installing certain Pulsar packages.)
+- PHP arrays spanning multiple lines are now foldable, as they always should have been.
+- Various dependency updates for ppm.
+- `core.allowWindowTransparency` setting is now hidden from the UI, as it has many limits and can cause unexpected issues, a situation which we inherit from the upstream Electron project. (Power-users who understand the drawbacks and still wish to enable transparency can add it to their user config files manually.)
+
+### Pulsar
+
+- CI: Compile newer Python for Cirrus ARM Linux [@DeeDeeG](https://github.com/pulsar-edit/pulsar/pull/1237)
+- CI: Update Rolling token for Cirrus CI [@DeeDeeG](https://github.com/pulsar-edit/pulsar/pull/1226)
+- ppm: Bump ppm to commit 6981ce79e0efdd9bae1fac9bd1 [@DeeDeeG](https://github.com/pulsar-edit/pulsar/pull/1223)
+- Tree-sitter fixes, 1.126.0 edition [@savetheclocktower](https://github.com/pulsar-edit/pulsar/pull/1207)
+- Specify a `PYTHON` env var on Windows so it doesn't get confused [@savetheclocktower](https://github.com/pulsar-edit/pulsar/pull/1220)
+- CI: Run `apt-get update` before installing Pulsar (for package tests) [@DeeDeeG](https://github.com/pulsar-edit/pulsar/pull/1209)
+- Remove `core.allowWindowTransparency` from the config schema [@savetheclocktower](https://github.com/pulsar-edit/pulsar/pull/1206)
+
+### ppm
+
+- Remove dependency on "request" package [@2colours](https://github.com/pulsar-edit/ppm/pull/149)
+- deps: Bump node-gyp to latest ^10.2.0 for Python 3.12 compat [@DeeDeeG](https://github.com/pulsar-edit/ppm/pull/137)
+- Eliminate trivial underscore [@2colours](https://github.com/pulsar-edit/ppm/pull/147)
+- chore(deps): update dependency express to v4.20.0 [security] [@renovate](https://github.com/pulsar-edit/ppm/pull/142)
+
 ## 1.125.0
 
 - The Windows installer no longer removes `pulsar` and `ppm` from your path when you update Pulsar to a newer version.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ## 1.126.0
 
-- Python 3.12+ compatibility in ppm (installing packages with native C/C++ modules with Python 3.12+ on your system should "just work"TM). (Python 3.7 and older no-longer supported for installing Pulsar packages with native C/C++ modules with ppm. Does not affect anything other than installing certain Pulsar packages.)
+- Python 3.12+ compatibility in ppm (installing packages with native C/C++ modules with Python 3.12+ on your system should Just Work™). (Python 3.7 and older no-longer supported for installing Pulsar packages with native C/C++ modules with ppm. Does not affect anything other than installing certain Pulsar packages.)
 - PHP arrays spanning multiple lines are now foldable, as they always should have been.
 - Various dependency updates for ppm.
 - `core.allowWindowTransparency` setting is now hidden from the UI, as it has many limits and can cause unexpected issues, a situation which we inherit from the upstream Electron project. (Power-users who understand the drawbacks and still wish to enable transparency can add it to their user config files manually.)
@@ -19,7 +19,7 @@
 - CI: Update Rolling token for Cirrus CI [@DeeDeeG](https://github.com/pulsar-edit/pulsar/pull/1226)
 - ppm: Bump ppm to commit 6981ce79e0efdd9bae1fac9bd1 [@DeeDeeG](https://github.com/pulsar-edit/pulsar/pull/1223)
 - Tree-sitter fixes, 1.126.0 edition [@savetheclocktower](https://github.com/pulsar-edit/pulsar/pull/1207)
-- Specify a `PYTHON` env var on Windows so it doesn't get confused [@savetheclocktower](https://github.com/pulsar-edit/pulsar/pull/1220)
+- CI: Specify a `PYTHON` env var on Windows so it doesn't get confused [@savetheclocktower](https://github.com/pulsar-edit/pulsar/pull/1220)
 - CI: Run `apt-get update` before installing Pulsar (for package tests) [@DeeDeeG](https://github.com/pulsar-edit/pulsar/pull/1209)
 - Remove `core.allowWindowTransparency` from the config schema [@savetheclocktower](https://github.com/pulsar-edit/pulsar/pull/1206)
 

--- a/packages/welcome/lib/changelog-view.js
+++ b/packages/welcome/lib/changelog-view.js
@@ -50,19 +50,16 @@ export default class ChangeLogView {
             <p>Feel free to read our <a href="https://github.com/pulsar-edit/pulsar/blob/master/CHANGELOG.md">Full Change Log</a>.</p>
             <ul>
               <li>
-                The Windows installer no longer removes <code>pulsar</code> and <code>ppm</code> from your path when you update Pulsar to a newer version.
+                Python 3.12+ compatibility in ppm (installing packages with native C/C++ modules with Python 3.12+ on your system should "just work"TM). (Python 3.7 and older no-longer supported for installing Pulsar packages with native C/C++ modules with ppm. Does not affect anything other than installing certain Pulsar packages.)
               </li>
               <li>
-                [spell-check] Removed <code>source comment</code> from the list of automatically checked scopes because of reports of high CPU usage. This means that Pulsar will no longer automatically perform spell-checking for all code comments in all source files. (If you liked the behavior, you can add it back to the list in the <code>spell-check.grammars</code> config setting.)
+                PHP arrays spanning multiple lines are now foldable, as they always should have been.
               </li>
               <li>
-                [language-python] Improved indentation hinting in some unusual scenarios like on one-line blocks and after code comments.
+                Various dependency updates for ppm.
               </li>
               <li>
-                [language-css] Updated <code>tree-sitter-css</code> to latest. Selector handling is now much better when typing incomplete selectors in a brand-new CSS file or at the bottom of an existing file.
-              </li>
-              <li>
-                Restored functionality of <a href="https://web.pulsar-edit.dev/packages/project-plus">project-plus</a> via exposing previously removed internal APIs.
+                <code>core.allowWindowTransparency</code> setting is now hidden from the UI, as it has many limits and can cause unexpected issues, a situation which we inherit from the upstream Electron project. (Power-users who understand the drawbacks and still wish to enable transparency can add it to their user config files manually.)
               </li>
             </ul>
 

--- a/packages/welcome/lib/changelog-view.js
+++ b/packages/welcome/lib/changelog-view.js
@@ -50,7 +50,7 @@ export default class ChangeLogView {
             <p>Feel free to read our <a href="https://github.com/pulsar-edit/pulsar/blob/master/CHANGELOG.md">Full Change Log</a>.</p>
             <ul>
               <li>
-                Python 3.12+ compatibility in ppm (installing packages with native C/C++ modules with Python 3.12+ on your system should "just work"TM). (Python 3.7 and older no-longer supported for installing Pulsar packages with native C/C++ modules with ppm. Does not affect anything other than installing certain Pulsar packages.)
+                Python 3.12+ compatibility in ppm (installing packages with native C/C++ modules with Python 3.12+ on your system should Just Work™). (Python 3.7 and older no-longer supported for installing Pulsar packages with native C/C++ modules with ppm. Does not affect anything other than installing certain Pulsar packages.)
               </li>
               <li>
                 PHP arrays spanning multiple lines are now foldable, as they always should have been.


### PR DESCRIPTION
Changelog updates for Pulsar Regular release 1.126.0, an upcoming planned release.

~~Might need to do one last-minute token update PR for Cirrus, so I'm a bit tempted to wait for that, but also said PR can update Changelog.md as well, there is no rule that changelog updates go in their own PR. (Rather the opposite, we are encouraged to update the Changelog as we go, but we usually don't, heh...)~~

UPDATE: PR https://github.com/pulsar-edit/pulsar/pull/1237 was merged to un-block ARM Linux binaries post-https://github.com/pulsar-edit/pulsar/pull/1223. Added to this Changelog update, rebased and force pushed. This PR is ready to go now.