### PR TITLE
[autocomplete-plus] Add support for “additional” text edits…

### DIFF
--- a/packages/autocomplete-plus/README.md
+++ b/packages/autocomplete-plus/README.md
@@ -14,7 +14,7 @@ Displays possible autocomplete suggestions on keystroke (or manually by typing `
 
 `autocomplete+` has a powerful autocomplete provider API, allowing provider authors to add language-specific behavior to this package.
 
-You should *definitely* install additional providers (the default provider bundled with this package is somewhat crude): https://github.com/atom/autocomplete-plus/wiki/Autocomplete-Providers
+You should *definitely* install additional providers (the default provider bundled with this package is somewhat crude): here’s [a list of all Pulsar packages (built-in or community) that provide `autocomplete.provider`](https://web.pulsar-edit.dev/packages?serviceType=provided&service=autocomplete.provider).
 
 ## Usage
 
@@ -77,7 +77,7 @@ Then add these to your keymap file:
 
 Great autocomplete depends on having great autocomplete providers. If there is not already a great provider for the language / grammar that you are working in, please consider creating a provider.
 
-[Read the `Provider API` documentation](https://github.com/atom/autocomplete-plus/wiki/Provider-API) to learn how to create a new autocomplete provider.
+[Read the `Provider API` documentation](./docs/provider-api.md) to learn how to create a new autocomplete provider.
 
 ## `SymbolProvider` Configuration
 

--- a/packages/autocomplete-plus/docs/provider-api.md
+++ b/packages/autocomplete-plus/docs/provider-api.md
@@ -1,0 +1,361 @@
+# `autocomplete.provider` service documentation
+
+Read this document if you’d like to write your own autocompletion provider.
+
+If you want to turn a language server into an autocompletion provider, you can use `atom-languageclient` instead of providing this service directly. [Consult its README](https://github.com/savetheclocktower/atom-languageclient?tab=readme-ov-file#developing-packages) for more information.
+
+## Service definition
+
+The following TypeScript-style code block describes the `autocomplete.provider` service in its current form.
+
+The current service version is **5.1.0**. The documentation is accurate for version 4 or greater of the API; aspects that are present only in versions later than 4 are annotated as such.
+
+```ts
+import { Point, Range, ScopeDescriptor, TextEditor } from 'atom';
+
+
+/**
+ * A {@link Range} or any object that can be accepted by {@link
+ * Range.prototype.fromObject}.
+ */
+type RangeCompatible =
+  | Range
+  | [Point, Point],
+  | [[number, number], [number, number]]
+  | [{ row: number, column: number}, { row: number, column: number}]
+
+/**
+ * Describes a range of a buffer and the text to insert into it. This is one
+ * possible insertion strategy among several for a suggestion.
+ *
+ * Like a `Range` from the Language Server Protocol specification, but with an
+ * Atom-style {@link Range}.
+ *
+ * This type bears some similarity to an existing `TextEdit` type used by
+ * Atom-IDE. The existing type uses the `oldRange` property instead of `range`,
+ * but is otherwise identical. Both are acceptable.
+ */
+type TextEdit = {
+  newText: string
+} & ({ range: RangeCompatible } | { oldRange: RangeCompatible })
+
+/**
+ * Known types of suggestions; these have predefined styles when rendered.
+ */
+type SuggestionType =
+  | 'variable'
+  | 'constant'
+  | 'property'
+  | 'value'
+  | 'method'
+  | 'function'
+  | 'class'
+  | 'type'
+  | 'keyword'
+  | 'tag'
+  | 'snippet'
+  | 'import'
+  | 'require'
+
+/**
+ * A single suggestion as returned by `getSuggestions` or
+ * `getSuggestionDetailsOnSelect`.
+ */
+type Suggestion = {
+  // A suggestion can be inserted one of several ways: as plain text, as a
+  // snippet, or as a `TextEdit`. One of these three properties is therefore
+  // required; the others are optional.
+  //
+  // Of these three, later properties win out over earlier ones. For example,
+  // `textEdit` will be preferred over both `snippet` and `text` if it is
+  // present.
+
+  /**
+   * The text to be inserted. Will be used if `snippet` is absent.
+   */
+  text?: string
+
+  /**
+   * A snippet to insert upon suggestion selection.
+   */
+  snippet?: string
+
+  /**
+   * Text edit to make when the item is chosen. Use this when you want to be
+   * specific about which range of the buffer is replaced. When present, this
+   * will be used as the insertion strategy instead of the default behavior.
+   *
+   * If a suggestion needs to make several edits upon insertion, the rest can
+   * be specified via `additionalTextEdits`.
+   *
+   * Added in 5.1.0.
+   */
+  textEdit?: TextEdit
+
+  /**
+   * The text to show in the menu for this suggestion. Optional; falls back to
+   * `snippet`, then `text`.
+   */
+  displayText?: string
+
+  /**
+   * A list of `Range`s to replace when inserting the text. Each `Range`present
+   * in this list will result in one insertion of the suggestion's textor
+   * snippet.
+   *
+   * Can insert the autocompletion's text/snippet into one specific range or
+   * multiple. Use this when you know the exact range of the current buffer
+   * that should be replaced with the given text.
+   *
+   * Added in 5.0.0. Has no effect if `textEdit` is specified.
+   */
+  ranges?: Range[]
+
+  /**
+   * Text before the cursor that should be replaced as part of the insertion of
+   * this suggestion. Optional; if omitted, the prefix before the cursor will
+   * be used. Has no effect if `textEdit` or `ranges` is specified.
+   */
+  replacementPrefix?: string
+
+  /**
+   * A "type" for this suggestion. Used to classify suggestions and distinguish
+   * them visually. The types of {@link SuggestionType} are preferred (and have
+   * predefined styles), but you can use an arbitrary string if none of those
+   * types suffice.
+   */
+  type?: SuggestionType | string
+
+  /**
+   * Text edits to make when the item is chosen — in addition to the main item.
+   *
+   * These are typically optional edits, such as an automatic `import`
+   * statement that's inserted when a suggestion warrants it.
+   *
+   * When present, these edits are made in all code paths, regardless of the
+   * original insertion strategy.
+   *
+   * Added in 5.1.0.
+   */
+  additionalTextEdits?: TextEdit
+
+  /**
+   * A label to display before the suggestion. This can indicate useful
+   * information like a method return type. Both text and HTML variants are
+   * supported; `leftLabelHTML` takes precedence over `leftLabel` when both are
+   * present.
+   */
+  leftLabel?: string
+  leftLabelHTML?: string
+
+  /**
+   * A label to display after the suggestion. This can indicate useful
+   * information like a type annotation. Both text and HTML variants are
+   * supported; `rightLabelHTML` takes precedence over `rightLabel` when both
+   * are present.
+   */
+  rightLabel?: string
+  rightLabelHTML?: string
+
+  /**
+   * Class name to add to the suggestion's row in the HTML. Allows for further
+   * styling customization, if needed.
+   */
+  className?: string
+
+  /**
+   * An override to allow you to specify your own icon. Should follow Octicon
+   * conventions; e.g., `"<i class="icon-move-right"></i>"`. Optional.
+   */
+  iconHTML?: string
+
+  /**
+   * A docstring summary or short description of the suggestion. When
+   * specified, it will be displayed at the bottom of the suggestions list.
+   * Optional.
+   */
+  description?: string
+
+  /**
+   * A url to the documentation or more information about this suggestion. When
+   * specified, a `More…` link will be displayed in the description area.
+   */
+  descriptionMoreURL?: string
+
+  /**
+   * A list of indices where the characters in the prefix appear in this
+   * suggestion's text.
+   * @type {Object}
+   */
+  characterMatchIndices?: number[]
+
+  // (Either `text`, `snippet`, or `textEdit` must be provided.)
+} & { text: string } | { snippet: string } | { textEdit: TextEdit};
+
+/**
+ * The provider object that you should make available to `autocomplete-plus`.
+ * This should be the return value of whatever method you specified in your
+ * `providedServices` metadata.
+ */
+type ServiceProvider = {
+  /**
+   * Selector for which this provider should be active. Multiple values can be
+   * given separated by commas.
+   */
+  selector: string,
+  /**
+   * Selector for which this provider should be inactive, even if scope
+   * otherwise matches `selector`. Multiple values can be given separated by
+   * commas.
+   */
+  disableForSelector: string,
+
+  /**
+   * The priority of this provider relative to others. Higher numbers beat
+   * lower numbers.
+   */
+  inclusionPriority: number,
+
+  /**
+   * When `true`, this provider excludes options from providers with a lower
+   * priority from even appearing in the menu.
+   */
+  excludeLowerPriority: boolean,
+
+  /**
+   * The priority of this provider's suggestions relative to other suggestions
+   * that may exist in the list. Influences the ordering of suggestions within
+   * a menu.
+   */
+  suggestionPriority: number,
+
+  /**
+   * When `true`, `autocomplete-plus` expects to receive many suggestions and
+   * will filter the list based on what's already been typed in the token. When
+   * `false`, you assert that whatever you deliver to `autocomplete-plus` has
+   * already been filtered.
+   */
+  filterSuggestions: boolean,
+
+  /**
+   * Retrieves suggestions for a given editor at a given point. Can consult
+   * other metadata. Can go async.
+   */
+  getSuggestions(meta: {
+    /** The current text editor. */
+    editor: TextEditor,
+    /** The position of the cursor. */
+    bufferPosition: Point,
+    /**
+     * The scope descriptor at the given buffer position.
+     * @see https://docs.pulsar-edit.dev/api/pulsar/latest/ScopeDescriptor/
+     */
+    scopeDescriptor: ScopeDescriptor,
+    /**
+     * The prefix that the user has typed before the cursor. Typically
+     * represents all word-like characters between the cursor and the last
+     * non-word character.
+     */
+    prefix: string,
+    /**
+     * Whether the user activated this menu manually or had it appear
+     * automatically while typing.
+     */
+    activatedManually: boolean
+  }): Suggestion[] | Promise<Suggestion[]>,
+
+  /**
+   * Fills in further details on this suggestion when it is highlighted in the
+   * menu. Optional.
+   *
+   * A language server can use this method to send `completionItem/resolve` and
+   * return an updated suggestion with the new data.
+   */
+  getSuggestionDetailsOnSelect?(suggestion: Suggestion): Promise<Suggestion>,
+
+  /**
+   * Invoked after a chosen suggestion is inserted into the editor. Optional.
+   */
+  onDidInsertSuggestion?(meta: {
+    /** The current text editor. */
+    editor: TextEditor,
+    /** The position of the cursor when the suggestion was chosen. */
+    triggerPosition: Point,
+    /** The suggestion that was chosen. */
+    suggestion: Suggestion
+  }): void;
+
+  /**
+   * Called when your provider needs to be cleaned up. Optional.
+   */
+  dispose?(): void;
+}
+
+```
+
+
+## Registering your provider with `autocomplete-plus`
+
+In your `package.json`, add:
+
+```json
+"providedServices": {
+  "autocomplete.provider": {
+    "versions": {
+      "4.0.0": "provideAutocomplete"
+    }
+  }
+}
+```
+
+You may call this value whatever you like; `provideAutocomplete` is a suggestion.
+
+Then, in your main package export, define a method of the same name:
+
+```js
+module.exports = {
+  activate() {
+    // existing activation code
+  }
+
+  provideAutocomplete() {
+    // Return a value that conforms to the `ServiceProvider` interface
+    // described above…
+    return new Provider()
+
+    // …or return multiple such providers as an array.
+    return [new Provider(), new OtherProvider()]
+  }
+}
+```
+
+
+## Tips
+
+`autocomplete-plus` guesses at the “prefix” — that is, the range of characters before the cursor that might be part of whatever suggestion you will insert.
+
+For some languages, you may need to override this by specifying a `replacementPrefix` value for each suggestion:
+
+```js
+let provider = {
+  selector: 'source.js',
+  getSuggestions({ editor, bufferPosition }) {
+    let prefix = this.getPrefix(editor, bufferPosition)
+  },
+
+  getPrefix(editor, bufferPosition) {
+    // Whatever your prefix regex might be.
+    let regex = /[\w0-9_-]+$/
+
+    // Get the text for the line up to the triggered buffer position.
+    let line = line = editor.getTextInRange([
+      [bufferPosition.row, 0],
+      bufferPosition
+    ])
+
+    // Match the regex to the line, and return the match (if any).
+    return line.match(regex)?.[0] ?? ''
+  }
+
+}
+```

--- a/packages/autocomplete-plus/lib/autocomplete-manager.js
+++ b/packages/autocomplete-plus/lib/autocomplete-manager.js
@@ -9,13 +9,34 @@ const getAdditionalWordCharacters = require('./get-additional-word-characters')
 const MAX_LEGACY_PREFIX_LENGTH = 80
 const wordCharacterRegexCache = new Map()
 
+const MARKER_LAYERS_FOR_EDITORS = new WeakMap()
+
+function findOrCreateMarkerLayerForEditor(editor) {
+  let layer = MARKER_LAYERS_FOR_EDITORS.get(editor)
+  if (!layer) {
+    layer = editor.addMarkerLayer()
+    MARKER_LAYERS_FOR_EDITORS.set(editor, layer)
+  }
+  return layer
+}
+
+function compareRanges(a, b) {
+  let rangeA = Range.fromObject(a)
+  let rangeB = Range.fromObject(b)
+  return rangeA.compare(rangeB)
+}
+
+function sortTextEdits(textEdits) {
+  return textEdits.sort((a, b) => compareRanges(a.range, b.range))
+}
+
 // Deferred requires
 let minimatch = null
 let grim = null
 
 module.exports =
 class AutocompleteManager {
-  constructor () {
+  constructor() {
     this.autosaveEnabled = false
     this.backspaceTriggersAutocomplete = true
     this.autoConfirmSingleSuggestionEnabled = true
@@ -48,7 +69,7 @@ class AutocompleteManager {
     this.watchedEditors = new WeakSet()
   }
 
-  initialize () {
+  initialize() {
     this.subscriptions = new CompositeDisposable()
 
     this.providerManager.initialize()
@@ -71,11 +92,11 @@ class AutocompleteManager {
     this.ready = true
   }
 
-  setSnippetsManager (snippetsManager) {
+  setSnippetsManager(snippetsManager) {
     this.snippetsManager = snippetsManager
   }
 
-  updateCurrentEditor (currentEditor, labels) {
+  updateCurrentEditor(currentEditor, labels) {
     if (currentEditor === this.editor) { return }
     if (this.editorSubscriptions) {
       this.editorSubscriptions.dispose()
@@ -86,6 +107,7 @@ class AutocompleteManager {
     this.editor = null
     this.editorView = null
     this.buffer = null
+    this.markerLayer = null
     this.isCurrentFileBlackListedCache = null
 
     if (!this.editorIsValid(currentEditor)) { return }
@@ -96,6 +118,7 @@ class AutocompleteManager {
     this.editorLabels = labels
     this.editorView = atom.views.getView(this.editor)
     this.buffer = this.editor.getBuffer()
+    this.markerLayer = findOrCreateMarkerLayerForEditor(this.editor)
 
     this.editorSubscriptions = new CompositeDisposable()
 
@@ -128,7 +151,7 @@ class AutocompleteManager {
     }))
   }
 
-  editorIsValid (editor) {
+  editorIsValid(editor) {
     // TODO: remove conditional when `isTextEditor` is shipped.
     if (typeof atom.workspace.isTextEditor === 'function') {
       return atom.workspace.isTextEditor(editor)
@@ -144,7 +167,7 @@ class AutocompleteManager {
   // providers with the given `labels`.
   //
   // Returns a {Disposable} to stop watching the `editor`.
-  watchEditor (editor, labels) {
+  watchEditor(editor, labels) {
     if (this.watchedEditors.has(editor)) return
 
     let view = atom.views.getView(editor)
@@ -176,7 +199,7 @@ class AutocompleteManager {
     })
   }
 
-  handleEvents () {
+  handleEvents() {
     this.subscriptions.add(atom.workspace.observeTextEditors((editor) => {
       const disposable = this.watchEditor(editor, ['workspace-center'])
       editor.onDidDestroy(() => disposable.dispose())
@@ -209,7 +232,7 @@ class AutocompleteManager {
     this.subscriptions.add(this.suggestionList.onDidSelect(suggestion => { this.getDetailsOnSelect(suggestion) }))
   }
 
-  handleCommands () {
+  handleCommands() {
     return this.subscriptions.add(atom.commands.add('atom-text-editor', {
       'autocomplete-plus:activate': (event) => {
         this.shouldDisplaySuggestions = true
@@ -232,7 +255,7 @@ class AutocompleteManager {
 
   // Private: Finds suggestions for the current prefix, sets the list items,
   // positions the overlay and shows it
-  findSuggestions (activatedManually) {
+  findSuggestions(activatedManually) {
     if (this.disposed) { return }
     if ((this.providerManager == null) || (this.editor == null) || (this.buffer == null)) { return }
     if (this.isCurrentFileBlackListed()) { return }
@@ -247,7 +270,7 @@ class AutocompleteManager {
     return this.getSuggestionsFromProviders({editor: this.editor, bufferPosition, scopeDescriptor, prefix, legacyPrefix, activatedManually})
   }
 
-  getSuggestionsFromProviders (options) {
+  getSuggestionsFromProviders(options) {
     let suggestionsPromise
     const providers = this.providerManager.applicableProviders(this.editorLabels, options.scopeDescriptor)
 
@@ -360,7 +383,7 @@ class AutocompleteManager {
     )
   }
 
-  filterSuggestions (suggestions, {prefix}) {
+  filterSuggestions(suggestions, {prefix}) {
     const results = []
     for (let i = 0; i < suggestions.length; i++) {
       // sortScore mostly preserves in the original sorting. The function is
@@ -389,7 +412,7 @@ class AutocompleteManager {
     return results
   }
 
-  reverseSortOnScoreComparator (a, b) {
+  reverseSortOnScoreComparator(a, b) {
     let bscore = b.score
     if (!bscore) {
       bscore = b.sortScore
@@ -402,7 +425,7 @@ class AutocompleteManager {
   }
 
   // providerSuggestions - array of arrays of suggestions provided by all called providers
-  mergeSuggestionsFromProviders (providerSuggestions) {
+  mergeSuggestionsFromProviders(providerSuggestions) {
     return providerSuggestions.reduce((suggestions, providerSuggestions) => {
       if (providerSuggestions && providerSuggestions.length) {
         suggestions = suggestions.concat(providerSuggestions)
@@ -412,7 +435,7 @@ class AutocompleteManager {
     }, [])
   }
 
-  deprecateForSuggestion (provider, suggestion) {
+  deprecateForSuggestion(provider, suggestion) {
     let hasDeprecations = false
     if (suggestion.word != null) {
       hasDeprecations = true
@@ -462,7 +485,7 @@ See https://github.com/atom/autocomplete-plus/wiki/Provider-API`
     return hasDeprecations
   }
 
-  displaySuggestions (suggestions, options) {
+  displaySuggestions(suggestions, options) {
     switch (atom.config.get('autocomplete-plus.similarSuggestionRemoval')) {
       case 'textOrSnippet': {
         suggestions = this.getUniqueSuggestions(suggestions, (suggestion) => suggestion.text + suggestion.snippet)
@@ -477,7 +500,7 @@ See https://github.com/atom/autocomplete-plus/wiki/Provider-API`
     }
   }
 
-  getUniqueSuggestions (suggestions, uniqueKeyFunction) {
+  getUniqueSuggestions(suggestions, uniqueKeyFunction) {
     const seen = {}
     const result = []
     for (let i = 0; i < suggestions.length; i++) {
@@ -491,7 +514,7 @@ See https://github.com/atom/autocomplete-plus/wiki/Provider-API`
     return result
   }
 
-  getPrefix (editor, position, scopeDescriptor) {
+  getPrefix(editor, position, scopeDescriptor) {
     const wordCharacterRegex = this.getWordCharacterRegex(scopeDescriptor)
     const line = editor.getBuffer().getTextInRange([[position.row, 0], position])
 
@@ -507,7 +530,7 @@ See https://github.com/atom/autocomplete-plus/wiki/Provider-API`
     return line.slice(startColumn)
   }
 
-  getWordCharacterRegex (scopeDescriptor) {
+  getWordCharacterRegex(scopeDescriptor) {
     const additionalWordChars = getAdditionalWordCharacters(scopeDescriptor)
     let regex = wordCharacterRegexCache.get(additionalWordChars)
 
@@ -518,7 +541,7 @@ See https://github.com/atom/autocomplete-plus/wiki/Provider-API`
     return regex
   }
 
-  getLegacyPrefix (editor, bufferPosition) {
+  getLegacyPrefix(editor, bufferPosition) {
     const {row, column} = bufferPosition
     const line = editor.getTextInRange(new Range(
       new Point(row, Math.max(0, column - MAX_LEGACY_PREFIX_LENGTH)),
@@ -532,7 +555,7 @@ See https://github.com/atom/autocomplete-plus/wiki/Provider-API`
   // Private: Gets called when the user successfully confirms a suggestion
   //
   // match - An {Object} representing the confirmed suggestion
-  confirm (suggestion) {
+  confirm(suggestion) {
     if ((this.editor == null) || (suggestion == null) || !!this.disposed) { return }
 
     const apiVersion = this.providerManager.apiVersionForProvider(suggestion.provider)
@@ -567,7 +590,7 @@ See https://github.com/atom/autocomplete-plus/wiki/Provider-API`
     }
   }
 
-  getDetailsOnSelect (suggestion) {
+  getDetailsOnSelect(suggestion) {
     if (suggestion != null && suggestion.provider && suggestion.provider.getSuggestionDetailsOnSelect) {
       Promise.resolve(suggestion.provider.getSuggestionDetailsOnSelect(suggestion))
         .then(detailedSuggestion => {
@@ -576,20 +599,20 @@ See https://github.com/atom/autocomplete-plus/wiki/Provider-API`
     }
   }
 
-  showSuggestionList (suggestions, options) {
+  showSuggestionList(suggestions, options) {
     if (this.disposed) { return }
     this.suggestionList.changeItems(suggestions)
     return this.suggestionList.show(this.editor, options)
   }
 
-  hideSuggestionList () {
+  hideSuggestionList() {
     if (this.disposed) { return }
     this.suggestionList.changeItems(null)
     this.suggestionList.hide()
     this.shouldDisplaySuggestions = false
   }
 
-  requestHideSuggestionList (command) {
+  requestHideSuggestionList(command) {
     if (this.hideTimeout == null) {
       this.hideTimeout = setTimeout(() => {
         this.hideSuggestionList()
@@ -599,29 +622,74 @@ See https://github.com/atom/autocomplete-plus/wiki/Provider-API`
     this.shouldDisplaySuggestions = false
   }
 
-  cancelHideSuggestionListRequest () {
+  cancelHideSuggestionListRequest() {
     clearTimeout(this.hideTimeout)
     this.hideTimeout = null
+  }
+
+  // Private: Applies a `TextEdit` to the given editor.
+  applyTextEdit(textEdit) {
+    if (this.editor === null) return;
+    let range = Range.fromObject(textEdit.range ?? textEdit.oldRange);
+    this.editor.setTextInBufferRange(range, textEdit.newText);
   }
 
   // Private: Replaces the current prefix with the given match.
   //
   // match - The match to replace the current prefix with
-  replaceTextWithMatch (suggestion) {
+  replaceTextWithMatch(suggestion) {
     if (this.editor == null) { return }
 
     const cursors = this.editor.getCursors()
     if (cursors == null) { return }
 
     return this.editor.transact(() => {
-      if(suggestion.ranges) {
-        for (let i = 0; i < suggestion.ranges.length; i++) {
-          const range = suggestion.ranges[i]
-          this.editor.setTextInBufferRange(
-            range, suggestion.text != null ? suggestion.text : suggestion.snippet
-          )
+      // Guard against any stray display markers somehow still being on the
+      // layer.
+      this.markerLayer.clear()
+
+      let additionalTextEditMarkers = null
+      if (suggestion.additionalTextEdits) {
+        let textEdits = sortTextEdits(Array.from(suggestion.additionalTextEdits))
+        additionalTextEditMarkers = []
+
+        // We could apply all the `TextEdit`s at once, but we'd have to find a
+        // way to express the default insertion strategy (with consideration of
+        // prefix) as a `TextEdit`, since `additionalTextEdits` is valid no
+        // matter the insertion strategy.
+        //
+        // So we won't do that; we'll apply the main edit first. But that means
+        // we must now guard against their buffer ranges changing after the
+        // edit, so we'll track any change in their buffer ranges with display
+        // markers.
+        for (let textEdit of textEdits) {
+          let range = Range.fromObject(textEdit.range ?? textEdit.oldRange)
+          let marker = this.markerLayer.markBufferRange(range)
+          additionalTextEditMarkers.push([marker, textEdit])
+        }
+      }
+
+      if (suggestion.textEdit) {
+        // Suggestion wants to apply a `TextEdit` in order to insert itself.
+        // This occurs instead of the default text insertion strategy. Sort
+        // them in buffer order, then apply them in reverse order (so that no
+        // buffer position is affected by any other edits).
+        this.applyTextEdit(suggestion.textEdit);
+      } else if (suggestion.ranges) {
+        // Suggestion wants to insert the default text over one or more
+        // specific ranges. This occurs instead of the default text insertion
+        // strategy. The same text is inserted into each range. Sort the ranges
+        // in buffer order, then apply the edits in reverse order (so that
+        // no buffer position is affected by any other edits).
+        let ranges = Array.from(suggestion.ranges).sort(compareRanges)
+        for (let i = ranges.length - 1; i >= 0; i--) {
+          const range = Range.fromObject(ranges[i])
+          this.editor.setTextInBufferRange(range, suggestion.text ?? suggestion.snippet)
         }
       } else {
+        // Default text insertion strategy: insert the text or snippet,
+        // possibly correcting for characters that might already have been
+        // typed.
         for (let i = 0; i < cursors.length; i++) {
           const cursor = cursors[i]
           const endPosition = cursor.getBufferPosition()
@@ -643,10 +711,46 @@ See https://github.com/atom/autocomplete-plus/wiki/Provider-API`
           }
         }
       }
+
+      // Alongside any of these insertion strategies, a suggestion can specify
+      // additional text edits that should be made. These are typically
+      // optional.
+      //
+      // One example might be auto-inserting an import/include statement when a
+      // suggestion from a specific library is inserted (and the library is not
+      // already included into the buffer).
+      //
+      // The buffer positions we originally received might be inaccurate now,
+      // because we've changed the buffer since we received these suggestions.
+      // That's why we marked the buffer ranges before we made this edit.
+      if (additionalTextEditMarkers) {
+        for (let i = additionalTextEditMarkers.length - 1; i >= 0; i--) {
+          let [marker, textEdit] = additionalTextEditMarkers[i]
+
+          // Now that a suggestion can contain any number of arbitrary text
+          // edits, there are some basic sanity rules expected from
+          // autocompletion providers. As the LSP spec says: "Edits must not
+          // overlap (including the same insert position) with the main edit
+          // nor with themselves."
+          //
+          // Hence this could only happen if the provider were behaving
+          // incorrectly, but we'll check for it anyway.
+          if (!marker.isValid()) continue
+
+          let newTextEdit = {
+            newText: textEdit.newText,
+            range: marker.getBufferRange()
+          }
+          this.applyTextEdit(newTextEdit)
+        }
+        // We're done with these markers. We only needed them for a moment so
+        // we could track any content shifts.
+        this.markerLayer.clear()
+      }
     })
   }
 
-  getSuffix (editor, bufferPosition, suggestion) {
+  getSuffix(editor, bufferPosition, suggestion) {
     // This just chews through the suggestion and tries to match the suggestion
     // substring with the lineText starting at the cursor. There is probably a
     // more efficient way to do this.
@@ -664,7 +768,7 @@ See https://github.com/atom/autocomplete-plus/wiki/Provider-API`
   // Private: Checks whether the current file is blacklisted.
   //
   // Returns {Boolean} that defines whether the current file is blacklisted
-  isCurrentFileBlackListed () {
+  isCurrentFileBlackListed() {
     // minimatch is slow. Not necessary to do this computation on every request for suggestions
     let left
     if (this.isCurrentFileBlackListedCache != null) { return this.isCurrentFileBlackListedCache }
@@ -689,7 +793,7 @@ See https://github.com/atom/autocomplete-plus/wiki/Provider-API`
   }
 
   // Private: Gets called when the content has been modified
-  requestNewSuggestions () {
+  requestNewSuggestions() {
     let delay = atom.config.get('autocomplete-plus.autoActivationDelay')
 
     if (this.delayTimeout != null) {
@@ -705,7 +809,7 @@ See https://github.com/atom/autocomplete-plus/wiki/Provider-API`
     this.shouldDisplaySuggestions = true
   }
 
-  cancelNewSuggestionsRequest () {
+  cancelNewSuggestionsRequest() {
     if (this.delayTimeout != null) {
       clearTimeout(this.delayTimeout)
     }
@@ -716,7 +820,7 @@ See https://github.com/atom/autocomplete-plus/wiki/Provider-API`
   // the text has not been changed.
   //
   // data - An {Object} containing information on why the cursor has been moved
-  cursorMoved ({textChanged}) {
+  cursorMoved({textChanged}) {
     // The delay is a workaround for the backspace case. The way atom implements
     // backspace is to select left 1 char, then delete. This results in a
     // cursorMoved event with textChanged == false. So we delay, and if the
@@ -728,11 +832,11 @@ See https://github.com/atom/autocomplete-plus/wiki/Provider-API`
 
   // Private: Gets called when the user saves the document. Cancels the
   // autocompletion.
-  bufferSaved () {
+  bufferSaved() {
     if (!this.autosaveEnabled) { return this.hideSuggestionList() }
   }
 
-  showOrHideSuggestionListForBufferChanges ({changes}) {
+  showOrHideSuggestionListForBufferChanges({changes}) {
     if (this.disposed) return
 
     const lastCursorPosition = this.editor.getLastCursor().getBufferPosition()
@@ -772,7 +876,7 @@ See https://github.com/atom/autocomplete-plus/wiki/Provider-API`
     }
   }
 
-  shouldSuppressActivationForEditorClasses () {
+  shouldSuppressActivationForEditorClasses() {
     for (let i = 0; i < this.suppressForClasses.length; i++) {
       const classNames = this.suppressForClasses[i]
       let containsCount = 0
@@ -786,7 +890,7 @@ See https://github.com/atom/autocomplete-plus/wiki/Provider-API`
   }
 
   // Public: Clean up, stop listening to events
-  dispose () {
+  dispose() {
     this.hideSuggestionList()
     this.disposed = true
     this.ready = false

--- a/packages/autocomplete-plus/spec/provider-api-spec.js
+++ b/packages/autocomplete-plus/spec/provider-api-spec.js
@@ -5,8 +5,11 @@ import {
   waitForAutocomplete,
   triggerAutocompletion,
   conditionPromise,
-  waitForAutocompleteToDisappear} from './spec-helper'
+  waitForAutocompleteToDisappear
+} from './spec-helper'
 import path from 'path'
+
+import { Range } from 'atom'
 
 describe('Provider API', () => {
   let [editor, mainModule, autocompleteManager, registration, testProvider, testProvider2] = []
@@ -314,7 +317,13 @@ describe('Provider API', () => {
         filterSuggestions: true,
         getSuggestions (options) {
           return [
-            {text: 'ohai', ranges: [[[0, 0], [0, 5]]]},
+            {
+              text: 'ohai',
+              ranges: [
+                [[0, 0], [0, 5]],
+                [[0, 7], [0, 12]]
+              ]
+            },
             {text: 'ca.ts'},
             {text: '::dogs'}
           ]
@@ -325,7 +334,7 @@ describe('Provider API', () => {
       await triggerAutocompletion()
       await confirmChoice(0)
 
-      expect(editor.getText()).toEqual("ohai, world\n")
+      expect(editor.getText()).toEqual("ohai, ohai\n")
     })
 
     it('ignores `prefix` if `range` is present', async () => {
@@ -334,7 +343,12 @@ describe('Provider API', () => {
         filterSuggestions: true,
         getSuggestions (options) {
           return [
-            {text: 'notmatch/foololohairange', ranges: [[[0, 0], [0, 5]]]},
+            {
+              text: 'notmatch/foololohairange',
+              ranges: [
+                [[0, 0], [0, 5]]
+              ]
+            },
             {text: 'notmatch/foololohaiprefix'},
             {text: 'foololohaiprefix2'}
           ]
@@ -346,6 +360,80 @@ describe('Provider API', () => {
       expect(document.querySelector('autocomplete-suggestion-list').innerText).toMatch(/notmatch\/foololohairange/)
       expect(document.querySelector('autocomplete-suggestion-list').innerText).toMatch(/foololohaiprefix2/)
       expect(document.querySelector('autocomplete-suggestion-list').innerText).toNotMatch(/notmatch\/foololohaiprefix/)
+    })
+  })
+
+  describe('Provider API v5.1.0', () => {
+    function triggerAutocompletion () {
+      atom.commands.dispatch(atom.views.getView(editor), 'autocomplete-plus:activate')
+      return waitForAutocomplete(editor)
+    }
+
+    function confirmChoice () {
+      atom.commands.dispatch(atom.views.getView(editor), 'autocomplete-plus:confirm')
+      return waitForAutocompleteToDisappear(editor)
+    }
+
+    beforeEach(() => editor.setText(''))
+
+    it('replaces the correct range on the editor when `textEdit` is present', async () => {
+      testProvider = {
+        scopeSelector: '.source.js',
+        filterSuggestions: true,
+        getSuggestions () {
+          return [
+            {
+              text: 'ohai',
+              textEdit: {
+                range: [{ row: 0, column: 0 }, { row: 0, column: 5 }],
+                newText: 'kbye'
+              }
+            },
+            { text: 'ca.ts' },
+            { text: '::dogs'}
+          ]
+        }
+      }
+      registration = atom.packages.serviceHub.provide('autocomplete.provider', '5.0.0', testProvider)
+      editor.insertText('hello, world\n')
+
+      await triggerAutocompletion()
+      await confirmChoice(0)
+
+      expect(editor.getText()).toEqual("kbye, world\n")
+    })
+
+    it('applies additional text edits if they are specified on the suggestion, even if their original buffer ranges are invalidated', async () => {
+      testProvider = {
+        scopeSelector: '.source.js',
+        filterSuggestions: true,
+        getSuggestions () {
+          return [
+            {
+              text: 'ohai',
+              textEdit: {
+                range: [[2, 0], [2, 5]],
+                // Our new text will insert a newline, thereby changing the
+                // buffer range of one of our `additionalTextEdits`.
+                newText: 'kbye\n'
+              },
+              additionalTextEdits: [
+                { range: [[1, 0], [1, 5]], newText: 'ipsum' },
+                { range: new Range([3, 0], [3, 5]), newText: 'amet' }
+              ]
+            },
+            { text: 'ca.ts' },
+            { text: '::dogs'}
+          ]
+        }
+      }
+      registration = atom.packages.serviceHub.provide('autocomplete.provider', '5.0.0', testProvider)
+      editor.insertText('\nlorem\nhello, world\ndolor\n')
+
+      await triggerAutocompletion()
+      await confirmChoice(0)
+
+      expect(editor.getText()).toEqual("\nipsum\nkbye\n, world\namet\n")
     })
   })
 })


### PR DESCRIPTION
…when a suggestion is accepted.

Suppose I'm writing some TypeScript and I've got `pulsar-ide-typescript` installed. I autocomplete a function name and am told that it can auto-import a suggestion.

<p><img width="635" alt="Screenshot 2025-06-29 at 5 59 21 PM" src="https://github.com/user-attachments/assets/98834edf-1289-428b-ae7e-f03c25bdc4d4" /></p>

Neat!

I accept the suggestion… and the import isn't auto’d after all.

<p><img width="553" alt="Screenshot 2025-06-29 at 5 59 33 PM" src="https://github.com/user-attachments/assets/49027f2d-c433-4f59-877c-2d17e56cd932" /></p>

Yet I know `typescript-language-server` is capable of inserting this import because I can activate a code action that does the same thing:

<p><img width="584" alt="Screenshot 2025-06-29 at 5 59 45 PM" src="https://github.com/user-attachments/assets/042ec629-dded-4f61-8e4a-f9c7b1924ad4" /></p>

This works just fine. So why doesn't the auto-import work in the first place?

## `autocomplete.provider`

`autocomplete-plus` consumes the `autocomplete.provider` service. It can only do what that service is capable of expressing.

For instance, language servers are often very precise about how an autocompletion suggestion should be inserted, to the point where it can describe the exact buffer range to replace. This is called a [`TextEdit`](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textEdit). This was a foreign concept to `autocomplete.provider`, since it typically matches what has already been typed before the cursor against the text to insert, and wisely assumes that it can subtract what has already been typed from what it has been told to insert. It's not prepared for a provider to volunteer to do that work for it.

@mauricioszabo dragged `autocomplete.provider` forward somewhat in #479. For the first time, a suggestion could describe one or more buffer ranges into which it could be inserted, bypassing the default insertion strategy.

This was good, but it wasn't complete enough for this use case. The [LSP spec’s definition of a `CompletionItem`](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#completionItem) envisions an array of `additionalTextEdits` that would make arbitrary changes to a buffer when a suggestion is accepted:

```
/**
 * An optional array of additional text edits that are applied when
 * selecting this completion. Edits must not overlap (including the same
 * insert position) with the main edit nor with themselves.
 *
 * Additional text edits should be used to change text unrelated to the
 * current cursor position (for example adding an import statement at the
 * top of the file if the completion item will insert an unqualified type).
 */
```

Seems like they had this exact use case in mind!

The `ranges` added in #479 still involve a single insertion placed into one or more specific ranges; whereas `additionalTextEdits` could insert different text into each of its ranges.

So I created a `TextEdit` equivalent for the Atom API. Language servers describe ranges in `line`s and `character`s instead of our (obviously superior!) terminology of `row`s and `column`s. But otherwise the type is the same!

```js
let textEdit = { range: new Range([0, 0], [0, 5]), newText: 'hello' };
```

I’ve just created a `TextEdit`.

In fact, there’s a similar sort of object in the Atom IDE type defintions, except it’s more like:

```ts
type TextEdit = {
  oldRange: Range,
  oldText?: string,
  newText: string
};
```

They use `oldRange` instead of `range` as the property name, plus they optionally include `oldText` — not strictly necessary for applying a `TextEdit`, but possibly useful as a sanity check that the range in the buffer still matches what was intended to be replaced. Anyway, it’s easy enough to be permissive and allow either one, so we can accept either `oldRange` or `range` as the property in our `TextEdit`s.

These edits must be applied carefully, and you might already have noticed why. Almost every time I edit a document, I’ll end up shifting content around. So if I’ve got a list of five edits, and I apply them in buffer order, I’ll probably invalidate ranges 2–5 as soon as I make the first edit.

One way around this is to apply them in _reverse_ buffer order; it’s easy to reason through how that’s a guaranteed way for the fifth not to affect the ranges of the first four.

But that doesn’t quite work for us because we’ve got to apply our `additionalTextEdits` _after_ the main insertion. So we create `DisplayMarker`s on the ranges of the `additionalTextEdits` before the main edit — that way we can track their movement!

Here’s the result, as it ought to be:

https://github.com/user-attachments/assets/9ac5f4bb-7d39-4de5-9aa3-504b62754679

I'll have to update `@savetheclocktower/atom-languageclient` before this magically propagates across all of the `pulsar-ide-*` world, but as soon as this lands and we release a new Pulsar version, individual packages will be able to opt into this behavior by manually augmenting suggestion objects via [the `onDidConvertAutocomplete` hook](https://github.com/savetheclocktower/atom-languageclient/blob/master/lib/auto-languageclient.ts#L1050-L1054). That's where you can view the original LSP `CompletionItem` and the `Suggestion` that it became, and do any further modification.

---

I also took the opportunity to stop linking to the Atom `autocomplete-plus` repository's wiki for the service definition. You'll see this PR includes a new Markdown file that describes the service contract. AtomDoc (which we use to document the rest of our API) isn't quite ideal for documenting abstract interfaces like this, so while I'm not 100% in love with having service definitions documented in random Markdown files, I think it's probably better than having them documented in random wiki pages that we don't own.