### PR TITLE
Fix timeouts for macOS bin building (Port of #1178 for updated-latest-electron branch)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -184,18 +184,16 @@ jobs:
         TEAM_ID: ${{ secrets.TEAM_ID }}
       uses: nick-fields/retry@7152eba30c6575329ac0576536151aca5a72780e
       with:
-        timeout_minutes: 45
-        max_attempts: 3
-        retry_on: error
+        timeout_minutes: 37
+        max_attempts: 7
         command: yarn dist --next
 
     - name: Build Pulsar Binaries (macOS) (Unsigned)
       if: ${{ runner.os == 'macOS' && github.event_name != 'push' }}
       uses: nick-fields/retry@7152eba30c6575329ac0576536151aca5a72780e
       with:
-        timeout_minutes: 45
-        max_attempts: 3
-        retry_on: error
+        timeout_minutes: 37
+        max_attempts: 7
         command: yarn dist --next
 
     - name: Build Pulsar Binaries

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -184,7 +184,7 @@ jobs:
         TEAM_ID: ${{ secrets.TEAM_ID }}
       uses: nick-fields/retry@7152eba30c6575329ac0576536151aca5a72780e
       with:
-        timeout_minutes: 37
+        timeout_minutes: 31
         max_attempts: 7
         command: yarn dist --next
 
@@ -192,7 +192,7 @@ jobs:
       if: ${{ runner.os == 'macOS' && github.event_name != 'push' }}
       uses: nick-fields/retry@7152eba30c6575329ac0576536151aca5a72780e
       with:
-        timeout_minutes: 37
+        timeout_minutes: 31
         max_attempts: 7
         command: yarn dist --next
 


### PR DESCRIPTION
Porting an IMO rather important (or at least frustration-reducing) PR from `master` branch to `updated-latest-electron`).

See original PR for details: #1178

Should ensure we get Linux and macOS Rolling bins for PulsarNext from GitHub Actions with much-improved consistency/reliability.