### PR TITLE
CI: New Rolling upload token for updated-latest-electron branch for C…

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -63,7 +63,7 @@ arm_linux_task:
     memory: 8G
   env:
     USE_SYSTEM_FPM: 'true'
-    ROLLING_UPLOAD_TOKEN: ENCRYPTED[9cfac7b7c2b28c0979ddd587f7cda3ed1bbe893bbf7ec1d8df9808ef24cdb53c17c1edc572ee249d83c65529cea18a30]
+    ROLLING_UPLOAD_TOKEN: ENCRYPTED[41b279482c1b61c9129e410233cc5cd71bbfd60e33d03cefae451aff6bc9915d1706a6e8fefd0e0f9041a4bd287c84be] # <-- This is the Electron Next Bins token! Careful when resolving merge conflicts to not overrite to/from master. master branch keeps its token, updated-latest-electron branch keeps this one!
   prepare_script:
     - apt-get update
     - export DEBIAN_FRONTEND="noninteractive"
@@ -135,7 +135,7 @@ silicon_mac_task:
     APPLEID: ENCRYPTED[549ce052bd5666dba5245f4180bf93b74ed206fe5e6e7c8f67a8596d3767c1f682b84e347b326ac318c62a07c8844a57]
     APPLEID_PASSWORD: ENCRYPTED[774c3307fd3b62660ecf5beb8537a24498c76e8d90d7f28e5bc816742fd8954a34ffed13f9aa2d1faf66ce08b4496e6f]
     TEAM_ID: ENCRYPTED[11f3fedfbaf4aff1859bf6c105f0437ace23d84f5420a2c1cea884fbfa43b115b7834a463516d50cb276d4c4d9128b49]
-    ROLLING_UPLOAD_TOKEN: ENCRYPTED[9cfac7b7c2b28c0979ddd587f7cda3ed1bbe893bbf7ec1d8df9808ef24cdb53c17c1edc572ee249d83c65529cea18a30]
+    ROLLING_UPLOAD_TOKEN: ENCRYPTED[41b279482c1b61c9129e410233cc5cd71bbfd60e33d03cefae451aff6bc9915d1706a6e8fefd0e0f9041a4bd287c84be] # <-- This is the Electron Next Bins token! Careful when resolving merge conflicts to not overrite to/from master. master branch keeps its token, updated-latest-electron branch keeps this one!
   prepare_script:
     - brew update
     - brew uninstall node@20


### PR DESCRIPTION
### Here's a token

This adds a new token allowing Cirrus runs pointing at this branch of _this_ repo to upload bins to https://github.com/pulsar-edit/pulsar-electron-next-binaries repo's releases.

Effectively, with respect to the updated-latest-lelectron branch, AKA "Electron Next" branch, this gets Cirrus going to build, test, and upload bins for **ARM Linux and ARM ("Apple Silicon") macOS**, on the ongoing **Rolling release** basis as GitHub Actions has already been doing for x64 bins for **"Electron Next"** Pulsar bins.

**tl;dr: This token lets us upload Apple Silicon (ARM) macOS and ARM Linux bins to https://github.com/pulsar-edit/pulsar-electron-next-binaries via Cirrus.**

### Action still needed on Cirrus web dashboard side -- will do once/if this PR is approved

Note: I still need to set a cron trigger up pointing to this branch in the Cirrus web dashboard. I am planning to set that up to run twice a week, on Mondays and Thursdays because it seemed like a reasonable two days to pick. And we avoid shipping on weekends or Fridays, which is arguably nice.

### Long tangent about merge conflicts with this token

Note also: I put a big, visually prominent, LONG comment in the .cirrus.yml on the same line as this token, as it's going to lend itself tremendously to subtle merge conflicts, and/or (through whatever means) overwriting tokens from one branch to another if merging and cherry-picking things across, etc.

Alternatively we could set a different env var on its own line of .cirrus.yml, and update `script/rolling-release-scripts/rolling-release-binary-upload.js` to read from same, so that this stuff ends up _not prone to meaningful/problematic merge conflicts overwriting the token..._

And to avoid something more insidious: _this PR as written lends itself to merge **non-conflicts**, wherein we mark on this branch that **this** electron-next token is **the** desired token per this branch, and then merge this branch eventually to master, at which point **the preferred token per this branch** overwrites master branch's token, and it's **not a conflict** it just **silently happens.** Hypothetically at some future date if this branch isn't carefully re-done/rebased to avoid it._

**So maybe some thought is warranted, thinking ahead to what we ant to do to anticipate/avoid merge conflicts, cherry-picking/rebasing/merging snafus, etc.** But on the other hand, I may have spilled more digital ink about it than it really warrants. So at minimum, see the LONG comment I added on the line, and mind the merges/cherry-picks!