### PR TITLE
Fix text-editor-component annoying bug

### DIFF
--- a/src/text-editor-component.js
+++ b/src/text-editor-component.js
@@ -1804,7 +1804,7 @@ module.exports = class TextEditorComponent {
     let scrollLeftChanged = false;
     if (!this.scrollTopPending) {
       scrollTopChanged = this.setScrollTop(
-        this.refs.verticalScrollbar ? this.refs.verticalScrollbar.element.scrollTop : 0
+        this.refs.verticalScrollbar?.element.scrollTop ?? 0
       );
     }
     if (!this.scrollLeftPending) {


### PR DESCRIPTION
Hi everyone!

`didScrollDummyScrollbar()` has a bug - in some cases (I'm not sure which ones) `element ` is not defined, which causes an Uncaught TypeError.

The bug is described here: https://github.com/pulsar-edit/pulsar/issues/1228

I couldn't pinpoint the exact reason, but it's been popping up too often for me lately and it's starting to get annoying.

I suspect it has something to do with projects being closed in the previous window, but again, it doesn't always happen, so I'm not sure.

There may be a better solution, but this should also prevent the error.