### PR TITLE
Port ARM Linux Cirrus fixes to `updated-latest-electron`

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -117,6 +117,7 @@ arm_linux_task:
     - python_fetch_and_build
   install_python_script:
     - cd "Python-${PYTHON_VERSION}.9" && make install
+    - python3 -m pip install setuptools
   install_script:
     - yarn install --ignore-engines || yarn install --ignore-engines
   build_script:


### PR DESCRIPTION
Porting https://github.com/pulsar-edit/pulsar/pull/1237 to the `updated-latest-electron` branch.

Doing so because ARM Linux hasn't been passing lately in Cirrus. (Thanks to @asiloisad for pointing this out on Discord!!). This particular issue probably wasn't singled out or noticed right away since it was masked by other problems causing ARM Linux to fail on this branch for some months now (at least as far back as the Cirrus logs are kept around for, March 31st as of the time of writing.)

**Verification Process:**

Worked in a one-off CI run I scheduled on the Cirrus dashboard for this repo... ✅ 

https://cirrus-ci.com/task/6442553949552640