### PR TITLE
Refactor `StateStore` to remove dependency on the `atom` global

### DIFF
--- a/spec/history-manager-spec.js
+++ b/spec/history-manager-spec.js
@@ -11,7 +11,10 @@ describe('HistoryManager', () => {
     commandRegistry = jasmine.createSpyObj('CommandRegistry', ['add']);
     commandRegistry.add.and.returnValue(commandDisposable);
 
-    stateStore = new StateStore('history-manager-test', 1);
+    stateStore = new StateStore('history-manager-test', 1, {
+      config: atom.config
+    });
+    stateStore.initialize({ configDirPath: atom.getConfigDirPath() });
     await stateStore.save('history-manager', {
       projects: [
         {

--- a/spec/state-store-spec.js
+++ b/spec/state-store-spec.js
@@ -12,47 +12,51 @@ describe('StateStore', () => {
       atom.config.set('core.useLegacySessionStore', true)
     })
 
-    it('can save, load, and delete states', () => {
-      const store = new StateStore(databaseName, version);
-      return store
-        .save('key', { foo: 'bar' })
-        .then(() => store.load('key'))
-        .then(state => {
-          expect(state).toEqual({ foo: 'bar' });
-        })
-        .then(() => store.delete('key'))
-        .then(() => store.load('key'))
-        .then(value => {
-          expect(value).toBeNull();
-        })
-        .then(() => store.count())
-        .then(count => {
-          expect(count).toBe(0);
-        });
+    it('can save, load, and delete states', async () => {
+      const store = new StateStore(databaseName, version, {
+        config: atom.config
+      });
+      store.initialize({ configDirPath: atom.getConfigDirPath() });
+
+      await store.save('key', { foo: 'bar' });
+
+      let state = await store.load('key');
+      expect(state).toEqual({ foo: 'bar' });
+
+      await store.delete('key');
+
+      expect(await store.load('key')).toBeNull();
+      expect(await store.count()).toBe(0);
     });
 
     it('resolves with null when a non-existent key is loaded', () => {
-      const store = new StateStore(databaseName, version);
+      const store = new StateStore(databaseName, version, {
+        config: atom.config
+      });
+      store.initialize({ configDirPath: atom.getConfigDirPath() });
       return store.load('no-such-key').then(value => {
         expect(value).toBeNull();
       });
     });
 
-    it('can clear the state object store', () => {
-      const store = new StateStore(databaseName, version);
-      return store
-        .save('key', { foo: 'bar' })
-        .then(() => store.count())
-        .then(count => expect(count).toBe(1))
-        .then(() => store.clear())
-        .then(() => store.count())
-        .then(count => {
-          expect(count).toBe(0);
-        });
+    it('can clear the state object store', async () => {
+      const store = new StateStore(databaseName, version, {
+        config: atom.config
+      });
+      store.initialize({ configDirPath: atom.getConfigDirPath() });
+
+      await store.save('key', { foo: 'bar' });
+      expect(await store.count()).toBe(1);
+
+      await store.clear();
+      expect(await store.count()).toBe(0);
     });
 
     it('returns a database instance via dbPromise', async () => {
-      const store = new StateStore(databaseName, version);
+      const store = new StateStore(databaseName, version, {
+        config: atom.config
+      });
+      store.initialize({ configDirPath: atom.getConfigDirPath() });
       const instance = await store.dbPromise;
       expect(instance instanceof IDBDatabase).toBe(true);
     });
@@ -60,13 +64,16 @@ describe('StateStore', () => {
     describe('when there is an error reading from the database', () => {
       it('rejects the promise returned by load', async () => {
         jasmine.useRealClock();
-        const store = new StateStore(databaseName, version);
+        const store = new StateStore(databaseName, version, {
+          config: atom.config
+        });
+        store.initialize({ configDirPath: atom.getConfigDirPath() });
 
         const fakeErrorEvent = {
           target: { errorCode: 'Something bad happened' }
         };
 
-        spyOn(IDBObjectStore.prototype, 'get').and.callFake(key => {
+        spyOn(IDBObjectStore.prototype, 'get').and.callFake(_key => {
           let request = {};
           process.nextTick(() => request.onerror(fakeErrorEvent));
           return request;
@@ -88,47 +95,51 @@ describe('StateStore', () => {
       atom.config.set('core.useLegacySessionStore', false)
     })
 
-    it('can save, load, and delete states', () => {
-      const store = new StateStore(databaseName, version);
-      return store
-        .save('key', { foo: 'bar' })
-        .then(() => store.load('key'))
-        .then(state => {
-          expect(state).toEqual({ foo: 'bar' });
-        })
-        .then(() => store.delete('key'))
-        .then(() => store.load('key'))
-        .then(value => {
-          expect(value).toBeNull();
-        })
-        .then(() => store.count())
-        .then(count => {
-          expect(count).toBe(0);
-        });
+    it('can save, load, and delete states', async () => {
+      const store = new StateStore(databaseName, version, {
+        config: atom.config
+      });
+      store.initialize({ configDirPath: atom.getConfigDirPath() });
+
+      await store.save('key', { foo: 'bar' });
+
+      let state = await store.load('key');
+      expect(state).toEqual({ foo: 'bar' });
+
+      await store.delete('key');
+
+      expect(await store.load('key')).toBeNull();
+      expect(await store.count()).toBe(0);
     });
 
     it('resolves with null when a non-existent key is loaded', () => {
-      const store = new StateStore(databaseName, version);
+      const store = new StateStore(databaseName, version, {
+        config: atom.config
+      });
+      store.initialize({ configDirPath: atom.getConfigDirPath() });
       return store.load('no-such-key').then(value => {
         expect(value).toBeNull();
       });
     });
 
-    it('can clear the state object store', () => {
-      const store = new StateStore(databaseName, version);
-      return store
-        .save('key', { foo: 'bar' })
-        .then(() => store.count())
-        .then(count => expect(count).toBe(1))
-        .then(() => store.clear())
-        .then(() => store.count())
-        .then(count => {
-          expect(count).toBe(0);
-        });
+    it('can clear the state object store', async () => {
+      const store = new StateStore(databaseName, version, {
+        config: atom.config
+      });
+      store.initialize({ configDirPath: atom.getConfigDirPath() });
+
+      await store.save('key', { foo: 'bar' });
+      expect(await store.count()).toBe(1);
+
+      await store.clear();
+      expect(await store.count()).toBe(0);
     });
 
     it('returns a database instance via dbPromise', async () => {
-      const store = new StateStore(databaseName, version);
+      const store = new StateStore(databaseName, version, {
+        config: atom.config
+      });
+      store.initialize({ configDirPath: atom.getConfigDirPath() });
       const instance = await store.dbPromise;
       const Database = require("better-sqlite3");
       expect(instance instanceof Database).toBe(true);

--- a/spec/workspace-spec.js
+++ b/spec/workspace-spec.js
@@ -75,6 +75,7 @@ describe('Workspace', () => {
       assert: atom.assert.bind(atom),
       textEditorRegistry: atom.textEditors
     });
+    workspace.initialize({ configDirPath: atom.getConfigDirPath() });
     workspace.deserialize(workspaceState, atom.deserializers);
   }
 

--- a/src/atom-environment.js
+++ b/src/atom-environment.js
@@ -87,8 +87,6 @@ class AtomEnvironment {
     /** @type {NotificationManager} */
     this.notifications = new NotificationManager();
 
-    this.stateStore = new StateStore('AtomEnvironments', 1);
-
     /** @type {Config} */
     this.config = new Config({
       saveCallback: settings => {
@@ -103,6 +101,10 @@ class AtomEnvironment {
     this.config.setSchema(null, {
       type: 'object',
       properties: _.clone(ConfigSchema)
+    });
+
+    this.stateStore = new StateStore('AtomEnvironments', 1, {
+      config: this.config
     });
 
     /** @type {KeymapManager} */
@@ -257,6 +259,10 @@ class AtomEnvironment {
       projectSpecification
     } = this.getLoadSettings();
 
+    this.stateStore.initialize({
+      configDirPath: this.getConfigDirPath()
+    });
+
     ConfigSchema.projectHome = {
       type: 'string',
       default: path.join(fs.getHomeDirectory(), 'github'),
@@ -323,7 +329,7 @@ class AtomEnvironment {
     this.attachSaveStateListeners();
     this.windowEventHandler.initialize(this.window, this.document);
 
-    this.workspace.initialize();
+    this.workspace.initialize({ configDirPath: this.getConfigDirPath() });
 
     const didChangeStyles = this.didChangeStyles.bind(this);
     this.disposables.add(this.styles.onDidAddStyleElement(didChangeStyles));
@@ -451,7 +457,7 @@ class AtomEnvironment {
     this.workspace.reset(this.packages);
     this.registerDefaultOpeners();
     this.project.reset(this.packages);
-    this.workspace.initialize();
+    this.workspace.initialize({ configDirPath: this.getConfigDirPath() });
     this.grammars.clear();
     this.textEditors.clear();
     this.views.clear();

--- a/src/state-store.js
+++ b/src/state-store.js
@@ -3,72 +3,70 @@ const IndexedDB = require('./state-store/indexed-db');
 const SQL = require('./state-store/sql');
 
 module.exports = class StateStore {
-  constructor(databaseName, version) {
+  constructor(databaseName, version, { config }) {
     this.databaseName = databaseName;
     this.version = version;
+    this.config = config;
+  }
+
+  initialize({ configDirPath }) {
+    this.configDirPath = configDirPath;
   }
 
   isConnected() {
-    // We don't need to wait for atom global here because this isConnected
-    // is only called on closing the editor
-    if(atom.config.get('core.useLegacySessionStore')) {
-      if(!this.indexed) return false;
-      return this.indexed.isConnected();
-    } else {
-      if(!this.sql) return false;
-      return this.sql.isConnected();
-    }
+    let impl = this._getImplementation();
+    return impl?.isConnected() ?? false;
   }
 
   connect() {
-    return this._getCorrectImplementation().then(i => i.connect());
+    return this._getOrCreateImplementation().connect();
   }
 
   save(key, value) {
-    return this._getCorrectImplementation().then(i => i.save(key, value));
+    return this._getOrCreateImplementation().save(key, value);
   }
 
   load(key) {
-    return this._getCorrectImplementation().then(i => i.load(key));
+    return this._getOrCreateImplementation().load(key);
   }
 
   delete(key) {
-    return this._getCorrectImplementation().then(i => i.delete(key));
+    return this._getOrCreateImplementation().delete(key);
   }
 
   clear() {
-    return this._getCorrectImplementation().then(i => i.clear());
+    return this._getOrCreateImplementation().clear();
   }
 
   count() {
-    return this._getCorrectImplementation().then(i => i.count());
+    return this._getOrCreateImplementation().count();
   }
 
   get dbPromise() {
     // Exposed due to usage in [`project-plus`](https://web.pulsar-edit.dev/packages/project-plus)
-    return this._getCorrectImplementation().then(i => i.dbPromise);
+    return this._getOrCreateImplementation().dbPromise;
   }
 
-  _getCorrectImplementation() {
-    return awaitForAtomGlobal().then(() => {
-      if(atom.config.get('core.useLegacySessionStore')) {
-        this.indexed ||= new IndexedDB(this.databaseName, this.version);
-        return this.indexed;
-      } else {
-        this.sql ||= new SQL(this.databaseName, this.version);
-        return this.sql;
+  _getImplementation() {
+    if (this.config.get('core.useLegacySessionStore')) {
+      return this.indexed;
+    } else {
+      return this.sql;
+    }
+  }
+
+  _getOrCreateImplementation() {
+    if (this.config.get('core.useLegacySessionStore')) {
+      this.indexed ??= new IndexedDB(this.databaseName, this.version);
+      return this.indexed;
+    } else {
+      if (!this.configDirPath) {
+        throw new Error(`state-store: Must initialize with configDirPath`);
       }
-    });
+      this.sql ??= new SQL(this.databaseName, this.version, {
+        storagePath: this.configDirPath
+      });
+      return this.sql;
+    }
   }
 };
-
-function awaitForAtomGlobal() {
-  return new Promise(resolve => {
-    const i = setInterval(() => {
-      if(atom) {
-        clearInterval(i)
-        resolve()
-      }
-    }, 50)
-  })
-}

--- a/src/state-store/sql.js
+++ b/src/state-store/sql.js
@@ -10,112 +10,104 @@ const nativeSQLite = require(path.join(
 const sqlite3 = require('better-sqlite3');
 
 module.exports = class SQLStateStore {
-  constructor(databaseName, version) {
-    const table = databaseName + version;
-    this.tableName = '"' + table + '"';
-    this.dbPromise = (async () => {
-      await awaitForAtomGlobal();
-      const dbPath = path.join(atom.getConfigDirPath(), 'session-store.db');
-      let db;
-      try {
-        db = sqlite3(dbPath, {nativeBinding: nativeSQLite});
-      } catch(error) {
-        atom.notifications.addFatalError('Error loading database', {
-          stack: new Error('Error loading SQLite database for state storage').stack,
-          dismissable: true
-        });
-        console.error('Error loading SQLite database', error);
-        return null;
-      }
-      db.pragma('journal_mode = WAL');
-      db.exec(
-        `CREATE TABLE IF NOT EXISTS ${this.tableName} (key VARCHAR, value JSON)`
+  constructor(databaseName, version, { storagePath }) {
+    const table = `${databaseName}${version}`;
+    this.tableName = `"${table}"`;
+
+    let dbPath = path.join(storagePath, 'session-store.db');
+    let db;
+    try {
+      db = sqlite3(dbPath, { nativeBinding: nativeSQLite });
+    } catch (error) {
+      let stack = new Error('Error loading SQLite database for state storage').stack;
+      atom.notifications.addFatalError(
+        'Error loading database',
+        { stack, dismissable: true }
       );
-      db.exec(
-        `CREATE UNIQUE INDEX IF NOT EXISTS "${table}_index" ON ${this.tableName}(key)`
-      );
-      return db;
-    })();
-    this.connected = false;
-    this.dbPromise.then(db => this.connected = !!db);
+      console.error('Error loading SQLite database', error);
+      return null;
+    }
+
+    db.pragma('journal_mode = WAL');
+    db.exec(
+      `CREATE TABLE IF NOT EXISTS ${this.tableName} (key VARCHAR, value JSON)`
+    );
+    db.exec(
+      `CREATE UNIQUE INDEX IF NOT EXISTS "${table}_index" ON ${this.tableName}(key)`
+    );
+
+    this.db = db;
+    this.connected = true;
+  }
+
+  // `better-sqlite3` offers a synchronous API and is militant about why it’s
+  // actually better for performance. But the contract for this adapter expects
+  // us to return promises here, so we mark all these functions as `async` so
+  // that they'll implicitly wrap return values in `Promise.resolve`.
+  get dbPromise() {
+    return Promise.resolve(this.db);
   }
 
   isConnected() {
     return this.connected;
   }
 
-  connect() {
-    return this.dbPromise.then(db => !!db);
+  async connect() {
+    return true;
   }
 
-  save(key, value) {
-    return this.dbPromise.then(db => {
-      if(!db) return null;
-      return exec(db,
-        `REPLACE INTO ${this.tableName} VALUES (?, ?)`,
-        key,
-        JSON.stringify({ value: value, storedAt: new Date().toString() })
-      );
-    });
-  }
-
-  load(key) {
-    return this.dbPromise.then(db => {
-      if(!db) return null;
-      return getOne(db, `SELECT value FROM ${this.tableName} WHERE key = ?`, key);
-    }).then(result => {
-      if(result) {
-        const parsed = JSON.parse(result.value, reviver);
-        return parsed?.value;
-      }
-      return null;
-    });
-  }
-
-  delete(key) {
-    return this.dbPromise.then(db =>
-      exec(db, `DELETE FROM ${this.tableName} WHERE key = ?`, key)
+  async save(key, value) {
+    if (!this.db) return null;
+    return exec(
+      this.db,
+      `REPLACE INTO ${this.tableName} VALUES (?, ?)`,
+      key,
+      JSON.stringify({ value: value, storedAt: new Date().toString() })
     );
   }
 
-  clear() {
-    return this.dbPromise.then(db =>
-      exec(db, `DELETE FROM ${this.tableName}`)
+  async load(key) {
+    if (!this.db) return null;
+    let result = getOne(
+      this.db,
+      `SELECT value FROM ${this.tableName} WHERE key = ?`,
+      key
     );
+    if (!result) return null;
+    let parsed = JSON.parse(result.value, reviver);
+    return parsed?.value;
   }
 
-  count() {
-    return this.dbPromise.then(db => {
-      if(!db) return null;
-      const r = getOne(db, `SELECT COUNT(key) c FROM ${this.tableName}`);
-      return r.c;
-    });
+  async delete(key) {
+    exec(this.db, `DELETE FROM ${this.tableName} WHERE key = ?`, key);
+  }
+
+  async clear() {
+    exec(this.db, `DELETE from ${this.tableName}`);
+  }
+
+  async count() {
+    if (!this.db) return null;
+    let result = getOne(
+      this.db,
+      `SELECT COUNT(key) itemCount FROM ${this.tableName}`
+    );
+    return result.itemCount;
   }
 };
 
 function getOne(db, sql, ...params) {
   const stmt = db.prepare(sql);
-  return stmt.get(params)
+  return stmt.get(params);
 }
 
 function exec(db, sql, ...params) {
   const stmt = db.prepare(sql);
-  stmt.run(params)
-}
-
-function awaitForAtomGlobal() {
-  return new Promise(resolve => {
-    const i = setInterval(() => {
-      if(atom) {
-        clearInterval(i);
-        resolve();
-      }
-    }, 50);
-  })
+  return stmt.run(params);
 }
 
 function reviver(_, value) {
-  if(value?.type === 'Buffer') {
+  if (value?.type === 'Buffer') {
     return Buffer.from(value.data);
   } else {
     return value;


### PR DESCRIPTION
I had occasion to visit `src/state-store.js` and thought I'd refactor it a bit.

I know we have this annoying problem where we want to rely on the `atom` global, but we end up acting before it's defined. This is vexing to `StateStore`, since it wants to read from config to decide which kind of adapter to use (IndexedDB or SQL). In this case, we can pass the `config` instance into the constructor, dependency-injection–style. By the time we actually need to read the config, it's been initialized and is ready to read values.

The SQL adapter also needs to know where to store its DB, so it reads `atom.getConfigDirPath()`. This value can't be introspected from `atom.config`, and it isn't even ready by the time we create `StateStore`; it gets initialized later in the environment setup process. The fix is similar to the fix for a lot of similar objects created during bootstrapping: a second “initialization” phase where the later properties can get set. This is still early enough to be set before the first time we need to actually use `StateStore`, so it all works out.

This allows us to simplify the implementation of `src/state-store.js` and make some more methods synchronous. (They still go async later, but the code is easier to read this way.) We also no longer need to do the awkward thing where we check for the `atom` global every 50ms.

All the relevant tests seem to pass locally, but let's see what CI says.