### PR TITLE
Update download link for `appimagetool`

### DIFF
--- a/script/fix-linux-appimage.sh
+++ b/script/fix-linux-appimage.sh
@@ -103,7 +103,7 @@ cd ../..
 # Now that we've made the change, we can use `appimagetool` to bundle
 # everything up with the original file name.
 echo "Downloading appimagetool…"
-wget "https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-${APPIMAGE_ARCH}.AppImage" -O appimagetool
+wget "https://github.com/AppImage/AppImageKit/releases/download/continuous/obsolete-appimagetool-${APPIMAGE_ARCH}.AppImage" -O appimagetool
 echo "Making appimagetool executable…"
 chmod +x appimagetool
 


### PR DESCRIPTION
After #1309 seemed to fix the build job in Ubuntu, we've got a new failure!

This time it's because the download link to `appimagetool` has changed in a passive-aggressive effort to get people to stop using the old version and start using a newer version.

The “proper” fix for this is present in #1241, but I need help from someone who can verify it in a Linux x86 environment. I can't easily run Linux x64 on my Apple Silicon Mac, so I wasn't able to verify the CI-generated binary, and running `fix-linux-appimage.sh` locally within my Linux ARM VM didn't seem to have the intended effect.

In the meantime, this updated download link should maintain the status quo. (The main downside to staying with this old version of `appimagetool` is that users might have to manually install `libfuse2`, since it generally is no longer bundled with the OS in major distros.)