### PR TITLE
CI: Compile newer Python for Cirrus ARM Linux

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -115,6 +115,7 @@ arm_linux_task:
     - python_fetch_and_build
   install_python_script:
     - cd "Python-${PYTHON_VERSION}.9" && make install
+    - python3 -m pip install setuptools
   install_script:
     - yarn install --ignore-engines || yarn install --ignore-engines
   build_script:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -87,11 +87,34 @@ arm_linux_task:
                 libnss3
                 wget
                 xvfb
+                libncursesw5-dev
+                libssl-dev
+                libsqlite3-dev
+                tk-dev
+                libgdbm-dev
+                libc6-dev
+                libbz2-dev
+                libffi-dev
+                zlib1g-dev
     - gem install dotenv -v '~>  2.8'
     - gem install fpm
     - git submodule init
     - git submodule update
     - sed -i -e "s/[0-9]*-dev/`date -u +%Y%m%d%H`/g" package.json
+  python_fetch_and_build_cache:
+    fingerprint_script: echo "${CIRRUS_OS}-$(uname -prsv)-Python-${PYTHON_VERSION}.9"
+    folder: Python-${PYTHON_VERSION}.9
+    populate_script:
+      - wget "https://www.python.org/ftp/python/${PYTHON_VERSION}.9/Python-${PYTHON_VERSION}.9.tgz"
+      - echo "45313e4c5f0e8acdec9580161d565cf5fea578e3eabf25df7cc6355bf4afa1ee  Python-${PYTHON_VERSION}.9.tgz" | sha256sum --check
+      - tar xzf "Python-${PYTHON_VERSION}.9.tgz"
+      - cd "Python-${PYTHON_VERSION}.9"
+      - ./configure --enable-optimizations
+      - make
+  upload_caches:
+    - python_fetch_and_build
+  install_python_script:
+    - cd "Python-${PYTHON_VERSION}.9" && make install
   install_script:
     - yarn install --ignore-engines || yarn install --ignore-engines
   build_script:


### PR DESCRIPTION
### Change

See commit message for details:

> Need this for compatibility with recent gyp-next, from the node-gyp
> bump in the latest ppm bump for Pulsar core. (https://github.com/pulsar-edit/pulsar/pull/1223)
> 
> That dependency bump improved our out-of-the-box support for
> Python 3.12+, relevant when building packages with native C/C++
> addon modules while installing said packages with ppm, or the GUI
> package management interface in Pulsar settings (which also uses ppm
> under the hood anyway).
> 
> We will cache the compiled Python in Cirrus's cache storage system,
>  much like we cache compiled Python in GitHub Actions caches.
> Want to save time and datacenter power use/emissions and such.
> 
> Known SHA256 hash of the Python source tarball is hardcoded and checked
> for safety/reliability. We can update that hash if we need to build
> a different Python version in the future.

Oh, and un-blocks ARM Linux bins from being generated, post-https://github.com/pulsar-edit/pulsar/pull/1223.

### Potential Downsides?

Appears to add about 4 minutes to finish installing the compiled Python, if restored from cache.

Takes about 14 minutes to compile Python from scratch if it needs to. (It is set to re-use the cache pretty darn widely. The cache key says basically "if still running Linux, and if `uname -psrv` comes back the same as when a previous cache was made, then re-use existing cached Python." Which I assume will be fairly stable since we're using a containerized OS... that said, I thnk perhaps the underlying CI host that _runs_ the container has its `uname` info returned? So this may churn every few months ago, requiring us to wait another ~14 minutes for Python to compile, and then set and able to restore from cache again for a month or few?)

\* As always with CI, estimated times for compiling or installing Python may vary wildly, as CI execution of resource-intensive tasks tends to swing wildly in duration.

### Verification Process

Worked in Cirrus: https://cirrus-ci.com/task/5975664756523008

ARM bins were generated successfully in the above CI run. (The bins would have been automatically posted to Rolling repo, if this has been a Cirrus cron build.) 

(On that branch, I temporarily set the workflow to run for branch pushes so it would run.)