### PR TITLE
CI: Delete hardcoded GITHUB_TOKEN reference (Cirrus)

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,7 +1,9 @@
 env:
   PYTHON_VERSION: 3.12
-  GITHUB_TOKEN: ENCRYPTED[!587e64c0e1412de985721fd9a82605b5b359a3565854235f9b092824dd50c847e5ed3fcf34acf5ead8b2707cd50ec895!]
-  # The above token, is a GitHub API Token, that allows us to download RipGrep without concern of API limits
+  # GITHUB_TOKEN: ENCRYPTED[!587e64c0e1412de985721fd9a82605b5b359a3565854235f9b092824dd50c847e5ed3fcf34acf5ead8b2707cd50ec895!]
+  # The above token, is a GitHub API Token, that allows us to download RipGrep without concern of API limits.
+  # We define it on the Cirrus web dashboard now, though. That way we don't need to update repo files (this file),
+  # or open any PR's and wait for review, just to update a permissionless token. (Expired tokens can block CI from passing/finishing!)
 
 # linux_task:
 #   alias: linux


### PR DESCRIPTION
### Change

Delete hardcoded GITHUB_TOKEN in Cirrus CI config file (`.cirrus.yml`)

### Commentary (Rationale)

We can define this (encrypted) token on the web dashboard, instead of hard-coding (an encrypted reference to) it in a repo file, to save ourselves the trouble of updating it in the file every time it expires.

This token isn't particularly sensitive, as it has no permissions. It's only for authing as a real user so rate limits are relaxed, letting us download vscode-ripgrep from an otherwise *heavily* rate-limited datacenter / "cloud" machine that we call "CI."

For the more sensitive tokens, I'd like to be able to apply them per-step. Which I don't _think_ the Cirrus web dashboard lets you do. This one should be alright to define globally.
(Heck, we already do define this one for the whole CI build file! Moving it to the web dashboard won't change that.)

### Verification Process

~~I can trigger a Cron job on this branch, I guess.~~

Yep, it worked: https://cirrus-ci.com/task/4603233122910208

(ARM Linux needs some help with a newer Python version due to https://github.com/pulsar-edit/pulsar/pull/1223. But it got past installing its npm deps, so _this PR's fix_ worked there, too!)