### PR TITLE
Experiment: Add `@parcel/watcher` as a file-watcher

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@babel/core": "7.18.6",
     "@electron/remote": "2.1.2",
     "@formatjs/fast-memoize": "^2.2.6",
+    "@parcel/watcher": "^2.5.1",
     "@pulsar-edit/atom-keymap": "^9.0.2",
     "@pulsar-edit/fuzzy-native": "1.3.0",
     "@pulsar-edit/get-scrollbar-style": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "etch": "0.14.1",
     "event-kit": "^2.5.3",
     "exception-reporting": "file:packages/exception-reporting",
+    "fdir": "6.4.6",
     "find-and-replace": "file:packages/find-and-replace",
     "find-parent-dir": "^0.3.0",
     "focus-trap": "6.3.0",

--- a/spec/path-watcher-spec.js
+++ b/spec/path-watcher-spec.js
@@ -375,7 +375,10 @@ describe('watchPath', function () {
         expect(watcher.constructor.name).toBe('PathWatcher');
       });
 
-      it('respects `core.ignoredNames`', async () => {
+      // TODO: File-watchers cannot respect `core.ignoredNames` by default
+      // without breaking backward-compatibility. Keeping this spec around for a
+      // future where we might use this new behavior on an opt-in basis.
+      xit('respects `core.ignoredNames`', async () => {
         jasmine.useRealClock();
 
         let existing = atom.config.get('core.ignoredNames');
@@ -536,44 +539,6 @@ describe('watchPath', function () {
     disposables?.dispose();
   })
 
-  // TODO: File-watchers cannot respect `core.ignoredNames` by default
-  // without breaking backward-compatibility. Keeping this spec around for a
-  // future where we might use this new behavior on an opt-in basis.
-  xit('respects `core.ignoredNames`', async () => {
-    jasmine.useRealClock();
-
-    let existing = atom.config.get('core.ignoredNames');
-    atom.config.set(
-      'core.ignoredNames',
-      [...existing, 'some-other-dir']
-    );
-
-    const rootDir = await tempMkdir('atom-fsmanager-test-');
-
-    // Create a directory that will be affected by our `core.ignoredNames`
-    // value.
-    let ignoredDir = path.join(rootDir, 'some-other-dir');
-    await mkdir(ignoredDir, { recursive: true });
-
-    let spy = jasmine.createSpy();
-
-    let watcher = await watchPath(rootDir, {}, spy);
-    disposables.add(watcher);
-
-    // Writing a file to a path within an ignored directory should not
-    // trigger the callback…
-    await writeFile(path.join(ignoredDir, 'foo.txt'), 'something');
-    // (file-watchers might have a debounce interval)
-    await wait(1000);
-    expect(spy).not.toHaveBeenCalled();
-
-    // …but writing a file to a path outside of an ignored directory should
-    // trigger the callback.
-    await writeFile(path.join(rootDir, 'foo.txt'), 'something');
-    // (file-watchers might have a debounce interval)
-    await wait(1000);
-    expect(spy).toHaveBeenCalled();
-  });
 
   it('reuses an existing native watcher and resolves getStartPromise immediately if attached to a running watcher', async function () {
     const rootDir = await tempMkdir('atom-fsmanager-test-');

--- a/spec/path-watcher-spec.js
+++ b/spec/path-watcher-spec.js
@@ -352,7 +352,7 @@ describe('watchPath', function () {
   const WATCHER_IMPLEMENTATIONS = ['nsfw', 'parcel'];
 
   for (let impl of WATCHER_IMPLEMENTATIONS) {
-    describe(`watchPath() (${impl})`, function () {
+    describe(`(${impl} implementation)`, function () {
       let disposables;
       beforeEach(async () => {
         jasmine.useRealClock();
@@ -366,6 +366,17 @@ describe('watchPath', function () {
 
       afterEach(() => {
         disposables?.dispose();
+      });
+
+      it('reuses an existing native watcher and resolves getStartPromise immediately if attached to a running watcher', async function () {
+        const rootDir = await tempMkdir('atom-fsmanager-test-');
+
+        const watcher0 = await watchPath(rootDir, {}, () => {});
+        const watcher1 = await watchPath(rootDir, {}, () => {});
+
+        disposables.add(watcher0, watcher1);
+
+        expect(watcher0.native).toBe(watcher1.native);
       });
 
       it('resolves the returned promise when the watcher begins listening', async function () {
@@ -526,244 +537,106 @@ describe('watchPath', function () {
           parentWatcherChanges
         ]);
       });
+
+      it("returns paths that appear to descend from the given path, even when symlinks are involved, when `realPaths` is `false`", async () => {
+        jasmine.useRealClock();
+        const rootDir = await tempMkdir('atom-fsmanager-test-');
+        const realRootDir = await realpath(rootDir);
+        const symlinkedPath = temp.path({ suffix: '-symlinked' });
+        await symlink(realRootDir, symlinkedPath);
+
+        let events0 = [];
+        let watcher0 = await watchPath(realRootDir, { realPaths: false }, (events) => {
+          console.log('watched 0', events);
+          events0.push(...events);
+        });
+
+        let events1 = [];
+        let watcher1 = await watchPath(symlinkedPath, { realPaths: false }, (events) => {
+          console.log('watched 1', events);
+          events1.push(...events);
+        });
+
+        disposables.add(watcher0, watcher1);
+
+        await writeFile(path.join(realRootDir, 'foo.txt'), '!')
+        await conditionPromise(() => {
+          return events0.length > 0 && events1.length > 0 && events0.length === events1.length;
+        });
+
+        let [first0] = events0;
+        let [first1] = events1;
+
+        // Even though these two events describe the same filesystem action,
+        // their `path` properties don't match one another; they correspond to
+        // the paths given in their respective calls to `watchPath`.
+        expect(first0.path).not.toBe(first1.path);
+        expect(first0.path.startsWith(realRootDir)).toBe(true);
+        expect(first1.path.startsWith(symlinkedPath)).toBe(true);
+      });
+
+      it("returns real paths for events when `realPaths` is `true`", async () => {
+        jasmine.useRealClock();
+        const rootDir = await tempMkdir('atom-fsmanager-test-');
+        const realRootDir = await realpath(rootDir);
+        const symlinkedPath = temp.path({ suffix: '-symlinked' });
+        await symlink(realRootDir, symlinkedPath);
+        // const realSymlinkedPath = await realpath(symlinkedPath);
+
+        let events0 = [];
+        let watcher0 = await watchPath(realRootDir, { realPaths: true }, (events) => {
+          events0.push(...events);
+        });
+        let events1 = [];
+        let watcher1 = await watchPath(symlinkedPath, { realPaths: true }, (events) => {
+          events1.push(...events);
+        });
+
+        disposables.add(watcher0, watcher1);
+
+        await writeFile(path.join(realRootDir, 'foo.txt'), '!')
+        await conditionPromise(() => {
+          return events0.length > 0 && events1.length > 0 &&
+            events0.length === events1.length;
+        });
+
+        let [first0] = events0;
+        let [first1] = events1;
+
+        // Because `realPaths` is `true`, these events will have identical `path`
+        // properties that point to the file's true path on disk.
+        expect(first0.path).toBe(first1.path);
+        expect(first0.path.startsWith(realRootDir)).toBe(true);
+        expect(first1.path.startsWith(symlinkedPath)).toBe(false);
+      })
+
+      it("normalizes a path without resolving symlinks when `realPaths` is `false`", async () => {
+        jasmine.useRealClock();
+        const rootDir = await tempMkdir('atom-fsmanager-test-');
+        const realRootDir = await realpath(rootDir);
+        const symlinkedPath = temp.path({ suffix: '-symlinked' })
+        await symlink(realRootDir, symlinkedPath);
+
+        const relativizedPath = `${symlinkedPath}${path.sep}..${path.sep}${path.basename(symlinkedPath)}`
+
+        let events0 = [];
+        let watcher0 = await watchPath(relativizedPath, { realPaths: false }, (events) => {
+          events0.push(...events);
+        });
+        disposables.add(watcher0);
+
+        await writeFile(path.join(realRootDir, 'foo.txt'), '!')
+        await conditionPromise(() => events0.length > 0);
+
+        let [first0] = events0;
+
+        // We want to ensure that the weird relative path the user gave to
+        // `watchPath` is resolved internally _without_ it pointing to the real
+        // path on disk.
+        expect(first0.path.startsWith(symlinkedPath)).toBe(true);
+        expect(first0.path.startsWith(relativizedPath)).toBe(false);
+      });
+
     });
   }
-
-
-  let disposables;
-  beforeEach(() => {
-    disposables = new CompositeDisposable();
-  })
-
-  afterEach(() => {
-    disposables?.dispose();
-  })
-
-
-  it('reuses an existing native watcher and resolves getStartPromise immediately if attached to a running watcher', async function () {
-    const rootDir = await tempMkdir('atom-fsmanager-test-');
-
-    const watcher0 = await watchPath(rootDir, {}, () => {});
-    const watcher1 = await watchPath(rootDir, {}, () => {});
-
-    disposables.add(watcher0, watcher1);
-
-    expect(watcher0.native).toBe(watcher1.native);
-  });
-
-  it('resolves the returned promise when the watcher begins listening', async function () {
-    const rootDir = await tempMkdir('atom-fsmanager-test-');
-    const watcher = await watchPath(rootDir, {}, () => {});
-    disposables.add(watcher);
-    expect(watcher.constructor.name).toBe('PathWatcher');
-  });
-
-  it('reuses an existing native watcher and resolves getStartPromise immediately if attached to a running watcher', async function () {
-    const rootDir = await tempMkdir('atom-fsmanager-test-');
-
-    const watcher0 = await watchPath(rootDir, {}, () => {});
-    const watcher1 = await watchPath(rootDir, {}, () => {});
-
-    disposables.add(watcher0, watcher1);
-
-    expect(watcher0.native).toBe(watcher1.native);
-  });
-
-  it("returns paths that appear to descend from the given path, even when symlinks are involved, when `realPaths` is `false`", async () => {
-    jasmine.useRealClock();
-    const rootDir = await tempMkdir('atom-fsmanager-test-');
-    const realRootDir = await realpath(rootDir)
-    const symlinkedPath = temp.path({ suffix: '-symlinked' })
-    await symlink(realRootDir, symlinkedPath)
-
-    let events0 = [];
-    let watcher0 = await watchPath(realRootDir, { realPaths: false }, (events) => {
-      events0.push(...events);
-    });
-    let events1 = [];
-    let watcher1 = await watchPath(symlinkedPath, { realPaths: false }, (events) => {
-      events1.push(...events);
-    });
-
-    disposables.add(watcher0, watcher1);
-
-    await writeFile(path.join(realRootDir, 'foo.txt'), '!')
-    await conditionPromise(() => {
-      return events0.length > 0 && events1.length > 0 && events0.length === events1.length;
-    });
-
-    let [first0] = events0;
-    let [first1] = events1;
-
-    // Even though these two events describe the same filesystem action,
-    // their `path` properties don't match one another; they correspond to
-    // the paths given in their respective calls to `watchPath`.
-    expect(first0.path).not.toBe(first1.path);
-    expect(first0.path.startsWith(realRootDir)).toBe(true);
-    expect(first1.path.startsWith(symlinkedPath)).toBe(true);
-  })
-
-  it("returns real paths for events when `realPaths` is `true`", async () => {
-    jasmine.useRealClock();
-    const rootDir = await tempMkdir('atom-fsmanager-test-');
-    const realRootDir = await realpath(rootDir)
-    const symlinkedPath = temp.path({ suffix: '-symlinked' })
-    await symlink(realRootDir, symlinkedPath)
-    const realSymlinkedPath = await realpath(symlinkedPath)
-
-    let events0 = [];
-    let watcher0 = await watchPath(realRootDir, { realPaths: true }, (events) => {
-      events0.push(...events);
-    });
-    let events1 = [];
-    let watcher1 = await watchPath(symlinkedPath, { realPaths: true }, (events) => {
-      events1.push(...events);
-    });
-
-    disposables.add(watcher0, watcher1);
-
-    await writeFile(path.join(realRootDir, 'foo.txt'), '!')
-    await conditionPromise(() => {
-      return events0.length > 0 && events1.length > 0 &&
-        events0.length === events1.length;
-    });
-
-    let [first0] = events0;
-    let [first1] = events1;
-
-    // Because `realPaths` is `true`, these events will have identical `path`
-    // properties that point to the file's true path on disk.
-    expect(first0.path).toBe(first1.path);
-    expect(first0.path.startsWith(realRootDir)).toBe(true);
-    expect(first1.path.startsWith(symlinkedPath)).toBe(false);
-  })
-
-  it("normalizes a path without resolving symlinks when `realPaths` is `false`", async () => {
-    jasmine.useRealClock();
-    const rootDir = await tempMkdir('atom-fsmanager-test-');
-    const realRootDir = await realpath(rootDir);
-    const symlinkedPath = temp.path({ suffix: '-symlinked' })
-    await symlink(realRootDir, symlinkedPath);
-
-    const relativizedPath = `${symlinkedPath}${path.sep}..${path.sep}${path.basename(symlinkedPath)}`
-
-    let events0 = [];
-    let watcher0 = await watchPath(relativizedPath, { realPaths: false }, (events) => {
-      events0.push(...events);
-    });
-    disposables.add(watcher0);
-
-    await writeFile(path.join(realRootDir, 'foo.txt'), '!')
-    await conditionPromise(() => events0.length > 0);
-
-    let [first0] = events0;
-
-    // We want to ensure that the weird relative path the user gave to
-    // `watchPath` is resolved internally _without_ it pointing to the real
-    // path on disk.
-    expect(first0.path.startsWith(symlinkedPath)).toBe(true);
-    expect(first0.path.startsWith(relativizedPath)).toBe(false);
-  })
-
-  it("reuses existing native watchers even while they're still starting", async function () {
-    const rootDir = await tempMkdir('atom-fsmanager-test-');
-
-    const [watcher0, watcher1] = await Promise.all([
-      watchPath(rootDir, {}, () => {}),
-      watchPath(rootDir, {}, () => {})
-    ]);
-    expect(watcher0.native).toBe(watcher1.native);
-  });
-
-  it("doesn't attach new watchers to a native watcher that's stopping", async function () {
-    const rootDir = await tempMkdir('atom-fsmanager-test-');
-
-    const watcher0 = await watchPath(rootDir, {}, () => {});
-    const native0 = watcher0.native;
-
-    watcher0.dispose();
-    const watcher1 = await watchPath(rootDir, {}, () => {});
-
-    expect(watcher1.native).not.toBe(native0);
-  });
-
-  it('reuses an existing native watcher on a parent directory and filters events', async function () {
-    const rootDir = await tempMkdir('atom-fsmanager-test-').then(realpath);
-    const rootFile = path.join(rootDir, 'rootfile.txt');
-    const subDir = path.join(rootDir, 'subdir');
-    const subFile = path.join(subDir, 'subfile.txt');
-
-    await mkdir(subDir);
-
-    // Keep the watchers alive with an undisposed subscription
-    const rootWatcher = await watchPath(rootDir, {}, () => {});
-    const childWatcher = await watchPath(subDir, {}, () => {});
-
-    expect(rootWatcher.native).toBe(childWatcher.native);
-    expect(rootWatcher.native.isRunning()).toBe(true);
-
-    const firstChanges = Promise.all([
-      waitForChanges(rootWatcher, subFile),
-      waitForChanges(childWatcher, subFile)
-    ]);
-    await writeFile(subFile, 'subfile\n', { encoding: 'utf8' });
-    await firstChanges;
-
-    const nextRootEvent = waitForChanges(rootWatcher, rootFile);
-    await writeFile(rootFile, 'rootfile\n', { encoding: 'utf8' });
-    await nextRootEvent;
-  });
-
-  it('adopts existing child watchers and filters events appropriately to them', async function () {
-    const parentDir = await tempMkdir('atom-fsmanager-test-').then(realpath);
-
-    // Create the directory tree
-    const rootFile = path.join(parentDir, 'rootfile.txt');
-    const subDir0 = path.join(parentDir, 'subdir0');
-    const subFile0 = path.join(subDir0, 'subfile0.txt');
-    const subDir1 = path.join(parentDir, 'subdir1');
-    const subFile1 = path.join(subDir1, 'subfile1.txt');
-
-    await mkdir(subDir0);
-    await mkdir(subDir1);
-    await Promise.all([
-      writeFile(rootFile, 'rootfile\n', { encoding: 'utf8' }),
-      writeFile(subFile0, 'subfile 0\n', { encoding: 'utf8' }),
-      writeFile(subFile1, 'subfile 1\n', { encoding: 'utf8' })
-    ]);
-
-    // Begin the child watchers and keep them alive
-    const subWatcher0 = await watchPath(subDir0, {}, () => {});
-    const subWatcherChanges0 = waitForChanges(subWatcher0, subFile0);
-
-    const subWatcher1 = await watchPath(subDir1, {}, () => {});
-    const subWatcherChanges1 = waitForChanges(subWatcher1, subFile1);
-
-    expect(subWatcher0.native).not.toBe(subWatcher1.native);
-
-    // Create the parent watcher
-    const parentWatcher = await watchPath(parentDir, {}, () => {});
-    const parentWatcherChanges = waitForChanges(
-      parentWatcher,
-      rootFile,
-      subFile0,
-      subFile1
-    );
-
-    expect(subWatcher0.native).toBe(parentWatcher.native);
-    expect(subWatcher1.native).toBe(parentWatcher.native);
-
-    // Ensure events are filtered correctly
-    await Promise.all([
-      appendFile(rootFile, 'change\n', { encoding: 'utf8' }),
-      appendFile(subFile0, 'change\n', { encoding: 'utf8' }),
-      appendFile(subFile1, 'change\n', { encoding: 'utf8' })
-    ]);
-
-    await Promise.all([
-      subWatcherChanges0,
-      subWatcherChanges1,
-      parentWatcherChanges
-    ]);
-  });
 });

--- a/spec/path-watcher-spec.js
+++ b/spec/path-watcher-spec.js
@@ -349,11 +349,182 @@ describe('watchPath', function () {
     });
   }
 
-  describe('watchPath()', function () {
-    let disposables;
-    beforeEach(() => {
-      disposables = new CompositeDisposable();
+  const WATCHER_IMPLEMENTATIONS = ['nsfw', 'parcel'];
+
+  for (let impl of WATCHER_IMPLEMENTATIONS) {
+    describe(`watchPath() (${impl})`, function () {
+      let disposables;
+      beforeEach(async () => {
+        jasmine.useRealClock();
+        atom.config.set('core.fileSystemWatcher', impl);
+        // Changing the config setting will trigger an async transition to new
+        // file-watchers. This helper method lets us wait until that transition
+        // has finished.
+        await watchPath.waitForTransition();
+        disposables = new CompositeDisposable();
+      });
+
+      afterEach(() => {
+        disposables?.dispose();
+      });
+
+      it('resolves the returned promise when the watcher begins listening', async function () {
+        const rootDir = await tempMkdir('atom-fsmanager-test-');
+        const watcher = await watchPath(rootDir, {}, () => {});
+        disposables.add(watcher);
+        expect(watcher.constructor.name).toBe('PathWatcher');
+      });
+
+      it('respects `core.ignoredNames`', async () => {
+        jasmine.useRealClock();
+
+        let existing = atom.config.get('core.ignoredNames');
+        atom.config.set(
+          'core.ignoredNames',
+          [...existing, 'some-other-dir']
+        );
+
+        const rootDir = await tempMkdir('atom-fsmanager-test-');
+
+        // Create a directory that will be affected by our `core.ignoredNames`
+        // value.
+        let ignoredDir = path.join(rootDir, 'some-other-dir');
+        await mkdir(ignoredDir, { recursive: true });
+
+        let spy = jasmine.createSpy();
+
+        let watcher = await watchPath(rootDir, {}, spy);
+        disposables.add(watcher);
+
+        // Writing a file to a path within an ignored directory should not
+        // trigger the callback…
+        await writeFile(path.join(ignoredDir, 'foo.txt'), 'something');
+        // (file-watchers might have a debounce interval)
+        await wait(1000);
+        expect(spy).not.toHaveBeenCalled();
+
+        // …but writing a file to a path outside of an ignored directory should
+        // trigger the callback.
+        await writeFile(path.join(rootDir, 'foo.txt'), 'something');
+        // (file-watchers might have a debounce interval)
+        await wait(1000);
+        expect(spy).toHaveBeenCalled();
+      });
+
+      it('reuses an existing native watcher and resolves getStartPromise immediately if attached to a running watcher', async function () {
+        const rootDir = await tempMkdir('atom-fsmanager-test-');
+
+        const watcher0 = await watchPath(rootDir, {}, () => {});
+        const watcher1 = await watchPath(rootDir, {}, () => {});
+
+        disposables.add(watcher0, watcher1);
+
+        expect(watcher0.native).toBe(watcher1.native);
+      });
+
+      it("reuses existing native watchers even while they're still starting", async function () {
+        const rootDir = await tempMkdir('atom-fsmanager-test-');
+
+        const [watcher0, watcher1] = await Promise.all([
+          watchPath(rootDir, {}, () => {}),
+          watchPath(rootDir, {}, () => {})
+        ]);
+        expect(watcher0.native).toBe(watcher1.native);
+      });
+
+      it("doesn't attach new watchers to a native watcher that's stopping", async function () {
+        const rootDir = await tempMkdir('atom-fsmanager-test-');
+
+        const watcher0 = await watchPath(rootDir, {}, () => {});
+        const native0 = watcher0.native;
+
+        watcher0.dispose();
+        const watcher1 = await watchPath(rootDir, {}, () => {});
+
+        expect(watcher1.native).not.toBe(native0);
+      });
+
+      it('reuses an existing native watcher on a parent directory and filters events', async function () {
+        const rootDir = await tempMkdir('atom-fsmanager-test-').then(realpath);
+        const rootFile = path.join(rootDir, 'rootfile.txt');
+        const subDir = path.join(rootDir, 'subdir');
+        const subFile = path.join(subDir, 'subfile.txt');
+
+        await mkdir(subDir);
+
+        // Keep the watchers alive with an undisposed subscription
+        const rootWatcher = await watchPath(rootDir, {}, () => {});
+        const childWatcher = await watchPath(subDir, {}, () => {});
+
+        expect(rootWatcher.native).toBe(childWatcher.native);
+        expect(rootWatcher.native.isRunning()).toBe(true);
+
+        const firstChanges = Promise.all([
+          waitForChanges(rootWatcher, subFile),
+          waitForChanges(childWatcher, subFile)
+        ]);
+        await writeFile(subFile, 'subfile\n', { encoding: 'utf8' });
+        await firstChanges;
+
+        const nextRootEvent = waitForChanges(rootWatcher, rootFile);
+        await writeFile(rootFile, 'rootfile\n', { encoding: 'utf8' });
+        await nextRootEvent;
+      });
+
+      it('adopts existing child watchers and filters events appropriately to them', async function () {
+        const parentDir = await tempMkdir('atom-fsmanager-test-').then(realpath);
+
+        // Create the directory tree
+        const rootFile = path.join(parentDir, 'rootfile.txt');
+        const subDir0 = path.join(parentDir, 'subdir0');
+        const subFile0 = path.join(subDir0, 'subfile0.txt');
+        const subDir1 = path.join(parentDir, 'subdir1');
+        const subFile1 = path.join(subDir1, 'subfile1.txt');
+
+        await mkdir(subDir0);
+        await mkdir(subDir1);
+        await Promise.all([
+          writeFile(rootFile, 'rootfile\n', { encoding: 'utf8' }),
+          writeFile(subFile0, 'subfile 0\n', { encoding: 'utf8' }),
+          writeFile(subFile1, 'subfile 1\n', { encoding: 'utf8' })
+        ]);
+
+        // Begin the child watchers and keep them alive
+        const subWatcher0 = await watchPath(subDir0, {}, () => {});
+        const subWatcherChanges0 = waitForChanges(subWatcher0, subFile0);
+
+        const subWatcher1 = await watchPath(subDir1, {}, () => {});
+        const subWatcherChanges1 = waitForChanges(subWatcher1, subFile1);
+
+        expect(subWatcher0.native).not.toBe(subWatcher1.native);
+
+        // Create the parent watcher
+        const parentWatcher = await watchPath(parentDir, {}, () => {});
+        const parentWatcherChanges = waitForChanges(
+          parentWatcher,
+          rootFile,
+          subFile0,
+          subFile1
+        );
+
+        expect(subWatcher0.native).toBe(parentWatcher.native);
+        expect(subWatcher1.native).toBe(parentWatcher.native);
+
+        // Ensure events are filtered correctly
+        await Promise.all([
+          appendFile(rootFile, 'change\n', { encoding: 'utf8' }),
+          appendFile(subFile0, 'change\n', { encoding: 'utf8' }),
+          appendFile(subFile1, 'change\n', { encoding: 'utf8' })
+        ]);
+
+        await Promise.all([
+          subWatcherChanges0,
+          subWatcherChanges1,
+          parentWatcherChanges
+        ]);
+      });
     });
+  }
 
     afterEach(() => {
       disposables?.dispose();

--- a/spec/path-watcher-spec.js
+++ b/spec/path-watcher-spec.js
@@ -44,7 +44,7 @@ describe('File', () => {
     file.unsubscribeFromNativeChangeEvents();
     fs.removeSync(filePath);
     closeAllWatchers();
-    await stopAllWatchers();
+    await watchPath.reset();
     await wait(100);
   });
 
@@ -324,7 +324,7 @@ describe('watchPath', function () {
 
   afterEach(async function () {
     subs.dispose();
-    await stopAllWatchers();
+    await watchPath.reset();
   });
 
   function waitForChanges(watcher, ...fileNames) {

--- a/spec/path-watcher-spec.js
+++ b/spec/path-watcher-spec.js
@@ -526,287 +526,279 @@ describe('watchPath', function () {
     });
   }
 
-    afterEach(() => {
-      disposables?.dispose();
+
+  let disposables;
+  beforeEach(() => {
+    disposables = new CompositeDisposable();
+  })
+
+  afterEach(() => {
+    disposables?.dispose();
+  })
+
+  // TODO: File-watchers cannot respect `core.ignoredNames` by default
+  // without breaking backward-compatibility. Keeping this spec around for a
+  // future where we might use this new behavior on an opt-in basis.
+  xit('respects `core.ignoredNames`', async () => {
+    jasmine.useRealClock();
+
+    let existing = atom.config.get('core.ignoredNames');
+    atom.config.set(
+      'core.ignoredNames',
+      [...existing, 'some-other-dir']
+    );
+
+    const rootDir = await tempMkdir('atom-fsmanager-test-');
+
+    // Create a directory that will be affected by our `core.ignoredNames`
+    // value.
+    let ignoredDir = path.join(rootDir, 'some-other-dir');
+    await mkdir(ignoredDir, { recursive: true });
+
+    let spy = jasmine.createSpy();
+
+    let watcher = await watchPath(rootDir, {}, spy);
+    disposables.add(watcher);
+
+    // Writing a file to a path within an ignored directory should not
+    // trigger the callback…
+    await writeFile(path.join(ignoredDir, 'foo.txt'), 'something');
+    // (file-watchers might have a debounce interval)
+    await wait(1000);
+    expect(spy).not.toHaveBeenCalled();
+
+    // …but writing a file to a path outside of an ignored directory should
+    // trigger the callback.
+    await writeFile(path.join(rootDir, 'foo.txt'), 'something');
+    // (file-watchers might have a debounce interval)
+    await wait(1000);
+    expect(spy).toHaveBeenCalled();
+  });
+
+  it('reuses an existing native watcher and resolves getStartPromise immediately if attached to a running watcher', async function () {
+    const rootDir = await tempMkdir('atom-fsmanager-test-');
+
+    const watcher0 = await watchPath(rootDir, {}, () => {});
+    const watcher1 = await watchPath(rootDir, {}, () => {});
+
+    disposables.add(watcher0, watcher1);
+
+    expect(watcher0.native).toBe(watcher1.native);
+  });
+
+  it('resolves the returned promise when the watcher begins listening', async function () {
+    const rootDir = await tempMkdir('atom-fsmanager-test-');
+    const watcher = await watchPath(rootDir, {}, () => {});
+    disposables.add(watcher);
+    expect(watcher.constructor.name).toBe('PathWatcher');
+  });
+
+  it('reuses an existing native watcher and resolves getStartPromise immediately if attached to a running watcher', async function () {
+    const rootDir = await tempMkdir('atom-fsmanager-test-');
+
+    const watcher0 = await watchPath(rootDir, {}, () => {});
+    const watcher1 = await watchPath(rootDir, {}, () => {});
+
+    disposables.add(watcher0, watcher1);
+
+    expect(watcher0.native).toBe(watcher1.native);
+  });
+
+  it("returns paths that appear to descend from the given path, even when symlinks are involved, when `realPaths` is `false`", async () => {
+    jasmine.useRealClock();
+    const rootDir = await tempMkdir('atom-fsmanager-test-');
+    const realRootDir = await realpath(rootDir)
+    const symlinkedPath = temp.path({ suffix: '-symlinked' })
+    await symlink(realRootDir, symlinkedPath)
+
+    let events0 = [];
+    let watcher0 = await watchPath(realRootDir, { realPaths: false }, (events) => {
+      events0.push(...events);
+    });
+    let events1 = [];
+    let watcher1 = await watchPath(symlinkedPath, { realPaths: false }, (events) => {
+      events1.push(...events);
     });
 
-    it('resolves the returned promise when the watcher begins listening', async function () {
-      const rootDir = await tempMkdir('atom-fsmanager-test-');
-      const watcher = await watchPath(rootDir, {}, () => {});
-      disposables.add(watcher);
-      expect(watcher.constructor.name).toBe('PathWatcher');
+    disposables.add(watcher0, watcher1);
+
+    await writeFile(path.join(realRootDir, 'foo.txt'), '!')
+    await conditionPromise(() => {
+      return events0.length > 0 && events1.length > 0 && events0.length === events1.length;
     });
 
-    it('respects `core.ignoredNames`', async () => {
-      jasmine.useRealClock();
+    let [first0] = events0;
+    let [first1] = events1;
 
-      let existing = atom.config.get('core.ignoredNames');
-      atom.config.set(
-        'core.ignoredNames',
-        [...existing, 'some-other-dir']
-      );
+    // Even though these two events describe the same filesystem action,
+    // their `path` properties don't match one another; they correspond to
+    // the paths given in their respective calls to `watchPath`.
+    expect(first0.path).not.toBe(first1.path);
+    expect(first0.path.startsWith(realRootDir)).toBe(true);
+    expect(first1.path.startsWith(symlinkedPath)).toBe(true);
+  })
 
-      const rootDir = await tempMkdir('atom-fsmanager-test-');
+  it("returns real paths for events when `realPaths` is `true`", async () => {
+    jasmine.useRealClock();
+    const rootDir = await tempMkdir('atom-fsmanager-test-');
+    const realRootDir = await realpath(rootDir)
+    const symlinkedPath = temp.path({ suffix: '-symlinked' })
+    await symlink(realRootDir, symlinkedPath)
+    const realSymlinkedPath = await realpath(symlinkedPath)
 
-      // Create a directory that will be affected by our `core.ignoredNames`
-      // value.
-      let ignoredDir = path.join(rootDir, 'some-other-dir');
-      await mkdir(ignoredDir, { recursive: true });
-
-      let spy = jasmine.createSpy();
-
-      let watcher = await watchPath(rootDir, {}, spy);
-      disposables.add(watcher);
-
-      // Writing a file to a path within an ignored directory should not
-      // trigger the callback…
-      await writeFile(path.join(ignoredDir, 'foo.txt'), 'something');
-      // (file-watchers might have a debounce interval)
-      await wait(1000);
-      expect(spy).not.toHaveBeenCalled();
-
-      // …but writing a file to a path outside of an ignored directory should
-      // trigger the callback.
-      await writeFile(path.join(rootDir, 'foo.txt'), 'something');
-      // (file-watchers might have a debounce interval)
-      await wait(1000);
-      expect(spy).toHaveBeenCalled();
+    let events0 = [];
+    let watcher0 = await watchPath(realRootDir, { realPaths: true }, (events) => {
+      events0.push(...events);
+    });
+    let events1 = [];
+    let watcher1 = await watchPath(symlinkedPath, { realPaths: true }, (events) => {
+      events1.push(...events);
     });
 
-    it('reuses an existing native watcher and resolves getStartPromise immediately if attached to a running watcher', async function () {
-      const rootDir = await tempMkdir('atom-fsmanager-test-');
+    disposables.add(watcher0, watcher1);
 
-      const watcher0 = await watchPath(rootDir, {}, () => {});
-      const watcher1 = await watchPath(rootDir, {}, () => {});
-
-      disposables.add(watcher0, watcher1);
-
-      expect(watcher0.native).toBe(watcher1.native);
+    await writeFile(path.join(realRootDir, 'foo.txt'), '!')
+    await conditionPromise(() => {
+      return events0.length > 0 && events1.length > 0 &&
+        events0.length === events1.length;
     });
 
-    let disposables;
-    beforeEach(() => {
-      disposables = new CompositeDisposable();
-    })
+    let [first0] = events0;
+    let [first1] = events1;
 
-    afterEach(() => {
-      disposables?.dispose();
-    })
+    // Because `realPaths` is `true`, these events will have identical `path`
+    // properties that point to the file's true path on disk.
+    expect(first0.path).toBe(first1.path);
+    expect(first0.path.startsWith(realRootDir)).toBe(true);
+    expect(first1.path.startsWith(symlinkedPath)).toBe(false);
+  })
 
-    it('resolves the returned promise when the watcher begins listening', async function () {
-      const rootDir = await tempMkdir('atom-fsmanager-test-');
-      const watcher = await watchPath(rootDir, {}, () => {});
-      disposables.add(watcher);
-      expect(watcher.constructor.name).toBe('PathWatcher');
+  it("normalizes a path without resolving symlinks when `realPaths` is `false`", async () => {
+    jasmine.useRealClock();
+    const rootDir = await tempMkdir('atom-fsmanager-test-');
+    const realRootDir = await realpath(rootDir);
+    const symlinkedPath = temp.path({ suffix: '-symlinked' })
+    await symlink(realRootDir, symlinkedPath);
+
+    const relativizedPath = `${symlinkedPath}${path.sep}..${path.sep}${path.basename(symlinkedPath)}`
+
+    let events0 = [];
+    let watcher0 = await watchPath(relativizedPath, { realPaths: false }, (events) => {
+      events0.push(...events);
     });
+    disposables.add(watcher0);
 
-    it('reuses an existing native watcher and resolves getStartPromise immediately if attached to a running watcher', async function () {
-      const rootDir = await tempMkdir('atom-fsmanager-test-');
+    await writeFile(path.join(realRootDir, 'foo.txt'), '!')
+    await conditionPromise(() => events0.length > 0);
 
-      const watcher0 = await watchPath(rootDir, {}, () => {});
-      const watcher1 = await watchPath(rootDir, {}, () => {});
+    let [first0] = events0;
 
-      disposables.add(watcher0, watcher1);
+    // We want to ensure that the weird relative path the user gave to
+    // `watchPath` is resolved internally _without_ it pointing to the real
+    // path on disk.
+    expect(first0.path.startsWith(symlinkedPath)).toBe(true);
+    expect(first0.path.startsWith(relativizedPath)).toBe(false);
+  })
 
-      expect(watcher0.native).toBe(watcher1.native);
-    });
+  it("reuses existing native watchers even while they're still starting", async function () {
+    const rootDir = await tempMkdir('atom-fsmanager-test-');
 
-    it("returns paths that appear to descend from the given path, even when symlinks are involved, when `realPaths` is `false`", async () => {
-      jasmine.useRealClock();
-      const rootDir = await tempMkdir('atom-fsmanager-test-');
-      const realRootDir = await realpath(rootDir)
-      const symlinkedPath = temp.path({ suffix: '-symlinked' })
-      await symlink(realRootDir, symlinkedPath)
+    const [watcher0, watcher1] = await Promise.all([
+      watchPath(rootDir, {}, () => {}),
+      watchPath(rootDir, {}, () => {})
+    ]);
+    expect(watcher0.native).toBe(watcher1.native);
+  });
 
-      let events0 = [];
-      let watcher0 = await watchPath(realRootDir, { realPaths: false }, (events) => {
-        events0.push(...events);
-      });
-      let events1 = [];
-      let watcher1 = await watchPath(symlinkedPath, { realPaths: false }, (events) => {
-        events1.push(...events);
-      });
+  it("doesn't attach new watchers to a native watcher that's stopping", async function () {
+    const rootDir = await tempMkdir('atom-fsmanager-test-');
 
-      disposables.add(watcher0, watcher1);
+    const watcher0 = await watchPath(rootDir, {}, () => {});
+    const native0 = watcher0.native;
 
-      await writeFile(path.join(realRootDir, 'foo.txt'), '!')
-      await conditionPromise(() => {
-        return events0.length > 0 && events1.length > 0 && events0.length === events1.length;
-      });
+    watcher0.dispose();
+    const watcher1 = await watchPath(rootDir, {}, () => {});
 
-      let [first0] = events0;
-      let [first1] = events1;
+    expect(watcher1.native).not.toBe(native0);
+  });
 
-      // Even though these two events describe the same filesystem action,
-      // their `path` properties don't match one another; they correspond to
-      // the paths given in their respective calls to `watchPath`.
-      expect(first0.path).not.toBe(first1.path);
-      expect(first0.path.startsWith(realRootDir)).toBe(true);
-      expect(first1.path.startsWith(symlinkedPath)).toBe(true);
-    })
+  it('reuses an existing native watcher on a parent directory and filters events', async function () {
+    const rootDir = await tempMkdir('atom-fsmanager-test-').then(realpath);
+    const rootFile = path.join(rootDir, 'rootfile.txt');
+    const subDir = path.join(rootDir, 'subdir');
+    const subFile = path.join(subDir, 'subfile.txt');
 
-    it("returns real paths for events when `realPaths` is `true`", async () => {
-      jasmine.useRealClock();
-      const rootDir = await tempMkdir('atom-fsmanager-test-');
-      const realRootDir = await realpath(rootDir)
-      const symlinkedPath = temp.path({ suffix: '-symlinked' })
-      await symlink(realRootDir, symlinkedPath)
-      const realSymlinkedPath = await realpath(symlinkedPath)
+    await mkdir(subDir);
 
-      let events0 = [];
-      let watcher0 = await watchPath(realRootDir, { realPaths: true }, (events) => {
-        events0.push(...events);
-      });
-      let events1 = [];
-      let watcher1 = await watchPath(symlinkedPath, { realPaths: true }, (events) => {
-        events1.push(...events);
-      });
+    // Keep the watchers alive with an undisposed subscription
+    const rootWatcher = await watchPath(rootDir, {}, () => {});
+    const childWatcher = await watchPath(subDir, {}, () => {});
 
-      disposables.add(watcher0, watcher1);
+    expect(rootWatcher.native).toBe(childWatcher.native);
+    expect(rootWatcher.native.isRunning()).toBe(true);
 
-      await writeFile(path.join(realRootDir, 'foo.txt'), '!')
-      await conditionPromise(() => {
-        return events0.length > 0 && events1.length > 0 &&
-          events0.length === events1.length;
-      });
+    const firstChanges = Promise.all([
+      waitForChanges(rootWatcher, subFile),
+      waitForChanges(childWatcher, subFile)
+    ]);
+    await writeFile(subFile, 'subfile\n', { encoding: 'utf8' });
+    await firstChanges;
 
-      let [first0] = events0;
-      let [first1] = events1;
+    const nextRootEvent = waitForChanges(rootWatcher, rootFile);
+    await writeFile(rootFile, 'rootfile\n', { encoding: 'utf8' });
+    await nextRootEvent;
+  });
 
-      // Because `realPaths` is `true`, these events will have identical `path`
-      // properties that point to the file's true path on disk.
-      expect(first0.path).toBe(first1.path);
-      expect(first0.path.startsWith(realRootDir)).toBe(true);
-      expect(first1.path.startsWith(symlinkedPath)).toBe(false);
-    })
+  it('adopts existing child watchers and filters events appropriately to them', async function () {
+    const parentDir = await tempMkdir('atom-fsmanager-test-').then(realpath);
 
-    it("normalizes a path without resolving symlinks when `realPaths` is `false`", async () => {
-      jasmine.useRealClock();
-      const rootDir = await tempMkdir('atom-fsmanager-test-');
-      const realRootDir = await realpath(rootDir);
-      const symlinkedPath = temp.path({ suffix: '-symlinked' })
-      await symlink(realRootDir, symlinkedPath);
+    // Create the directory tree
+    const rootFile = path.join(parentDir, 'rootfile.txt');
+    const subDir0 = path.join(parentDir, 'subdir0');
+    const subFile0 = path.join(subDir0, 'subfile0.txt');
+    const subDir1 = path.join(parentDir, 'subdir1');
+    const subFile1 = path.join(subDir1, 'subfile1.txt');
 
-      const relativizedPath = `${symlinkedPath}${path.sep}..${path.sep}${path.basename(symlinkedPath)}`
+    await mkdir(subDir0);
+    await mkdir(subDir1);
+    await Promise.all([
+      writeFile(rootFile, 'rootfile\n', { encoding: 'utf8' }),
+      writeFile(subFile0, 'subfile 0\n', { encoding: 'utf8' }),
+      writeFile(subFile1, 'subfile 1\n', { encoding: 'utf8' })
+    ]);
 
-      let events0 = [];
-      let watcher0 = await watchPath(relativizedPath, { realPaths: false }, (events) => {
-        events0.push(...events);
-      });
-      disposables.add(watcher0);
+    // Begin the child watchers and keep them alive
+    const subWatcher0 = await watchPath(subDir0, {}, () => {});
+    const subWatcherChanges0 = waitForChanges(subWatcher0, subFile0);
 
-      await writeFile(path.join(realRootDir, 'foo.txt'), '!')
-      await conditionPromise(() => events0.length > 0);
+    const subWatcher1 = await watchPath(subDir1, {}, () => {});
+    const subWatcherChanges1 = waitForChanges(subWatcher1, subFile1);
 
-      let [first0] = events0;
+    expect(subWatcher0.native).not.toBe(subWatcher1.native);
 
-      // We want to ensure that the weird relative path the user gave to
-      // `watchPath` is resolved internally _without_ it pointing to the real
-      // path on disk.
-      expect(first0.path.startsWith(symlinkedPath)).toBe(true);
-      expect(first0.path.startsWith(relativizedPath)).toBe(false);
-    })
+    // Create the parent watcher
+    const parentWatcher = await watchPath(parentDir, {}, () => {});
+    const parentWatcherChanges = waitForChanges(
+      parentWatcher,
+      rootFile,
+      subFile0,
+      subFile1
+    );
 
-    it("reuses existing native watchers even while they're still starting", async function () {
-      const rootDir = await tempMkdir('atom-fsmanager-test-');
+    expect(subWatcher0.native).toBe(parentWatcher.native);
+    expect(subWatcher1.native).toBe(parentWatcher.native);
 
-      const [watcher0, watcher1] = await Promise.all([
-        watchPath(rootDir, {}, () => {}),
-        watchPath(rootDir, {}, () => {})
-      ]);
-      expect(watcher0.native).toBe(watcher1.native);
-    });
+    // Ensure events are filtered correctly
+    await Promise.all([
+      appendFile(rootFile, 'change\n', { encoding: 'utf8' }),
+      appendFile(subFile0, 'change\n', { encoding: 'utf8' }),
+      appendFile(subFile1, 'change\n', { encoding: 'utf8' })
+    ]);
 
-    it("doesn't attach new watchers to a native watcher that's stopping", async function () {
-      const rootDir = await tempMkdir('atom-fsmanager-test-');
-
-      const watcher0 = await watchPath(rootDir, {}, () => {});
-      const native0 = watcher0.native;
-
-      watcher0.dispose();
-      const watcher1 = await watchPath(rootDir, {}, () => {});
-
-      expect(watcher1.native).not.toBe(native0);
-    });
-
-    it('reuses an existing native watcher on a parent directory and filters events', async function () {
-      const rootDir = await tempMkdir('atom-fsmanager-test-').then(realpath);
-      const rootFile = path.join(rootDir, 'rootfile.txt');
-      const subDir = path.join(rootDir, 'subdir');
-      const subFile = path.join(subDir, 'subfile.txt');
-
-      await mkdir(subDir);
-
-      // Keep the watchers alive with an undisposed subscription
-      const rootWatcher = await watchPath(rootDir, {}, () => {});
-      const childWatcher = await watchPath(subDir, {}, () => {});
-
-      expect(rootWatcher.native).toBe(childWatcher.native);
-      expect(rootWatcher.native.isRunning()).toBe(true);
-
-      const firstChanges = Promise.all([
-        waitForChanges(rootWatcher, subFile),
-        waitForChanges(childWatcher, subFile)
-      ]);
-      await writeFile(subFile, 'subfile\n', { encoding: 'utf8' });
-      await firstChanges;
-
-      const nextRootEvent = waitForChanges(rootWatcher, rootFile);
-      await writeFile(rootFile, 'rootfile\n', { encoding: 'utf8' });
-      await nextRootEvent;
-    });
-
-    it('adopts existing child watchers and filters events appropriately to them', async function () {
-      const parentDir = await tempMkdir('atom-fsmanager-test-').then(realpath);
-
-      // Create the directory tree
-      const rootFile = path.join(parentDir, 'rootfile.txt');
-      const subDir0 = path.join(parentDir, 'subdir0');
-      const subFile0 = path.join(subDir0, 'subfile0.txt');
-      const subDir1 = path.join(parentDir, 'subdir1');
-      const subFile1 = path.join(subDir1, 'subfile1.txt');
-
-      await mkdir(subDir0);
-      await mkdir(subDir1);
-      await Promise.all([
-        writeFile(rootFile, 'rootfile\n', { encoding: 'utf8' }),
-        writeFile(subFile0, 'subfile 0\n', { encoding: 'utf8' }),
-        writeFile(subFile1, 'subfile 1\n', { encoding: 'utf8' })
-      ]);
-
-      // Begin the child watchers and keep them alive
-      const subWatcher0 = await watchPath(subDir0, {}, () => {});
-      const subWatcherChanges0 = waitForChanges(subWatcher0, subFile0);
-
-      const subWatcher1 = await watchPath(subDir1, {}, () => {});
-      const subWatcherChanges1 = waitForChanges(subWatcher1, subFile1);
-
-      expect(subWatcher0.native).not.toBe(subWatcher1.native);
-
-      // Create the parent watcher
-      const parentWatcher = await watchPath(parentDir, {}, () => {});
-      const parentWatcherChanges = waitForChanges(
-        parentWatcher,
-        rootFile,
-        subFile0,
-        subFile1
-      );
-
-      expect(subWatcher0.native).toBe(parentWatcher.native);
-      expect(subWatcher1.native).toBe(parentWatcher.native);
-
-      // Ensure events are filtered correctly
-      await Promise.all([
-        appendFile(rootFile, 'change\n', { encoding: 'utf8' }),
-        appendFile(subFile0, 'change\n', { encoding: 'utf8' }),
-        appendFile(subFile1, 'change\n', { encoding: 'utf8' })
-      ]);
-
-      await Promise.all([
-        subWatcherChanges0,
-        subWatcherChanges1,
-        parentWatcherChanges
-      ]);
-    });
+    await Promise.all([
+      subWatcherChanges0,
+      subWatcherChanges1,
+      parentWatcherChanges
+    ]);
   });
 });

--- a/spec/path-watcher-spec.js
+++ b/spec/path-watcher-spec.js
@@ -400,14 +400,14 @@ describe('watchPath', function () {
         // trigger the callback…
         await writeFile(path.join(ignoredDir, 'foo.txt'), 'something');
         // (file-watchers might have a debounce interval)
-        await wait(1000);
+        await wait(process.env.CI ? 3000 : 1000);
         expect(spy).not.toHaveBeenCalled();
 
         // …but writing a file to a path outside of an ignored directory should
         // trigger the callback.
         await writeFile(path.join(rootDir, 'foo.txt'), 'something');
         // (file-watchers might have a debounce interval)
-        await wait(1000);
+        await wait(process.env.CI ? 3000 : 1000);
         expect(spy).toHaveBeenCalled();
       });
 

--- a/src/atom-environment.js
+++ b/src/atom-environment.js
@@ -488,6 +488,7 @@ class AtomEnvironment {
     // need other disposing objects to be able to check it. We won't need to
     // reset it because another environment will be created.
     this.isDestroying = true;
+    this.emitter.emit('will-destroy');
 
     this.disposables.dispose();
     if (this.workspace) this.workspace.destroy();
@@ -500,6 +501,20 @@ class AtomEnvironment {
     this.uriHandlerRegistry.destroy();
 
     this.uninstallWindowEventHandler();
+  }
+
+  /**
+   * @memberof AtomEnvironment
+   * @function onWillDestroy
+   * @desc Invoke the given callback when the environment is destroying, as
+   *   happens during window close or reload.
+   * @param {function} callback - Function to be called when the environment is
+   *   destroying.
+   * @returns {Disposable} on which `.dispose()` can be called to unsubscribe.
+   * @category Event Subscription
+   */
+  onWillDestroy (callback) {
+    return this.emitter.on('will-destroy', callback);
   }
 
   /**

--- a/src/config-schema.js
+++ b/src/config-schema.js
@@ -348,13 +348,13 @@ const configSchema = {
       },
       fileSystemWatcher: {
         description:
-          'Choose the underlying implementation used to watch for filesystem changes. Emulating changes will miss any events caused by applications other than Pulsar, but may help prevent crashes or freezes.',
+          'Choose the underlying implementation used to watch for filesystem changes. It’s best to let Pulsar manage this, but you can change this value if you want to opt into a specific watcher that may work better for your platform.',
         type: 'string',
-        default: 'native',
+        default: 'default',
         enum: [
           {
-            value: 'native',
-            description: 'Native operating system APIs'
+            value: 'default',
+            description: 'Default (let Pulsar decide)'
           },
           {
             value: 'nsfw',

--- a/src/config-schema.js
+++ b/src/config-schema.js
@@ -1,6 +1,7 @@
 // This is loaded by atom-environment.coffee. See
-// https://atom.io/docs/api/latest/Config for more information about config TODO: Link to Pulsar API site when documented
-// schemas.
+// https://atom.io/docs/api/latest/Config for more information about config
+//
+// TODO: Link to Pulsar API site when documented schemas.
 const configSchema = {
   core: {
     type: 'object',
@@ -354,6 +355,14 @@ const configSchema = {
           {
             value: 'native',
             description: 'Native operating system APIs'
+          },
+          {
+            value: 'nsfw',
+            description: 'Node Sentinel File Watcher'
+          },
+          {
+            value: 'parcel',
+            description: '@parcel/watcher'
           }
         ]
       },

--- a/src/nsfw-watcher-worker.js
+++ b/src/nsfw-watcher-worker.js
@@ -1,0 +1,209 @@
+/* global emit */
+
+const nsfw = require('nsfw');
+const minimatch = require('minimatch');
+const { fdir } = require('fdir');
+const path = require('path');
+
+const ACTION_MAP = new Map([
+  [nsfw.actions.MODIFIED, 'modified'],
+  [nsfw.actions.CREATED, 'created'],
+  [nsfw.actions.DELETED, 'deleted'],
+  [nsfw.actions.RENAMED, 'renamed']
+]);
+
+// Organizes watchers by unique ID.
+const WATCHERS_BY_PATH = new Map();
+
+function onError(instance, err) {
+  emit('watcher:error', { id: instance, error: err.message });
+}
+
+function handler(instance, events) {
+  let normalizedEvents = events.map((event) => {
+    const action =
+      ACTION_MAP.get(event.action) || `unexpected (${event.action})`;
+    const payload = { action };
+
+    if (event.file) {
+      payload.path = path.join(event.directory, event.file);
+    } else {
+      payload.oldPath = path.join(
+        event.directory,
+        typeof event.oldFile === 'undefined' ? '' : event.oldFile
+      );
+      payload.path = path.join(
+        event.directory,
+        typeof event.newFile === 'undefined' ? '' : event.newFile
+      );
+    }
+
+    return payload;
+  });
+
+  console.log('File events:', normalizedEvents)
+
+  emit('watcher:events', {
+    id: instance,
+    events: normalizedEvents
+  });
+}
+
+// A shim over the real `console` methods so that they send log messages back
+// to the renderer process instead of making us dig into their own console.
+const console = {
+  enabled: false,
+  log(...args) {
+    if (!this.enabled) return;
+    emit('console:log', ['nsfw-worker', ...args]);
+  },
+  warn(...args) {
+    if (!this.enabled) return;
+    emit('console:warn', ['nsfw-worker', ...args]);
+  },
+  error(...args) {
+    // Send errors whether logging is enabled or not.
+    emit('console:error', ['nsfw-worker', ...args]);
+  }
+};
+
+// Given a root path and a list of globs, generates a list of excluded paths to
+// pass to the `nsfw` watcher.
+//
+// This is _painful_! It drives us nuts because what we really want is to give
+// these globs to `nsfw` and have it use them when adding a recursive watcher.
+// (On Linux, it does this by spidering its way through the descendant folders
+// and adding `inotify` watches on each, but it should ignore some altogether!)
+//
+// But `nsfw` doesn't take globs; it takes explicit absolute paths. So we have
+// to do the filesystem crawling ourselves.
+//
+// If we were running this watcher on the renderer process, we'd have to worry
+// about scheduling this work so as not to lock up the process. But we can more
+// easily afford to go synchronous here because we're on a worker process.
+async function buildExcludedPaths(normalizedPath, ignoredNames) {
+  let results = [];
+  let _totalTimeSpentMinimatching = 0;
+  let start = new Date().valueOf();
+  console.log('Beginning generation of exclusions', normalizedPath, ignoredNames, performance.now());
+  await new fdir()
+    .withDirs()
+    .onlyDirs()
+    // Treat symlinks as though they're genuinely in the places they pretend to
+    // be.
+    .withSymlinks({ resolvePaths: false })
+    .exclude((_, dirPath) => {
+      // This is a trick. Returning `true` from this handler will prevent the
+      // filesystem crawler from diving any deeper down this path. That's what
+      // we want for each directory that matches any of our globs. So we
+      // assemble the results at the same time that we prevent further crawling
+      // for a certain path.
+      let start = performance.now();
+      let matches = ignoredNames.some(pattern => minimatch(dirPath, pattern, { matchBase: true }))
+      let stop = performance.now();
+      _totalTimeSpentMinimatching += (stop - start);
+      if (matches) {
+        results.push(dirPath);
+        return true;
+      }
+    })
+    // Don't actually return any results, since we compile our exclusions a
+    // different way. This probably doesn't help much, but no sense in building
+    // a big array full of paths when we're not going to use it.
+    .filter(() => false)
+    .crawl(normalizedPath)
+    // We could go synchronous here because we're in a worker and it won't lock
+    // up the renderer process. But some tests suggest that this actually
+    // finishes faster if we let it go async.
+    .withPromise();
+
+  let end = new Date().valueOf();
+
+  console.log('Generated exclusions in', end - start, 'ms', 'with time spent minimatching:', _totalTimeSpentMinimatching);
+  let excludedPaths = results;
+  console.log('Excluded paths:', excludedPaths);
+  return excludedPaths;
+}
+
+// Reacts to messages sent by the renderer.
+async function handleMessage(message) {
+  let { id, event = null, args } = JSON.parse(message);
+  console.log('handleMessage:', id, event, args);
+  switch (event) {
+    case 'watcher:watch': {
+      // `instance` is a unique ID for the watcher instance. We use it when we
+      // push filesystem events so that they can be routed back to the correct
+      // instance.
+      let { normalizedPath, instance, ignored } = args;
+      console.log('handling watcher:watch with normalizedPath', normalizedPath, 'and ignored', ignored);
+      let wrappedHandler = (err, events) => handler(instance, err, events);
+      try {
+        let watcher = await nsfw(normalizedPath, wrappedHandler, {
+          debounceMS: 200,
+          errorCallback: (error) => onError(instance, error),
+          excludedPaths: await buildExcludedPaths(normalizedPath, ignored)
+        });
+        await watcher.start();
+        WATCHERS_BY_PATH.set(instance, watcher);
+        emit('watcher:reply', { id, args: instance });
+      } catch (err) {
+        console.error('Error trying to watch path:', normalizedPath, err.message);
+        emit('watcher:reply', { id, error: err.message });
+      }
+      break;
+    }
+    case 'watcher:update': {
+      let { normalizedPath, instance, ignored } = args;
+      /** @type {nsfw.NSFW} */
+      let watcher = WATCHERS_BY_PATH.get(instance);
+      let excludedPaths = await buildExcludedPaths(normalizedPath, ignored);
+      await watcher.updateExcludedPaths(excludedPaths);
+      emit('watcher:reply', { id, args: instance });
+      break;
+    }
+    case 'watcher:unwatch': {
+      let { instance } = args;
+      let watcher = WATCHERS_BY_PATH.get(instance);
+      if (watcher) {
+        await watcher.stop();
+      }
+      emit('watcher:reply', { id, args: instance });
+      break;
+    }
+    default: {
+      console.warn(`Unrecognized event:`, event);
+    }
+  }
+}
+
+function run() {
+  // Run a no-op on an interval just to keep the task alive.
+  setInterval(() => {}, 10000);
+  process.on('message', handleMessage);
+  console.log('nsfw worker starting');
+  emit('watcher:ready');
+}
+
+process.on('uncaughtException', (error) => {
+  // Dilemma: most of the things that can cause exceptions in this worker are
+  // things that prevent us from communicating the error to anything — e.g.,
+  // ERR_IPC_CHANNEL_CLOSED.
+  //
+  // The goal here is to try to emit the exception and then fall back to
+  // exiting the process no matter what. But `uncaughtException` is
+  // unrecoverable and we shouldn't try to keep the worker going; we should
+  // just try to gather forensic data while we have the chance.
+  //
+  // See also:
+  // https://github.com/AtomLinter/linter-eslint-node/blob/main/lib/worker.js#L413-L429
+  try {
+    console.error(error?.message ?? error);
+  } finally {
+    // eslint-disable-next-line no-process-exit
+    process.exit(1);
+  }
+});
+
+process.title = `Pulsar file watcher worker (NSFW) [PID: ${process.pid}]`;
+
+module.exports = run;

--- a/src/nsfw-watcher-worker.js
+++ b/src/nsfw-watcher-worker.js
@@ -208,4 +208,6 @@ process.on('uncaughtException', (error) => {
 
 process.title = `Pulsar file watcher worker (NSFW) [PID: ${process.pid}]`;
 
+process.on('disconnect', () => process.exit(0));
+
 module.exports = run;

--- a/src/nsfw-watcher-worker.js
+++ b/src/nsfw-watcher-worker.js
@@ -121,7 +121,6 @@ async function buildExcludedPaths(normalizedPath, ignoredNames) {
 
   console.log('Generated exclusions in', end - start, 'ms', 'with time spent minimatching:', _totalTimeSpentMinimatching);
   let excludedPaths = results;
-  console.log('Excluded paths:', excludedPaths);
   return excludedPaths;
 }
 
@@ -138,10 +137,13 @@ async function handleMessage(message) {
       console.log('handling watcher:watch with normalizedPath', normalizedPath, 'and ignored', ignored);
       let wrappedHandler = (err, events) => handler(instance, err, events);
       try {
+        let excludedPaths = await buildExcludedPaths(normalizedPath, ignored);
+        console.log('Excluded paths:', instance, excludedPaths);
+
         let watcher = await nsfw(normalizedPath, wrappedHandler, {
           debounceMS: 200,
           errorCallback: (error) => onError(instance, error),
-          excludedPaths: await buildExcludedPaths(normalizedPath, ignored)
+          excludedPaths
         });
         await watcher.start();
         WATCHERS_BY_PATH.set(instance, watcher);

--- a/src/parcel-watcher-worker.js
+++ b/src/parcel-watcher-worker.js
@@ -184,4 +184,6 @@ process.on('uncaughtException', (error) => {
 
 process.title = `Pulsar file watcher worker (Parcel) [PID: ${process.pid}]`;
 
+process.on('disconnect', () => process.exit(0));
+
 module.exports = run;

--- a/src/parcel-watcher-worker.js
+++ b/src/parcel-watcher-worker.js
@@ -1,0 +1,124 @@
+/* global emit */
+
+// A worker script for `@parcel/watcher`. Runs as a `Task` (see src/task.js).
+//
+// Manages any number of individual folder watchers in a single process,
+// communicating over IPC.
+
+const watcher = require("@parcel/watcher");
+
+const EVENT_MAP = {
+  update: 'updated',
+  delete: 'deleted',
+  create: 'created'
+};
+
+// Reacts to filesystem events and sends batches back to the renderer process.
+function handler(instance, err, events) {
+  if (err) {
+    emit('watcher:error', { id: instance, error: err.message });
+    return;
+  }
+
+  let normalizedEvents = events.map(event => {
+    let action = EVENT_MAP[event.type] ?? `unexpected (${event.type})`;
+    let payload = { action };
+    if (event.path) {
+      payload.path = event.path;
+    }
+    return payload;
+  });
+
+  emit('watcher:events', {
+    id: instance,
+    events: normalizedEvents
+  });
+}
+
+// Organizes watchers by unique ID.
+const WATCHERS_BY_PATH = new Map();
+
+// A shim over the real `console` methods so that they send log messages back
+// to the renderer process instead of making us dig into their own console.
+const console = {
+  enabled: false,
+  log(...args) {
+    if (!this.enabled) return;
+    emit('console:log', ['parcel-worker', ...args]);
+  },
+  warn(...args) {
+    if (!this.enabled) return;
+    emit('console:warn', ['parcel-worker', ...args]);
+  },
+  error(...args) {
+    // Send errors whether logging is enabled or not.
+    emit('console:error', ['parcel-worker', ...args]);
+  }
+};
+
+// Reacts to messages sent by the renderer.
+async function handleMessage(message) {
+  let { id, event = null, args } = JSON.parse(message);
+  switch (event) {
+    case 'watcher:watch': {
+      // `instance` is a unique ID for the watcher instance. We use it when we
+      // push filesystem events so that they can be routed back to the correct
+      // instance.
+      let { normalizedPath, instance } = args;
+      let wrappedHandler = (err, events) => handler(instance, err, events);
+      try {
+        let handle = await watcher.subscribe(normalizedPath, wrappedHandler);
+        WATCHERS_BY_PATH.set(instance, handle);
+        emit('watcher:reply', { id, args: instance });
+      } catch (err) {
+        console.error('Error trying to watch path:', normalizedPath, err.message);
+        emit('watcher:reply', { id, error: err.message });
+      }
+      break;
+    }
+    case 'watcher:unwatch': {
+      let { instance } = args;
+      let handle = WATCHERS_BY_PATH.get(instance);
+      if (handle) {
+        await handle.unsubscribe();
+      }
+      emit('watcher:reply', { id, args: instance });
+      break;
+    }
+    default: {
+      console.warn(`Unrecognized event:`, event);
+    }
+  }
+}
+
+function run() {
+  // Run a no-op on an interval just to keep the task alive.
+  setInterval(() => {}, 10000);
+  console.log('@parcel/watcher worker starting');
+  process.on('message', handleMessage);
+  emit('watcher:ready');
+}
+
+process.on('uncaughtException', (error) => {
+  // Dilemma: most of the things that can cause exceptions in this worker are
+  // things that prevent us from communicating the error to anything — e.g.,
+  // ERR_IPC_CHANNEL_CLOSED.
+  //
+  // The goal here is to try to emit the exception and then fall back to
+  // exiting the process no matter what. But `uncaughtException` is
+  // unrecoverable and we shouldn't try to keep the worker going; we should
+  // just try to gather forensic data while we have the chance.
+  //
+  // See also:
+  // https://github.com/AtomLinter/linter-eslint-node/blob/main/lib/worker.js#L413-L429
+  try {
+    console.error(error?.message ?? error);
+  } finally {
+    // eslint-disable-next-line no-process-exit
+    process.exit(1);
+  }
+});
+
+process.title = `Pulsar file watcher worker (Parcel) [PID: ${process.pid}]`;
+
+module.exports = run;

--- a/src/parcel-watcher-worker.js
+++ b/src/parcel-watcher-worker.js
@@ -1,6 +1,7 @@
 /* global emit */
 
-// A worker script for `@parcel/watcher`. Runs as a `Task` (see src/task.js).
+// A worker script for `@parcel/watcher`. Runs as a `WatcherTask` (see
+// src/worker-task.js).
 //
 // Manages any number of individual folder watchers in a single process,
 // communicating over IPC.
@@ -8,7 +9,7 @@
 // Requests to watch files (rather than directories) are handled via Node's
 // builtin `fs.watch` API.
 
-const watcher = require("@parcel/watcher");
+const watcher = require('@parcel/watcher');
 const fs = require('fs');
 
 const EVENT_MAP = {

--- a/src/path-watcher.js
+++ b/src/path-watcher.js
@@ -16,12 +16,6 @@ const ACTION_MAP = new Map([
   [nsfw.actions.RENAMED,  'renamed' ]
 ]);
 
-const PARCEL_WATCHER_ACTION_MAP = new Map([
-  ['create', 'created'],
-  ['update', 'updated'],
-  ['delete', 'deleted']
-]);
-
 // Private: Possible states of a {NativeWatcher}.
 const WATCHER_STATE = {
   STOPPED:  Symbol('stopped'),
@@ -202,7 +196,7 @@ class ParcelWatcherNativeWatcher extends NativeWatcher {
     this.INSTANCES.set(instance.id, instance);
   }
 
-  static unregister (instance) {
+  static unregister(instance) {
     this.INSTANCES.delete(instance.id);
     if (this.INSTANCES.size === 0) {
       this.task.terminate();
@@ -286,9 +280,9 @@ class ParcelWatcherNativeWatcher extends NativeWatcher {
     let id = this.getID();
     let bundle = { id, event, args };
     let meta = {};
-    let promise = new Promise((request, resolve) => {
-      meta.request = request;
+    let promise = new Promise((resolve, reject) => {
       meta.resolve = resolve;
+      meta.reject = reject;
     });
     meta.promise = promise;
     this.PROMISE_META.set(id, meta);
@@ -922,4 +916,4 @@ watchPath.printWatchers = function () {
   return PathWatcherManager.active().print();
 };
 
-module.exports = { watchPath, stopAllWatchers};
+module.exports = { watchPath, stopAllWatchers };

--- a/src/path-watcher.js
+++ b/src/path-watcher.js
@@ -534,7 +534,6 @@ class NSFWNativeWatcher extends NativeWatcher {
   }
 
   async doStart() {
-    console.log('nsfw-worker doStart!');
     // “Registration” would ordinarily happen earlier in the lifecycle of this
     // instance. But (a) the purpose of it is to make the constructor know
     // about our ID so it can funnel events to us, which isn't necessary until

--- a/src/path-watcher.js
+++ b/src/path-watcher.js
@@ -177,7 +177,7 @@ class NativeWatcher {
 // been fully tracked down. That's fine, though; we can run it in its own
 // long-running task, much like VS Code does.
 class ParcelWatcherNativeWatcher extends NativeWatcher {
-  static task = new Task(require.resolve('./parcel-watcher-worker.js'));
+  static task = new Task(require.resolve('./parcel-watcher-worker.js'), { autoStart: false });
 
   // Whether the task has been started.
   static started = false;
@@ -204,7 +204,7 @@ class ParcelWatcherNativeWatcher extends NativeWatcher {
       this.initialized = false;
       // Once a task is terminated, it cannot be started again. We have to
       // replace it with a new instance.
-      this.task = new Task(require.resolve('./parcel-watcher-worker.js'));
+      this.task = new Task(require.resolve('./parcel-watcher-worker.js'), { autoStart: false });
       this.PROMISE_META.clear();
       this.initialize();
     }
@@ -272,8 +272,8 @@ class ParcelWatcherNativeWatcher extends NativeWatcher {
       meta.promise = promise;
       this.PROMISE_META.set('self:start', meta);
     }
-    await meta.promise;
     this.started = true;
+    await meta.promise;
   }
 
   static async sendEvent(event, args) {
@@ -371,7 +371,7 @@ class ParcelWatcherNativeWatcher extends NativeWatcher {
 
 // A file-watcher implementation that uses `nsfw`. Runs in a separate process.
 class NSFWNativeWatcher extends NativeWatcher {
-  static task = new Task(require.resolve('./nsfw-watcher-worker.js'));
+  static task = new Task(require.resolve('./nsfw-watcher-worker.js'), { autoStart: false });
 
   // Whether the task has been started.
   static started = false;
@@ -398,7 +398,7 @@ class NSFWNativeWatcher extends NativeWatcher {
       this.initialized = false;
       // Once a task is terminated, it cannot be started again. We have to
       // replace it with a new instance.
-      this.task = new Task(require.resolve('./nsfw-watcher-worker.js'));
+      this.task = new Task(require.resolve('./nsfw-watcher-worker.js'), { autoStart: false });
       this.PROMISE_META.clear();
       this.initialize();
     }
@@ -466,8 +466,8 @@ class NSFWNativeWatcher extends NativeWatcher {
       meta.promise = promise;
       this.PROMISE_META.set('self:start', meta);
     }
-    await meta.promise;
     this.started = true;
+    await meta.promise;
   }
 
   static async sendEvent(event, args) {

--- a/src/path-watcher.js
+++ b/src/path-watcher.js
@@ -1125,6 +1125,14 @@ watchPath.waitForTransition = async function waitForTransition() {
   await PathWatcherManager.transitionPromise;
 };
 
+// Private: Stop all watchers and reset `PathWatcherManager` to its initial
+// state.
+watchPath.reset = function reset() {
+  return PathWatcherManager.active().stopAllWatchers().then(() => {
+    PathWatcherManager.activeManager = null;
+  });
+}
+
 // Which implementation to use for each possible value of
 // `core.fileSystemWatcher`.
 //

--- a/src/task.js
+++ b/src/task.js
@@ -93,7 +93,11 @@ module.exports = class Task {
 
   createChildProcess () {
     const compileCachePath = require('./compile-cache').getCacheDirectory();
-    const env = Object.assign({}, process.env, { userAgent: navigator.userAgent });
+    const env = Object.assign({}, process.env, {
+      userAgent: navigator.userAgent,
+      ELECTRON_RUN_AS_NODE: '1',
+      ELECTRON_NO_ATTACH_CONSOLE: '1'
+    });
     if (window.atom?.unloading) {
       this.childProcess = null;
     } else {

--- a/src/task.js
+++ b/src/task.js
@@ -78,7 +78,7 @@ module.exports = class Task {
       this.childProcess = ChildProcess.fork(
         require.resolve('./task-bootstrap'),
         [compileCachePath, taskPath],
-        { env, silent: true }
+        { env, silent: true, windowsHide: true }
       );
     }
 

--- a/src/task.js
+++ b/src/task.js
@@ -66,20 +66,13 @@ module.exports = class Task {
   //
   // * `taskPath` The {String} path to the CoffeeScript/JavaScript file that
   //   exports a single {Function} to execute.
-  constructor(taskPath) {
+  constructor(taskPath, { autoStart = true } = {}) {
     this.emitter = new Emitter();
-    const compileCachePath = require('./compile-cache').getCacheDirectory();
-    taskPath = require.resolve(taskPath);
-    const env = Object.assign({}, process.env, { userAgent: navigator.userAgent });
+    this.autoStart = autoStart;
+    this.taskPath = require.resolve(taskPath);
 
-    if (atom.unloading) {
-      this.childProcess = null;
-    } else {
-      this.childProcess = ChildProcess.fork(
-        require.resolve('./task-bootstrap'),
-        [compileCachePath, taskPath],
-        { env, silent: true, windowsHide: true }
-      );
+    if (autoStart) {
+      this.createChildProcess();
     }
 
     this.on("task:log", (...args) => console.log(...args));
@@ -96,6 +89,20 @@ module.exports = class Task {
         this.callback(...args)
       }
     });
+  }
+
+  createChildProcess () {
+    const compileCachePath = require('./compile-cache').getCacheDirectory();
+    const env = Object.assign({}, process.env, { userAgent: navigator.userAgent });
+    if (window.atom?.unloading) {
+      this.childProcess = null;
+    } else {
+      this.childProcess = ChildProcess.fork(
+        require.resolve('./task-bootstrap'),
+        [compileCachePath, this.taskPath],
+        { env, silent: true, windowsHide: true }
+      );
+    }
     this.handleEvents();
   }
 
@@ -130,10 +137,13 @@ module.exports = class Task {
     // Don't spawn any new tasks during shutdown.
     if (atom.unloading) return;
     const [callback] = args.splice(-1);
-    if (this.childProcess == null) {
-      throw new Error('Cannot start terminated process');
+    if (this.autoStart && !this.childProcess) {
+      if (this.childProcess == null) {
+        throw new Error('Cannot start terminated process');
+      }
+    } else if (!this.autoStart && !this.childProcess) {
+      this.createChildProcess();
     }
-    this.handleEvents();
     if (_.isFunction(callback)) {
       this.callback = callback;
     } else {

--- a/src/watcher-task-bootstrap.js
+++ b/src/watcher-task-bootstrap.js
@@ -1,0 +1,73 @@
+const { userAgent } = process.env;
+const taskPath = process.argv.at(-1);
+const compileCachePath = process.env.PULSAR_COMPILE_CACHE_PATH;
+
+const CompileCache = require('./compile-cache');
+CompileCache.setCacheDirectory(compileCachePath);
+CompileCache.install(`${process.resourcesPath}`, require);
+
+function setupGlobals() {
+	global.attachEvent = () => {};
+
+	const console = {
+		warn() {
+      return global.emit('task:warn', ...arguments);
+    },
+    log() {
+      return global.emit('task:log', ...arguments);
+    },
+    error() {
+      return global.emit('task:error', ...arguments);
+    },
+    trace() {}
+	};
+
+	global.__defineGetter__('console', () => console);
+
+	global.document = {
+    createElement() {
+      return {
+        setAttribute() {},
+        getElementsByTagName() {
+          return [];
+        },
+        appendChild() {}
+      };
+    },
+    documentElement: {
+      insertBefore() {},
+      removeChild() {}
+    },
+    getElementById() {
+      return {};
+    },
+    createComment() {
+      return {};
+    },
+    createDocumentFragment() {
+      return {};
+    }
+  };
+
+	global.emit = (event, ...args) => process.send({ event, args });
+	global.navigator = { userAgent };
+
+	return (global.window = global);
+}
+
+let handler;
+
+function handleEvents() {
+	process.on('uncaughtException', error => {
+		console.error(error.message, error.stack);
+	});
+
+	return process.on('message', function ({ event, args } = {}) {
+		if (event !== 'start') return;
+		handler(...args);
+	});
+}
+
+setupGlobals();
+handleEvents();
+handler = require(taskPath);

--- a/src/watcher-task.js
+++ b/src/watcher-task.js
@@ -1,0 +1,113 @@
+const _ = require('underscore-plus');
+const ChildProcess = require('child_process');
+const { Emitter } = require('event-kit');
+
+// Private: Like {Task}, but designed for file-watcher processes. Does not
+// start automatically; once it starts, it expects to run indefinitely.
+class WatcherTask {
+  emitter = new Emitter();
+  constructor(taskPath) {
+    console.log('[PathWatcher] new WatcherTask:', taskPath);
+    this.taskPath = taskPath;
+  }
+
+  createChildProcess () {
+    let compileCachePath = require('./compile-cache').getCacheDirectory();
+    let env = Object.assign({}, process.env, {
+      userAgent: navigator.userAgent,
+      ELECTRON_RUN_AS_NODE: '1',
+      ELECTRON_NO_ATTACH_CONSOLE: '1',
+      PULSAR_COMPILE_CACHE_PATH: compileCachePath
+    });
+    if (window.atom?.unloading) {
+      this.childProcess = null;
+    } else {
+      console.log('Creating child process at task path:', this.taskPath);
+      this.childProcess = ChildProcess.fork(
+        require.resolve('./watcher-task-bootstrap'),
+        ['--no-deprecation', this.taskPath],
+        { env, silent: true, windowsHide: true }
+      );
+    }
+    this.handleEvents();
+  }
+
+  handleEvents () {
+    if (!this.childProcess) return;
+    this.childProcess.removeAllListeners();
+    this.childProcess.on('message', ({ event, args }) => {
+      if (!this.childProcess) return;
+      this.emitter.emit(event, args);
+    });
+
+    const { stdout, stderr } = this.childProcess;
+
+    // Catch the errors that happened before bootstrap.
+    if (stdout != null) {
+      stdout.removeAllListeners();
+      stdout.on('data', data => console.log(data.toString()));
+    }
+
+    if (stderr != null) {
+      stderr.removeAllListeners();
+      stderr.on('data', data => console.error(data.toString()));
+    }
+  }
+
+  start (...args) {
+    console.log('[PathWatcher] Start called for worker with task path:', this.taskPath);
+    // Don't spawn any workers during shutdown.
+    if (window.atom?.unloading) return;
+    const [callback] = args.splice(-1);
+    this.createChildProcess();
+    if (_.isFunction(callback)) {
+      this.callback = callback;
+    } else {
+      args.push(callback);
+    }
+    this.send({ event: 'start', args });
+    return;
+  }
+
+  send (message) {
+    console.log('Sending:', message, 'to process with task path:', this.taskPath);
+    if (!this.childProcess) {
+      return;
+      // throw new Error('Cannot send message to terminated process');
+    }
+    this.childProcess.send(message);
+    return;
+  }
+
+  on (eventName, callback) {
+    return this.emitter.on(eventName, (args) => {
+      callback(...(args || []))
+    });
+  }
+
+  once (eventName, callback) {
+    return this.emitter.once(eventName, (args) => {
+      callback(...(args || []))
+    });
+  }
+
+  terminate () {
+    if (!this.childProcess) return false;
+    this.childProcess.removeAllListeners();
+    this.childProcess.stdout?.removeAllListeners();
+    this.childProcess.stderr?.removeAllListeners();
+    this.childProcess.kill();
+    this.childProcess = null;
+    return true;
+  }
+
+  cancel () {
+    let didForcefullyTerminate = this.terminate();
+    if (didForcefullyTerminate) {
+      this.emitter.emit('task:cancelled');
+    }
+    return didForcefullyTerminate;
+  }
+}
+
+module.exports = WatcherTask;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1654,6 +1654,95 @@
   dependencies:
     "@noble/hashes" "^1.1.5"
 
+"@parcel/watcher-android-arm64@2.5.6":
+  version "2.5.6"
+  resolved "https://registry.yarnpkg.com/@parcel/watcher-android-arm64/-/watcher-android-arm64-2.5.6.tgz#5f32e0dba356f4ac9a11068d2a5c134ca3ba6564"
+  integrity sha512-YQxSS34tPF/6ZG7r/Ih9xy+kP/WwediEUsqmtf0cuCV5TPPKw/PQHRhueUo6JdeFJaqV3pyjm0GdYjZotbRt/A==
+
+"@parcel/watcher-darwin-arm64@2.5.6":
+  version "2.5.6"
+  resolved "https://registry.yarnpkg.com/@parcel/watcher-darwin-arm64/-/watcher-darwin-arm64-2.5.6.tgz#88d3e720b59b1eceffce98dac46d7c40e8be5e8e"
+  integrity sha512-Z2ZdrnwyXvvvdtRHLmM4knydIdU9adO3D4n/0cVipF3rRiwP+3/sfzpAwA/qKFL6i1ModaabkU7IbpeMBgiVEA==
+
+"@parcel/watcher-darwin-x64@2.5.6":
+  version "2.5.6"
+  resolved "https://registry.yarnpkg.com/@parcel/watcher-darwin-x64/-/watcher-darwin-x64-2.5.6.tgz#bf05d76a78bc15974f15ec3671848698b0838063"
+  integrity sha512-HgvOf3W9dhithcwOWX9uDZyn1lW9R+7tPZ4sug+NGrGIo4Rk1hAXLEbcH1TQSqxts0NYXXlOWqVpvS1SFS4fRg==
+
+"@parcel/watcher-freebsd-x64@2.5.6":
+  version "2.5.6"
+  resolved "https://registry.yarnpkg.com/@parcel/watcher-freebsd-x64/-/watcher-freebsd-x64-2.5.6.tgz#8bc26e9848e7303ac82922a5ae1b1ef1bdb48a53"
+  integrity sha512-vJVi8yd/qzJxEKHkeemh7w3YAn6RJCtYlE4HPMoVnCpIXEzSrxErBW5SJBgKLbXU3WdIpkjBTeUNtyBVn8TRng==
+
+"@parcel/watcher-linux-arm-glibc@2.5.6":
+  version "2.5.6"
+  resolved "https://registry.yarnpkg.com/@parcel/watcher-linux-arm-glibc/-/watcher-linux-arm-glibc-2.5.6.tgz#1328fee1deb0c2d7865079ef53a2ba4cc2f8b40a"
+  integrity sha512-9JiYfB6h6BgV50CCfasfLf/uvOcJskMSwcdH1PHH9rvS1IrNy8zad6IUVPVUfmXr+u+Km9IxcfMLzgdOudz9EQ==
+
+"@parcel/watcher-linux-arm-musl@2.5.6":
+  version "2.5.6"
+  resolved "https://registry.yarnpkg.com/@parcel/watcher-linux-arm-musl/-/watcher-linux-arm-musl-2.5.6.tgz#bad0f45cb3e2157746db8b9d22db6a125711f152"
+  integrity sha512-Ve3gUCG57nuUUSyjBq/MAM0CzArtuIOxsBdQ+ftz6ho8n7s1i9E1Nmk/xmP323r2YL0SONs1EuwqBp2u1k5fxg==
+
+"@parcel/watcher-linux-arm64-glibc@2.5.6":
+  version "2.5.6"
+  resolved "https://registry.yarnpkg.com/@parcel/watcher-linux-arm64-glibc/-/watcher-linux-arm64-glibc-2.5.6.tgz#b75913fbd501d9523c5f35d420957bf7d0204809"
+  integrity sha512-f2g/DT3NhGPdBmMWYoxixqYr3v/UXcmLOYy16Bx0TM20Tchduwr4EaCbmxh1321TABqPGDpS8D/ggOTaljijOA==
+
+"@parcel/watcher-linux-arm64-musl@2.5.6":
+  version "2.5.6"
+  resolved "https://registry.yarnpkg.com/@parcel/watcher-linux-arm64-musl/-/watcher-linux-arm64-musl-2.5.6.tgz#da5621a6a576070c8c0de60dea8b46dc9c3827d4"
+  integrity sha512-qb6naMDGlbCwdhLj6hgoVKJl2odL34z2sqkC7Z6kzir8b5W65WYDpLB6R06KabvZdgoHI/zxke4b3zR0wAbDTA==
+
+"@parcel/watcher-linux-x64-glibc@2.5.6":
+  version "2.5.6"
+  resolved "https://registry.yarnpkg.com/@parcel/watcher-linux-x64-glibc/-/watcher-linux-x64-glibc-2.5.6.tgz#ce437accdc4b30f93a090b4a221fd95cd9b89639"
+  integrity sha512-kbT5wvNQlx7NaGjzPFu8nVIW1rWqV780O7ZtkjuWaPUgpv2NMFpjYERVi0UYj1msZNyCzGlaCWEtzc+exjMGbQ==
+
+"@parcel/watcher-linux-x64-musl@2.5.6":
+  version "2.5.6"
+  resolved "https://registry.yarnpkg.com/@parcel/watcher-linux-x64-musl/-/watcher-linux-x64-musl-2.5.6.tgz#02400c54b4a67efcc7e2327b249711920ac969e2"
+  integrity sha512-1JRFeC+h7RdXwldHzTsmdtYR/Ku8SylLgTU/reMuqdVD7CtLwf0VR1FqeprZ0eHQkO0vqsbvFLXUmYm/uNKJBg==
+
+"@parcel/watcher-win32-arm64@2.5.6":
+  version "2.5.6"
+  resolved "https://registry.yarnpkg.com/@parcel/watcher-win32-arm64/-/watcher-win32-arm64-2.5.6.tgz#caae3d3c7583ca0a7171e6bd142c34d20ea1691e"
+  integrity sha512-3ukyebjc6eGlw9yRt678DxVF7rjXatWiHvTXqphZLvo7aC5NdEgFufVwjFfY51ijYEWpXbqF5jtrK275z52D4Q==
+
+"@parcel/watcher-win32-ia32@2.5.6":
+  version "2.5.6"
+  resolved "https://registry.yarnpkg.com/@parcel/watcher-win32-ia32/-/watcher-win32-ia32-2.5.6.tgz#9ac922550896dfe47bfc5ae3be4f1bcaf8155d6d"
+  integrity sha512-k35yLp1ZMwwee3Ez/pxBi5cf4AoBKYXj00CZ80jUz5h8prpiaQsiRPKQMxoLstNuqe2vR4RNPEAEcjEFzhEz/g==
+
+"@parcel/watcher-win32-x64@2.5.6":
+  version "2.5.6"
+  resolved "https://registry.yarnpkg.com/@parcel/watcher-win32-x64/-/watcher-win32-x64-2.5.6.tgz#73fdafba2e21c448f0e456bbe13178d8fe11739d"
+  integrity sha512-hbQlYcCq5dlAX9Qx+kFb0FHue6vbjlf0FrNzSKdYK2APUf7tGfGxQCk2ihEREmbR6ZMc0MVAD5RIX/41gpUzTw==
+
+"@parcel/watcher@^2.5.1":
+  version "2.5.6"
+  resolved "https://registry.yarnpkg.com/@parcel/watcher/-/watcher-2.5.6.tgz#3f932828c894f06d0ad9cfefade1756ecc6ef1f1"
+  integrity sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ==
+  dependencies:
+    detect-libc "^2.0.3"
+    is-glob "^4.0.3"
+    node-addon-api "^7.0.0"
+    picomatch "^4.0.3"
+  optionalDependencies:
+    "@parcel/watcher-android-arm64" "2.5.6"
+    "@parcel/watcher-darwin-arm64" "2.5.6"
+    "@parcel/watcher-darwin-x64" "2.5.6"
+    "@parcel/watcher-freebsd-x64" "2.5.6"
+    "@parcel/watcher-linux-arm-glibc" "2.5.6"
+    "@parcel/watcher-linux-arm-musl" "2.5.6"
+    "@parcel/watcher-linux-arm64-glibc" "2.5.6"
+    "@parcel/watcher-linux-arm64-musl" "2.5.6"
+    "@parcel/watcher-linux-x64-glibc" "2.5.6"
+    "@parcel/watcher-linux-x64-musl" "2.5.6"
+    "@parcel/watcher-win32-arm64" "2.5.6"
+    "@parcel/watcher-win32-ia32" "2.5.6"
+    "@parcel/watcher-win32-x64" "2.5.6"
+
 "@playwright/test@1.22.2":
   version "1.22.2"
   resolved "https://registry.yarnpkg.com/@playwright/test/-/test-1.22.2.tgz#b848f25f8918140c2d0bae8e9227a40198f2dd4a"
@@ -3892,7 +3981,7 @@ detect-libc@^1.0.3:
   resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"
   integrity sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==
 
-detect-libc@^2.0.0, detect-libc@^2.0.1:
+detect-libc@^2.0.0, detect-libc@^2.0.1, detect-libc@^2.0.3:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-2.1.2.tgz#689c5dcdc1900ef5583a4cb9f6d7b473742074ad"
   integrity sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==
@@ -4795,6 +4884,11 @@ fd-slicer@~1.1.0:
   integrity sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==
   dependencies:
     pend "~1.2.0"
+
+fdir@6.4.6:
+  version "6.4.6"
+  resolved "https://registry.yarnpkg.com/fdir/-/fdir-6.4.6.tgz#2b268c0232697063111bbf3f64810a2a741ba281"
+  integrity sha512-hiFoqpyZcfNm1yc4u8oWCf9A2c4D3QjCrks3zmoVKVxpQRzmPNar1hUJcBG2RQHvEVGDN+Jm81ZheVLAQMK6+w==
 
 file-entry-cache@^6.0.1:
   version "6.0.1"
@@ -7489,7 +7583,7 @@ node-addon-api@^6.1.0:
   resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-6.1.0.tgz#ac8470034e58e67d0c6f1204a18ae6995d9c0d76"
   integrity sha512-+eawOlIgy680F0kBzPUNFhMZGtJ1YmqM6l4+Crf4IkImjYrO/mqPwRMh352g23uIaQKFItcQ64I7KMaJxHgAVA==
 
-node-addon-api@^7.1.1:
+node-addon-api@^7.0.0, node-addon-api@^7.1.1:
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-7.1.1.tgz#1aba6693b0f255258a049d621329329322aad558"
   integrity sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==
@@ -7989,6 +8083,11 @@ picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
   integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
+
+picomatch@^4.0.3:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-4.0.3.tgz#796c76136d1eead715db1e7bad785dedd695a042"
+  integrity sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==
 
 pify@^4.0.1:
   version "4.0.1"


### PR DESCRIPTION

This is one of those PRs that may sit here for a while without much attention. But that’s OK, because the alternative is that it sits on my hard drive or in one of my Git stashes.

In theory, we have a pluggable file-watching architecture that handles _some_ of our file-watching tasks. The [original PR](https://github.com/atom/atom/pull/14853) that added it to Atom explained that various packages were using various file-watching libraries and probably duplicating efforts, so it made sense for it to be part of Atom’s API offering.

[`nsfw`](https://github.com/Axosoft/nsfw/) was picked to back the initial implementation, but Atom then [forked `nsfw`](https://github.com/atom/nsfw/), and in parallel were working on their own [`@atom/watcher` library](https://github.com/atom/watcher). (Not to be confused with [`node-pathwatcher`](https://github.com/atom/node-pathwatcher/), which dates back to the early Atom days and is more challenging to remove from our codebase than asbestos is from buildings.)

We don’t want to maintain our own file-watcher library, but neither do we want to be beholden to someone else’s library. It’s good to have options. A while back I poked around to see how VS Code was handling file watching, and it turns out they’re using `@parcel/watcher`. It’s built by the [Parcel](https://parceljs.org/) folks and offers a similar feature set to `nsfw`.


### I have weird ideas of “fun”

I gave myself an evening to integrate this into Pulsar as an alternative to `nsfw`. At first, this PR was designed to point to the `master` branch — `@parcel/watcher` claims to support Node versions [all the way back to v10](https://github.com/parcel-bundler/watcher/blob/v2.5.1/package.json#L38-L40) — but it failed during the `electron-rebuild` stage. That suggests to me that it installs fine on Node 16 (the version I run in my `pulsar` folder) but not on Node 14 (the major version against which it builds when it does `electron-rebuild` targeting `v12.2.3`), hence its `engines` field may be inaccurate.

That was the first hiccup.

I wrote a wrapper around `@parcel/watcher` that was nearly identical to the one around `nsfw`. All worked great until I needed to reload the window; when I did, I got a renderer process crash on a consistent basis. Sentry’s stack trace points to the new library but gives me a pretty generic error:

<p><img width="646" alt="Screenshot 2025-06-26 at 12 58 05 AM" src="https://github.com/user-attachments/assets/f91d5f74-a770-4051-9416-6767a644925f" /></p>


Pretty much _all_ crashes in N-API are due to thread-safe functions, so that’s not much help! I wonder if it’s not context-aware in practice; N-API gives you the framework to be context-aware, but you still have to do the hard work of not accidentally sharing things between contexts that should not be shared.

I vaguely recalled that VS Code ran their file-watcher in a separate process, so I thought I’d give that a shot. It went great!

### `Task`: the underappreciated core class

We’ve got a class whose purpose is to simplify the job of spawning another process to run a worker. [It’s called `Task`](https://github.com/pulsar-edit/pulsar/blob/master/src/task.js) and, though there aren’t many usages within the Pulsar codebase, it was easier to figure out how to use it than to start from scratch. I recalled some of the design decisions we made while building [`linter-eslint-node`](https://github.com/pulsar-linter/linter-eslint-node/) and that made things go even faster.

The short version:

* One process is all you need. No matter how many different folders you want to monitor for changes, you can hold all of their file-watchers in one worker process.
* It’s the same sort of bi-directional communication you might be accustomed to if you’ve ever worked with WebSockets. In other words: sometimes you send a message to a worker and you want to wait around for the reply, much like an HTTP model. And other times, the worker wants to push stuff to you whenever it arrives — like filesystem events.
* Ultimately, even though it’s a lot more code than `NSFWNativeWatcher`, it’s not bad at all. It means one more process per window taking up space in your task manager, but that process uses _hardly any_ CPU and is basically hibernating most of the time.
* Like most file-watchers (other than `nsfw`), `@parcel/watcher` doesn’t have explicit support for renaming as a filesystem event. But since it delivers events in batches, it’s not hard to envision that we could detect renames by looking for two files in the same batch of events — one with type `deleted` and the other with type `created`.

### Why did I do this?

There’s someone on Discord who often experiences a Pulsar-related process using 100% of CPU (on a single core) while they’ve got it open. Louder fans, lower battery life, et cetera. The mystery goes pretty deep and we’re not sure exactly where the cost is being paid, but at this point we’ve got it narrowed down to file-watching.

This user is on Linux and often has a project window open to a path called `/user/home` — which, regardless of the particular Linux distro, has the potential to be a _busy_ directory with _lots_ of stuff in it.

On top of which: Linux uses `inotify` for filesystem watchers. Unlike the FSEvents API on macOS — which is basically a metadata firehose that can easily be filtered down to only the filesystem events you’re interested in — `inotify` is not recursive and can monitor one directory at a time. So to approximate a recursive watcher, `nsfw` crawls a directory tree and creates one `inotify` watcher for each directory.

By itself that isn’t enough to explain how a process ends up using 100% of CPU, but it’s a hard data point to ignore. I asked same user to test what happens if they open a new Pulsar project in a new empty folder; the user says that they’re not able to reproduce the high CPU usage in this test.

**Anyway,** it felt like a good time to audition an alternative file-watching library, if only to keep our options open! In support situations like the one I just described, I don’t have much to offer for troubleshooting outside of “build Pulsar from scratch, generate a debug build of `nsfw`, and step through it in your favorite C/C++ debugger” — and that’s rough. It’d be great if I could say something like “try switching to a different filesystem watcher in your settings and see if that makes a difference.”

There are other thoughts I eventually want to capture about recursive vs. non-recursive watchers, but it’s late and I can do that tomorrow.

### What should I do with this PR?

Play around with it a bit! There’s not much urgency, since this is feeling like a post-PulsarNext task. My eventual goal is to introduce this as a new option while keeping the same default, much like we did with the SQL state store _vis-a-vis_ the IndexedDB state store. Folks could switch to it to try it out, and if it doesn’t work great, the worst that happens to them is that they’d have to switch back.

That reminds me: the setting to change is under Core -> File System Watcher in the settings GUI. There’s currently only one option (“native operating system APIs”), and the name is misleading, but I envision three options: NSFW, @parcel/watcher, and “default,” where you just let us pick one. Amazingly, you can change this setting on the fly in the middle of a session — the `PathWatcher` class handles all the work of tearing down the old watchers and creating new ones!

<p><img width="610" alt="Screenshot 2025-06-26 at 1 23 43 AM" src="https://github.com/user-attachments/assets/d1269904-2e7c-47d4-8c76-eef0f0435429" /></p>

No tests or anything yet, so this is a draft to start out. I'll probably ignore it for a while now, but at least it's on public display.