### PR TITLE
Cirrus: Pin macOS builds to using Sonoma images

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -151,7 +151,7 @@ silicon_mac_task:
   only_if: $CIRRUS_CRON != "" || $CIRRUS_TAG != ""
   skip: $CIRRUS_CHANGE_IN_REPO == $CIRRUS_LAST_GREEN_CHANGE
   macos_instance:
-    image: ghcr.io/cirruslabs/macos-ventura-xcode:latest
+    image: ghcr.io/cirruslabs/macos-runner:sonoma
     memory: 8G
   env:
     CSC_LINK: ENCRYPTED[0078015a03bb6cfdbd80113ae5bbb6f448fd4bbbc40efd81bf2cb1554373046b475a4d7c77e3e3e82ac1ce2f7e3d2da5]


### PR DESCRIPTION
Pin our Cirrus macOS tasks to using a Sonoma-based image, the earliest image it offers for macOS at the moment, to work around a compilation issue we started hitting recently in our `node_modules/tree-sitter` dependency.

(We've been auto-upgraded to the latest OS Cirrus had available for a while now; currently, that's Sequoia.)

### Verification Process

Cirrus CI passed: https://cirrus-ci.com/task/6498265765511168