### PR TITLE
[markdown-preview] Update `dompurify` to 2.5.7

### DIFF
--- a/packages/markdown-preview/package-lock.json
+++ b/packages/markdown-preview/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "cheerio": "^1.0.0-rc.3",
         "dedent": "^1.5.3",
-        "dompurify": "^2.0.17",
+        "dompurify": "2.5.7",
         "emoji-images": "^0.1.1",
         "fs-plus": "^3.0.0",
         "github-markdown-css": "^5.5.1",
@@ -137,8 +137,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "2.4.7",
-      "license": "(MPL-2.0 OR Apache-2.0)"
+      "version": "2.5.7",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.5.7.tgz",
+      "integrity": "sha512-2q4bEI+coQM8f5ez7kt2xclg1XsecaV9ASJk/54vwlfRRNQfDqJz2pzQ8t0Ix/ToBpXlVjrRIx7pFC/o8itG2Q=="
     },
     "node_modules/domutils": {
       "version": "1.5.1",
@@ -475,7 +476,9 @@
       }
     },
     "dompurify": {
-      "version": "2.4.7"
+      "version": "2.5.7",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.5.7.tgz",
+      "integrity": "sha512-2q4bEI+coQM8f5ez7kt2xclg1XsecaV9ASJk/54vwlfRRNQfDqJz2pzQ8t0Ix/ToBpXlVjrRIx7pFC/o8itG2Q=="
     },
     "domutils": {
       "version": "1.5.1",

--- a/packages/markdown-preview/package.json
+++ b/packages/markdown-preview/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "cheerio": "^1.0.0-rc.3",
     "dedent": "^1.5.3",
-    "dompurify": "^2.0.17",
+    "dompurify": "2.5.7",
     "emoji-images": "^0.1.1",
     "fs-plus": "^3.0.0",
     "github-markdown-css": "^5.5.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3807,10 +3807,10 @@ dompurify@2.0.17:
   resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-2.0.17.tgz#505ffa126a580603df4007e034bdc9b6b738668e"
   integrity sha512-nNwwJfW55r8akD8MSFz6k75bzyT2y6JEa1O3JrZFBf+Y5R9JXXU4OsRl0B9hKoPgHTw2b7ER5yJ5Md97MMUJPg==
 
-dompurify@^2.0.17:
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-2.4.1.tgz#f9cb1a275fde9af6f2d0a2644ef648dd6847b631"
-  integrity sha512-ewwFzHzrrneRjxzmK6oVz/rZn9VWspGFRDb4/rRtIsM1n36t9AKma/ye8syCpcw+XJ25kOK/hOG7t1j2I2yBqA==
+dompurify@2.5.7:
+  version "2.5.7"
+  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-2.5.7.tgz#6e0d36b9177db5a99f18ade1f28579db5ab839d7"
+  integrity sha512-2q4bEI+coQM8f5ez7kt2xclg1XsecaV9ASJk/54vwlfRRNQfDqJz2pzQ8t0Ix/ToBpXlVjrRIx7pFC/o8itG2Q==
 
 dompurify@^3.0.6:
   version "3.0.6"
@@ -6685,7 +6685,7 @@ markdown-it@^13.0.2:
   dependencies:
     cheerio "^1.0.0-rc.3"
     dedent "^1.5.3"
-    dompurify "^2.0.17"
+    dompurify "2.5.7"
     emoji-images "^0.1.1"
     fs-plus "^3.0.0"
     github-markdown-css "^5.5.1"


### PR DESCRIPTION
This dependency hasn’t been updated in a while and it’s an important one to stay current on.

Also pinned to a known good release instead of relying on magical NPM caret behavior in the `package.json`.