### PR TITLE
Cirrus: Fetch Buster packages from archive.debian.org (for latest Electron branch)

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -65,6 +65,8 @@ arm_linux_task:
     USE_SYSTEM_FPM: 'true'
     ROLLING_UPLOAD_TOKEN: ENCRYPTED[693f9eca17f910a1851028ce17637e39adb6393e84f8a18a58a40384ea7cc92bee9196a9671e2fe3031d359a572a4398] # <-- This is the Electron Next Bins token! Careful when resolving merge conflicts to not overrite to/from master. master branch keeps its token, updated-latest-electron branch keeps this one!
   prepare_script:
+    - sed -i s/deb.debian.org/archive.debian.org/g /etc/apt/sources.list
+    - sed -i s/security.debian.org/archive.debian.org/g /etc/apt/sources.list
     - apt-get update
     - export DEBIAN_FRONTEND="noninteractive"
     - apt-get install -y


### PR DESCRIPTION
### Cirrus CI Fix (for latest Electron branch this time)

Debian Buster is old, and its package repos are archived. If we want to keep using it, then we have to update the URL we fetch its packages from.

Copied from @savetheclocktower's fix in PR #1309, which fixed the issue for our GitHub Actions workflows (commit 45abc5bb4286a2bfc5f690c3838889baa4d214f0)

### Verification Process

Worked in CI: https://cirrus-ci.com/task/5315908932993024?logs=prepare#L3

### Port Note

**(This is a port of PR #1315, but targeting the `updated-latest-electron` branch, whereas #1315 targeted `master` branch.)**