### PR TITLE
[snippets] Add getter to fix `emmet` package

### DIFF
--- a/packages/snippets/lib/snippet-expansion.js
+++ b/packages/snippets/lib/snippet-expansion.js
@@ -495,4 +495,22 @@ module.exports = class SnippetExpansion {
     this.editor = editor
     this.snippets.addExpansion(this.editor, this)
   }
+
+  // This getter is present in order to prevent the `emmet` package from
+  // breaking. Because it also adds behavior to the [Tab] key, it relies on
+  // internal state to determine whether a snippet is on its final tab stop,
+  // and that code path has been broken ever since
+  // https://github.com/atom/snippets/pull/312 removed the `tabStopMarkers`
+  // property.
+  //
+  // This getter returns an array that is as useful to `emmet` as
+  // `tabStopMarkers` was, since it can tell `emmet` the number of tab stops in
+  // the active snippet. The array items themselves are not markers, but
+  // `length` is the only thing `emmet` cares about, so this is an acceptable
+  // workaround that requires no code changes on the `emmet` side.
+  //
+  // See https://github.com/pulsar-edit/pulsar/issues/1132.
+  get tabStopMarkers () {
+    return this.insertionsByIndex
+  }
 }


### PR DESCRIPTION
### Identify the Bug

#1132 describes the issue with the `emmet` package. This is not our bug, but we’re the only ones that can fix it, since `emmet` is no longer maintained.

### Description of the Change

I was a maintainer of the `snippets` package back in the Atom days. I landed a PR back in 2021 (months after the last signs of life in the `emmet` repo) that inadvertently broke `emmet` for anyone who used the <kbd>Tab</kbd> key to expand abbreviations, since it renamed a property that `emmet` relied on to decide whether it should respond to <kbd>Tab</kbd> or defer to the `snippets` package.

I’ve been using `emmet` for years, but I never noticed this bug because I map `emmet:expand-abbreviation` to another key rather than let it overload my <kbd>Tab</kbd> key with yet another action.

Anyway, it reads an array defined on `SnippetExpansion` to find out how many tab stops the current snippet has, and whether or not the user is on the final tab stop. That PR renamed `tabStopMarkers` to `insertionsByIndex`  (because the code changed such that we needed to keep track of more than just markers) and violated `emmet`’s assumptions. But all `emmet` cares about is reading the `length` property — so if we make the array available at the old name, that’s all `emmet` needs to start working again.

### Alternate Designs

1. We could’ve renamed `insertionsByIndex` back to `tabStopMarkers` even though the name is less accurate.
2. A more thorough getter could’ve been written that maps `insertionsByIndex` to the corresponding markers (which are now stored in a map keyed on `Insertion` instances).

Instead of either of these approaches, I went with the fix that involved the fewest lines of code. Alternative 2 could be worth doing in the future, but only if we had evidence that some other popular package was broken and needed that fix to start working again.

### Possible Drawbacks

I can’t think of any. As I say above, any community package code that expects `tabStopMarkers` to be present _and contain `DisplayMarker`s_ (unlike `emmet`, which just expects it to be present and an array) will be broken after this change — but that code would’ve already been broken _before_ this change, so it’s a lateral move at worst.

### Verification Process

Sadly, I couldn’t find an easy way to write a spec for this. The existing specs are very practical in nature and test the behavior of snippets at a distance, rather than caring about the contracts of specific classes like `SnippetExpansion`.

So manual verification would be something like:

1. Check out this PR and run Pulsar locally in dev mode with `ATOM_DEV_RESOURCE_PATH` set.
2. Install the `emmet` package (the official one).
3. In a new editor, set the grammar to “HTML,” type `div`, and press <kbd>Tab</kbd>. (If nothing happens, or if an actual tab character is inserted, backspace; then open the command palette and choose **Emmet: Expand Abbreviation With Tab**.) You should see it transform `div` into `<div></div>`; no errors should be present in the console or in a notification.

### Release Notes

* \[snippets\] Fixed an issue preventing the `emmet` package from expanding abbreviations under many conditions.