### PR TITLE
Cirrus: Fetch Buster packages from archive.debian.org

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -65,6 +65,8 @@ arm_linux_task:
     USE_SYSTEM_FPM: 'true'
     ROLLING_UPLOAD_TOKEN: ENCRYPTED[6806f0b2346b9fc7d98ea3930087c063b8c44492e720223271331c0f317d77532062a2c8d4538f9ddc6f81415706bcf5]
   prepare_script:
+    - sed -i s/deb.debian.org/archive.debian.org/g /etc/apt/sources.list
+    - sed -i s/security.debian.org/archive.debian.org/g /etc/apt/sources.list
     - apt-get update
     - export DEBIAN_FRONTEND="noninteractive"
     - apt-get install -y


### PR DESCRIPTION
# Cirrus: Fetch Buster packages from archive.debian.org

Debian Buster is old, and its package repos are archived. If we want to keep using it, then we have to update the URL we fetch its packages from.

Copied from @savetheclocktower's fix in PR https://github.com/pulsar-edit/pulsar/pull/1309
(commit 45abc5bb4286a2bfc5f690c3838889baa4d214f0)

## Verification Process

As of yet **_untested_** in Cirrus. But our Cirrus logs do indicate our setup is using a Debian Buster-based image currently. So, the same fix from #1309 ought to work. I can optionally spin up a cron task to test this in Cirrus if desired. (It works already in GitHub Actions.)

## To-Do (Port This)

Port this to the "latest Electron" branch(es) (I am particularly thinking of the `updated-latest-electron` branch)