### PR TITLE
Bump Ubuntu in CI to `ubuntu-latest`

### DIFF
--- a/.github/workflows/editor-tests.yml
+++ b/.github/workflows/editor-tests.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         # os: [ubuntu-20.04, macos-13, windows-2019]
-        os: [ubuntu-20.04, macos-13]
+        os: [ubuntu-latest, macos-13]
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/editor-tests.yml
+++ b/.github/workflows/editor-tests.yml
@@ -20,6 +20,9 @@ jobs:
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
+    - name: Install build dependencies
+      run: sudo apt-get update && sudo apt-get install -y libx11-dev libxkbfile-dev pkg-config libsecret-1-dev libncursesw5-dev libgdbm-dev libc6-dev libffi-dev
+    
     - name: Checkout the latest code
       uses: actions/checkout@v4
 

--- a/.github/workflows/editor-tests.yml
+++ b/.github/workflows/editor-tests.yml
@@ -21,6 +21,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - name: Install build dependencies
+      if: runner.os == 'Linux'
       run: sudo apt-get update && sudo apt-get install -y libx11-dev libxkbfile-dev pkg-config libsecret-1-dev libncursesw5-dev libgdbm-dev libc6-dev libffi-dev
     
     - name: Checkout the latest code

--- a/.github/workflows/package-tests-linux.yml
+++ b/.github/workflows/package-tests-linux.yml
@@ -12,7 +12,7 @@ jobs:
     if: |
       !startsWith(github.event.pull_request.title, '[skip-ci]') &&
       !startsWith(github.event.pull_request.title, '[skip-package-ci]')
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
     - name: Checkout the latest code
       uses: actions/checkout@v4
@@ -59,7 +59,7 @@ jobs:
   test:
     name: Package
     needs: setup
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       max-parallel: 8

--- a/.github/workflows/package-tests-linux.yml
+++ b/.github/workflows/package-tests-linux.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Install build dependencies
-      run: sudo apt-get update && sudo apt-get install -y libx11-dev libxkbfile-dev
+      run: sudo apt-get update && sudo apt-get install -y libx11-dev libxkbfile-dev pkg-config libsecret-1-dev libncursesw5-dev libgdbm-dev libc6-dev libffi-dev
 
     - name: Checkout the latest code
       uses: actions/checkout@v4

--- a/.github/workflows/package-tests-linux.yml
+++ b/.github/workflows/package-tests-linux.yml
@@ -14,6 +14,9 @@ jobs:
       !startsWith(github.event.pull_request.title, '[skip-package-ci]')
     runs-on: ubuntu-latest
     steps:
+    - name: Install build dependencies
+      run: apt-get update && apt-get install -y libx11-dev libxkbfile-dev
+
     - name: Checkout the latest code
       uses: actions/checkout@v4
 

--- a/.github/workflows/package-tests-linux.yml
+++ b/.github/workflows/package-tests-linux.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Install build dependencies
-      run: sudo apt-get update && apt-get install -y libx11-dev libxkbfile-dev
+      run: sudo apt-get update && sudo apt-get install -y libx11-dev libxkbfile-dev
 
     - name: Checkout the latest code
       uses: actions/checkout@v4

--- a/.github/workflows/package-tests-linux.yml
+++ b/.github/workflows/package-tests-linux.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Install build dependencies
-      run: apt-get update && apt-get install -y libx11-dev libxkbfile-dev
+      run: sudo apt-get update && apt-get install -y libx11-dev libxkbfile-dev
 
     - name: Checkout the latest code
       uses: actions/checkout@v4


### PR DESCRIPTION
Our CI has ground to a halt because of our love of slightly vintage technology.

Moving to `ubuntu-latest` should get us unstuck. And using `-latest` instead of pinning to a specific version is theoretically fine, since the actual binary is built inside Docker anyway.