### PR TITLE
Cirrus: Update Electron Next binary upload token

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -63,7 +63,7 @@ arm_linux_task:
     memory: 8G
   env:
     USE_SYSTEM_FPM: 'true'
-    ROLLING_UPLOAD_TOKEN: ENCRYPTED[693f9eca17f910a1851028ce17637e39adb6393e84f8a18a58a40384ea7cc92bee9196a9671e2fe3031d359a572a4398] # <-- This is the Electron Next Bins token! Careful when resolving merge conflicts to not overrite to/from master. master branch keeps its token, updated-latest-electron branch keeps this one!
+    ROLLING_UPLOAD_TOKEN: ENCRYPTED[6ea041b7b3895b42d7a47009ecd7eab28ce132b0e03b677f97272c06c6a461e159258fdba7a8cb14d8a99738cc80efa0] # <-- This is the Electron Next Bins token! Careful when resolving merge conflicts to not overrite to/from master. master branch keeps its token, updated-latest-electron branch keeps this one!
   prepare_script:
     - sed -i s/deb.debian.org/archive.debian.org/g /etc/apt/sources.list
     - sed -i s/security.debian.org/archive.debian.org/g /etc/apt/sources.list
@@ -161,7 +161,7 @@ silicon_mac_task:
     APPLEID: ENCRYPTED[549ce052bd5666dba5245f4180bf93b74ed206fe5e6e7c8f67a8596d3767c1f682b84e347b326ac318c62a07c8844a57]
     APPLEID_PASSWORD: ENCRYPTED[774c3307fd3b62660ecf5beb8537a24498c76e8d90d7f28e5bc816742fd8954a34ffed13f9aa2d1faf66ce08b4496e6f]
     TEAM_ID: ENCRYPTED[11f3fedfbaf4aff1859bf6c105f0437ace23d84f5420a2c1cea884fbfa43b115b7834a463516d50cb276d4c4d9128b49]
-    ROLLING_UPLOAD_TOKEN: ENCRYPTED[693f9eca17f910a1851028ce17637e39adb6393e84f8a18a58a40384ea7cc92bee9196a9671e2fe3031d359a572a4398] # <-- This is the Electron Next Bins token! Careful when resolving merge conflicts to not overrite to/from master. master branch keeps its token, updated-latest-electron branch keeps this one!
+    ROLLING_UPLOAD_TOKEN: ENCRYPTED[6ea041b7b3895b42d7a47009ecd7eab28ce132b0e03b677f97272c06c6a461e159258fdba7a8cb14d8a99738cc80efa0] # <-- This is the Electron Next Bins token! Careful when resolving merge conflicts to not overrite to/from master. master branch keeps its token, updated-latest-electron branch keeps this one!
   prepare_script:
     - brew update
     - brew uninstall node@20


### PR DESCRIPTION
The old Electron Next binary upload token was set to expire soon.

Putting in a new one with a later expiry date.