### PR TITLE
v1.127.1 Hotfix Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@
 
 ## [Unreleased]
 
+## 1.127.1
+
+- Hotfix: Reverted a Wayland-related change that Linux users reported issues with on Electron 12.
+
+### Pulsar
+
+- Revert "Wayland pulsar script" [@mauricioszabo](https://github.com/pulsar-edit/pulsar/pull/1261)
+
 ## 1.127.0
 
 - Added a Jasmine 2-based test runner, migrated core editor tests to use it. Packages bundled into the core editor can migrate their tests to use this as well, over time. The Jasmine 1 test runner remains available.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "pulsar",
   "author": "Pulsar-Edit <admin@pulsar-edit.dev>",
   "productName": "Pulsar",
-  "version": "1.127.0-dev",
+  "version": "1.127.1",
   "description": "A Community-led Hyper-Hackable Text Editor",
   "branding": {
     "id": "pulsar",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "pulsar",
   "author": "Pulsar-Edit <admin@pulsar-edit.dev>",
   "productName": "Pulsar",
-  "version": "1.127.1",
+  "version": "1.127.1-dev",
   "description": "A Community-led Hyper-Hackable Text Editor",
   "branding": {
     "id": "pulsar",

--- a/packages/welcome/lib/changelog-view.js
+++ b/packages/welcome/lib/changelog-view.js
@@ -50,6 +50,9 @@ export default class ChangeLogView {
             <p>Feel free to read our <a href="https://github.com/pulsar-edit/pulsar/blob/master/CHANGELOG.md">Full Change Log</a>.</p>
             <ul>
               <li>
+                Pulsar v1.127.1 Hotfix: Reverted a Wayland-related change that Linux users reported issues with on Electron 12. (The remaining changes listed below are from Pulsar v1.127.0.)
+              </li>
+              <li>
                 Added a Jasmine 2-based test runner, migrated core editor tests to use it. Packages bundled into the core editor can migrate their tests to use this as well, over time. The Jasmine 1 test runner remains available.
               </li>
               <li>


### PR DESCRIPTION
- Add changelog entries for v1.127.1
- Bump version string to `1.127.1` in `package.json`
  - Ensures binaries reflect a proper Regular release with the hotfix version number, and so the version isn't automatically converted to a timestamp-based Rolling-style version number. 


This is for the imminently planned hotfix release containing only #1261 relative to v1.127.0 (that is, reverting #1246).

As I understand it, this change requires newer Electron and was initially tested on newer Electron, and there were no problems in CI. Unclear to me if the reported issue (#1260) happens on _all_ Wayland setups or not, but since it is causing problems on this branch with Electron 12, we are reverting it on this branch for now.

**Note:** As always, we should ensure `-dev` gets added back to the end of the version string **before merging this PR.**