### PR TITLE
Ensure `watchPath` "de-normalizes" filesystem event paths if opted into…

### DIFF
--- a/spec/path-watcher-spec.js
+++ b/spec/path-watcher-spec.js
@@ -7,6 +7,7 @@ import { promisify } from 'util';
 
 import { CompositeDisposable } from 'event-kit';
 import { watchPath, stopAllWatchers } from '../src/path-watcher';
+const { conditionPromise } = require('./helpers/async-spec-helpers');
 
 temp.track();
 
@@ -14,10 +15,11 @@ const writeFile = promisify(fs.writeFile);
 const mkdir = promisify(fs.mkdir);
 const appendFile = promisify(fs.appendFile);
 const realpath = promisify(fs.realpath);
+const symlink = promisify(fs.symlink);
 
 const tempMkdir = promisify(temp.mkdir);
 
-describe('watchPath', function() {
+fdescribe('watchPath', function() {
   let subs;
 
   beforeEach(function() {
@@ -52,13 +54,6 @@ describe('watchPath', function() {
   }
 
   describe('watchPath()', function() {
-    it('resolves the returned promise when the watcher begins listening', async function() {
-      const rootDir = await tempMkdir('atom-fsmanager-test-');
-
-      const watcher = await watchPath(rootDir, {}, () => {});
-      expect(watcher.constructor.name).toBe('PathWatcher');
-    });
-
     it('reuses an existing native watcher and resolves getStartPromise immediately if attached to a running watcher', async function() {
       const rootDir = await tempMkdir('atom-fsmanager-test-');
 
@@ -67,6 +62,130 @@ describe('watchPath', function() {
 
       expect(watcher0.native).toBe(watcher1.native);
     });
+
+    let disposables;
+    beforeEach(() => {
+      disposables = new CompositeDisposable();
+    })
+
+    afterEach(() => {
+      disposables?.dispose();
+    })
+
+    it('resolves the returned promise when the watcher begins listening', async function () {
+      const rootDir = await tempMkdir('atom-fsmanager-test-');
+      const watcher = await watchPath(rootDir, {}, () => {});
+      disposables.add(watcher);
+      expect(watcher.constructor.name).toBe('PathWatcher');
+    });
+
+    it('reuses an existing native watcher and resolves getStartPromise immediately if attached to a running watcher', async function () {
+      const rootDir = await tempMkdir('atom-fsmanager-test-');
+
+      const watcher0 = await watchPath(rootDir, {}, () => {});
+      const watcher1 = await watchPath(rootDir, {}, () => {});
+
+      disposables.add(watcher0, watcher1);
+
+      expect(watcher0.native).toBe(watcher1.native);
+    });
+
+    it("returns paths that appear to descend from the given path, even when symlinks are involved", async () => {
+      jasmine.useRealClock();
+      const rootDir = await tempMkdir('atom-fsmanager-test-');
+      const realRootDir = await realpath(rootDir)
+      const symlinkedPath = temp.path({ suffix: '-symlinked' })
+      await symlink(realRootDir, symlinkedPath)
+
+      let events0 = [];
+      let watcher0 = await watchPath(realRootDir, {}, (events) => {
+        events0.push(...events);
+      });
+      let events1 = [];
+      let watcher1 = await watchPath(symlinkedPath, {}, (events) => {
+        events1.push(...events);
+      });
+
+      disposables.add(watcher0, watcher1);
+
+      await writeFile(path.join(realRootDir, 'foo.txt'), '!')
+      await conditionPromise(() => {
+        return events0.length > 0 && events1.length > 0 && events0.length === events1.length;
+      });
+
+      let [first0] = events0;
+      let [first1] = events1;
+
+      // Even though these two events describe the same filesystem action,
+      // their `path` properties don't match one another; they correspond to
+      // the paths given in their respective calls to `watchPath`.
+      expect(first0.path).not.toBe(first1.path);
+      expect(first0.path.startsWith(realRootDir)).toBe(true);
+      expect(first1.path.startsWith(symlinkedPath)).toBe(true);
+    })
+
+    it("returns real paths for events when the user opts into it via `rawPaths: true`", async () => {
+      jasmine.useRealClock();
+      const rootDir = await tempMkdir('atom-fsmanager-test-');
+      const realRootDir = await realpath(rootDir)
+      const symlinkedPath = temp.path({ suffix: '-symlinked' })
+      await symlink(realRootDir, symlinkedPath)
+      const realSymlinkedPath = await realpath(symlinkedPath)
+      console.log('Generated:', { rootDir, realRootDir, symlinkedPath, realSymlinkedPath });
+
+      let events0 = [];
+      let watcher0 = await watchPath(realRootDir, { rawPaths: true }, (events) => {
+        events0.push(...events);
+      });
+      let events1 = [];
+      let watcher1 = await watchPath(symlinkedPath, { rawPaths: true }, (events) => {
+        events1.push(...events);
+      });
+
+      disposables.add(watcher0, watcher1);
+
+      await writeFile(path.join(realRootDir, 'foo.txt'), '!')
+      await conditionPromise(() => {
+        return events0.length > 0 && events1.length > 0 &&
+          events0.length === events1.length;
+      });
+
+      let [first0] = events0;
+      let [first1] = events1;
+
+      // Because `rawPaths` is `true`, these events will have identical `path`
+      // properties that point to the file's true path on disk.
+      expect(first0.path).toBe(first1.path);
+      expect(first0.path.startsWith(realRootDir)).toBe(true);
+      expect(first1.path.startsWith(symlinkedPath)).toBe(false);
+    })
+
+    it("normalizes a path without resolving symlinks", async () => {
+      jasmine.useRealClock();
+      const rootDir = await tempMkdir('atom-fsmanager-test-');
+      const realRootDir = await realpath(rootDir);
+      const symlinkedPath = temp.path({ suffix: '-symlinked' })
+      await symlink(realRootDir, symlinkedPath);
+
+      const relativizedPath = `${symlinkedPath}${path.sep}..${path.sep}${path.basename(symlinkedPath)}`
+
+      let events0 = [];
+      let watcher0 = await watchPath(relativizedPath, {}, (events) => {
+        events0.push(...events);
+      });
+      disposables.add(watcher0);
+
+      await writeFile(path.join(realRootDir, 'foo.txt'), '!')
+      await conditionPromise(() => events0.length > 0);
+
+      let [first0] = events0;
+
+      // We want to ensure that the weird relative path the user gave to
+      // `watchPath` is resolved internally _without_ it pointing to the real
+      // path on disk.
+      expect(first0.path.startsWith(symlinkedPath)).toBe(true);
+      expect(first0.path.startsWith(relativizedPath)).toBe(false);
+    })
 
     it("reuses existing native watchers even while they're still starting", async function() {
       const rootDir = await tempMkdir('atom-fsmanager-test-');

--- a/spec/path-watcher-spec.js
+++ b/spec/path-watcher-spec.js
@@ -19,7 +19,7 @@ const symlink = promisify(fs.symlink);
 
 const tempMkdir = promisify(temp.mkdir);
 
-fdescribe('watchPath', function() {
+describe('watchPath', function() {
   let subs;
 
   beforeEach(function() {
@@ -90,7 +90,7 @@ fdescribe('watchPath', function() {
       expect(watcher0.native).toBe(watcher1.native);
     });
 
-    it("returns paths that appear to descend from the given path, even when symlinks are involved", async () => {
+    it("returns paths that appear to descend from the given path, even when symlinks are involved, when `realPaths` is `false`", async () => {
       jasmine.useRealClock();
       const rootDir = await tempMkdir('atom-fsmanager-test-');
       const realRootDir = await realpath(rootDir)
@@ -98,11 +98,11 @@ fdescribe('watchPath', function() {
       await symlink(realRootDir, symlinkedPath)
 
       let events0 = [];
-      let watcher0 = await watchPath(realRootDir, {}, (events) => {
+      let watcher0 = await watchPath(realRootDir, { realPaths: false }, (events) => {
         events0.push(...events);
       });
       let events1 = [];
-      let watcher1 = await watchPath(symlinkedPath, {}, (events) => {
+      let watcher1 = await watchPath(symlinkedPath, { realPaths: false }, (events) => {
         events1.push(...events);
       });
 
@@ -124,21 +124,20 @@ fdescribe('watchPath', function() {
       expect(first1.path.startsWith(symlinkedPath)).toBe(true);
     })
 
-    it("returns real paths for events when the user opts into it via `rawPaths: true`", async () => {
+    it("returns real paths for events when `realPaths` is `true`", async () => {
       jasmine.useRealClock();
       const rootDir = await tempMkdir('atom-fsmanager-test-');
       const realRootDir = await realpath(rootDir)
       const symlinkedPath = temp.path({ suffix: '-symlinked' })
       await symlink(realRootDir, symlinkedPath)
       const realSymlinkedPath = await realpath(symlinkedPath)
-      console.log('Generated:', { rootDir, realRootDir, symlinkedPath, realSymlinkedPath });
 
       let events0 = [];
-      let watcher0 = await watchPath(realRootDir, { rawPaths: true }, (events) => {
+      let watcher0 = await watchPath(realRootDir, { realPaths: true }, (events) => {
         events0.push(...events);
       });
       let events1 = [];
-      let watcher1 = await watchPath(symlinkedPath, { rawPaths: true }, (events) => {
+      let watcher1 = await watchPath(symlinkedPath, { realPaths: true }, (events) => {
         events1.push(...events);
       });
 
@@ -153,14 +152,14 @@ fdescribe('watchPath', function() {
       let [first0] = events0;
       let [first1] = events1;
 
-      // Because `rawPaths` is `true`, these events will have identical `path`
+      // Because `realPaths` is `true`, these events will have identical `path`
       // properties that point to the file's true path on disk.
       expect(first0.path).toBe(first1.path);
       expect(first0.path.startsWith(realRootDir)).toBe(true);
       expect(first1.path.startsWith(symlinkedPath)).toBe(false);
     })
 
-    it("normalizes a path without resolving symlinks", async () => {
+    it("normalizes a path without resolving symlinks when `realPaths` is `false`", async () => {
       jasmine.useRealClock();
       const rootDir = await tempMkdir('atom-fsmanager-test-');
       const realRootDir = await realpath(rootDir);
@@ -170,7 +169,7 @@ fdescribe('watchPath', function() {
       const relativizedPath = `${symlinkedPath}${path.sep}..${path.sep}${path.basename(symlinkedPath)}`
 
       let events0 = [];
-      let watcher0 = await watchPath(relativizedPath, {}, (events) => {
+      let watcher0 = await watchPath(relativizedPath, { realPaths: false }, (events) => {
         events0.push(...events);
       });
       disposables.add(watcher0);


### PR DESCRIPTION
…so that users of `watchPath` don't have to do their own realpath resolution.

I've been going through the PulsarNext package tests in order to fix some regressions. Many of them are related to file-change monitoring in one way or another. For all its faults, the old `pathwatcher` was able to start watching a file for changes in a totally synchronous manner (don't ask me how), which made it quite easy to write tests around. The new `pathwatcher` has the same synchronous API, but cannot guarantee instant subscription in an environment (like a spec suite!) where unsubscription and resubscription happen in rapid succession. This is annoying.

For this reason and others — like not wanting to be maintainers of our own file-watching library — we have a medium-term goal to replace our own `pathwatcher` library with `nsfw` across the board. In fact, the goal is convert usages of `pathwatcher` to a newer file-watching interface defined by Atom called `watchPath`; the idea is that we'd be further away from the bare metal of a particular file-watching library and could more easily migrate to a different one in the future should the need arise.

For that reason, I’ve tried to seize opportunities to convert usages of `pathwatcher` to `watchPath`.

But there’s a problem I’ve had to solve each time. Consider this `pathwatcher` code:

```js
const userSnippetsFile = new File(userSnippetsPath)
userSnippetsFileDisposable.add(userSnippetsFile.onDidChange(
  () => this.handleUserSnippetsDidChange()
))
userSnippetsFileDisposable.add(userSnippetsFile.onDidDelete(
  () => this.handleUserSnippetsDidChange()
))
userSnippetsFileDisposable.add(userSnippetsFile.onDidRename(
  () => this.handleUserSnippetsDidChange()
))
```

Here’s the rough analog of that code using `watchPath`:

```js
watchPath(path.dirname(userSnippetsFile), {}, (events) => {
  for (let event of events) {
    if (event.path === userSnippetsFile || event.oldPath === userSnippetsFile) {
      this.handleUserSnippetsDidChange();
      break;
    }
  }
})
```

This reflects the fact that `watchPath` watches directories, not individual files.

But this doesn’t work out of the box on my machine — the specs that test this behavior will fail.

Here’s why: the specs rely on the `temp` module to generate directories within `/tmp` to use as temporary `ATOM_HOME`s and the like… but on macOS, everything in `/tmp` is actually symlinked to `/private/tmp`! So `watchPath` will normalize the desired path to something that starts with `/private/tmp`, and all the filesystem events within the callback will have `path` and `oldPath` properties that start with `/private/tmp`. So all the equality checks will fail.

But this isn’t just a problem with specs, since symlinks can happen anywhere. So it needs fixing in the general case.

There’s one way to fix this that works just fine as long as you already know that `userSnippetsFile` exists and is an absolute path:

```js
let realUserSnippetsFile = fs.realPathSync(userSnippetsFile)
watchPath(path.dirname(realUserSnippetsFile), {}, (events) => {
  for (let event of events) {
    if (event.path === realUserSnippetsFile || event.oldPath === realUserSnippetsFile) {
      this.handleUserSnippetsDidChange();
      break;
    }
  }
})
```

But it’s not nice to make each consumer do this work when `watchPath` itself could handle it instead. That’s what this PR does:

* We add a new option to `watchPath` (which previously had no options — just an empty placeholder for future options!) called `realPaths`. It defaults to `false`.
* This new functionality is enabled when someone opts into it via `{ realPaths: true }`. When they do…
  * Everything about watchers still works identically. Each call to `watchPath` creates a `PathWatcher` instance, and multiple `PathWatcher`s are likely to share a single instance of `NativeWatcher`.
  * One filesystem event as generated by `NativeWatcher` will contain the canonical path on disk for the file and can be given to multiple `PathWatcher`s…
  * …but each `PathWatcher` knows the path the user specified and can generate its own custom “denormalized” version of the event with the paths the user might expect. (If no symlinks are involved, then `PathWatcher` will re-use the existing event.)

This is how `watchPath` should always have worked. I tried very hard to convince myself to make this the new default behavior… but it would theoretically be a breaking change, even though I doubt it would affect many packages.

At any rate, lots of packages won’t be using this API directly; they’ll use the `File` and `Directory` classes that are exported from `atom`. Those have been around for much longer and have built-in change monitoring via `onDidChange`, `onDidDelete`, et cetera.

But `atom` gets `File` and `Directory` straight from `pathwatcher`. If we really want to reduce reliance on `pathwatcher`, we’ll need to build new `File` and `Directory` wrappers that can behave identically enough but use `watchPath`. I’ll see about doing that as well.
