### PR TITLE
update-manager-spec.js - release notes url spec change

### DIFF
--- a/packages/about/spec/update-manager-spec.js
+++ b/packages/about/spec/update-manager-spec.js
@@ -12,13 +12,13 @@ describe('UpdateManager', () => {
       expect(updateManager.getReleaseNotesURLForVersion('1.100.0-dev')).toContain(
         'pulsar-edit/pulsar/blob/master/CHANGELOG.md#11000-dev'
       );
-    });
-    it('returns the page for the release when not a dev version', () => {
       expect(updateManager.getReleaseNotesURLForVersion('1.108.2023090322')).toContain(
         'pulsar-edit/pulsar/blob/master/CHANGELOG.md#11082023090322'
       );
-      expect(updateManager.getReleaseNotesURLForVersion('1.100.0')).toContain(
-        'pulsar-edit/pulsar/blob/master/CHANGELOG.md#11000'
+    });
+    it('returns the page for the release when not a dev version', () => {
+      expect(updateManager.getReleaseNotesURLForVersion('1.129.0')).toContain(
+        'pulsar-edit/pulsar/blob/master/CHANGELOG.md#11290'
       );
       expect(updateManager.getReleaseNotesURLForVersion('v1.100.0')).toContain(
         'pulsar-edit/pulsar/blob/master/CHANGELOG.md#11000'

--- a/packages/about/spec/update-manager-spec.js
+++ b/packages/about/spec/update-manager-spec.js
@@ -12,10 +12,14 @@ describe('UpdateManager', () => {
       expect(updateManager.getReleaseNotesURLForVersion('1.100.0-dev')).toContain(
         'pulsar-edit/pulsar/blob/master/CHANGELOG.md#11000-dev'
       );
+    });
+
+    it('returns the page for the release when a rolling ("nightly") release version', () => {
       expect(updateManager.getReleaseNotesURLForVersion('1.108.2023090322')).toContain(
         'pulsar-edit/pulsar/blob/master/CHANGELOG.md#11082023090322'
       );
     });
+
     it('returns the page for the release when not a dev version', () => {
       expect(updateManager.getReleaseNotesURLForVersion('1.129.0')).toContain(
         'pulsar-edit/pulsar/blob/master/CHANGELOG.md#11290'


### PR DESCRIPTION
nest the test for a nightly version number release notes url under the dev version assertion.

https://github.com/pulsar-edit/pulsar/pull/706/files/94a24dbec32a487eb70d66e0d9c225a7a2067890#r2299519186