### PR TITLE
[main] Fix Window Capture Compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -298,6 +298,7 @@
     "private-js-docs": "jsdoc2md --private --files src --configure docs/.jsdoc.json > ./docs/Source-Code-Documentation.md",
     "test:editor": "yarn test:only spec",
     "test:only": "yarn start --test"
+    "start": "electron . --enable-gpu"
   },
   "devDependencies": {
     "@electron/notarize": "^1.2.3",

--- a/src/main-process/main.js
+++ b/src/main-process/main.js
@@ -18,10 +18,23 @@ function createWindow() {
     },
     transparent: false,
     backgroundColor: '#FFF',
-    autoHideMenuBar: true,
+    hardwareAcceleration: false,
   });
 
   mainWindow.loadFile('index.html');
+}
+
+  mainWindow.on('minimize', () => {
+    mainWindow.hide();
+  });
+
+  mainWindow.on('restore', () => {
+    mainWindow.show();
+  });
+}
+
+if (process.argv.includes('--screen-capture-mode')) {
+  app.disableHardwareAcceleration();
 }
 
 app.whenReady().then(() => {

--- a/src/main-process/main.js
+++ b/src/main-process/main.js
@@ -6,7 +6,35 @@ const path = require('path');
 const fs = require('fs-plus');
 const CSON = require('season');
 const yargs = require('yargs');
-const { app } = require('electron');
+const { app, BrowserWindow } = require('electron');
+
+function createWindow() {
+  const mainWindow = new BrowserWindow({
+    width: 800,
+    height: 600,
+    webPreferences: {
+      nodeIntegration: true,
+      contextIsolation: false,
+    },
+    transparent: false,
+    backgroundColor: '#FFF',
+    autoHideMenuBar: true,
+  });
+
+  mainWindow.loadFile('index.html');
+}
+
+app.whenReady().then(() => {
+  createWindow();
+
+  app.on('activate', () => {
+    if (BrowserWindow.getAllWindows().length === 0) createWindow();
+  });
+});
+
+app.on('window-all-closed', () => {
+  if (process.platform !== 'darwin') app.quit();
+});
 
 const args = yargs(process.argv)
   // Don't handle --help or --version here; they will be handled later.


### PR DESCRIPTION
# Window Capture Compatibility: 
_The problem is that the Pulsar Editor application does not appear in the list of available windows to capture in Discord and OBS. This is usually due to the way the application handles graphical context and how it interacts with operating system windows._

_I made this change, so I write mainly on Pulsar, but at the same moment I stream on Twitch, but OBS doesn't capture Pulsar and I have to show it on Visual Studio._


_**Changed main.js and added this code that disables hardware acceleration, because of it often problems**._
```javascript
const { app, BrowserWindow } = require('electron');

function createWindow() {
  const allowTransparency = settings.get('core.allowWindowTransparency', false);
  const mainWindow = new BrowserWindow({
    width: 800,
    height: 600,
    webPreferences: {
      nodeIntegration: true,
      contextIsolation: false,
      hardwareAcceleration: false,
    },
    transparent: false,
    backgroundColor: '#FFF',
  });

  mainWindow.loadFile('index.html');
}
  mainWindow.on('minimize', () => {
    mainWindow.hide();
  });

  mainWindow.on('restore', () => {
    mainWindow.show();
  });
}

app.whenReady().then(() => {
  createWindow();

  app.on('activate', () => {
    if (BrowserWindow.getAllWindows().length === 0) createWindow();
  });
});

app.on('window-all-closed', () => {
  if (process.platform !== 'darwin') app.quit();
});



app.disableHardwareAcceleration();
``` 

_**And added --enable-gpu to package.json.**_
```javascript
"start": "electron . --enable-gpu"
```
_Sry if the code is not correct, I would be glad if you could correct it._