### PR TITLE
Update keymap documentation links

### DIFF
--- a/dot-atom/keymap.cson
+++ b/dot-atom/keymap.cson
@@ -18,8 +18,8 @@
 #   'ctrl-p': 'core:move-down'
 #
 # You can find more information about keymaps in these guides:
-# * https://pulsar-edit.dev/docs/launch-manual/sections/using-pulsar/#customizing-keybindings
-# * https://pulsar-edit.dev/docs/launch-manual/sections/behind-pulsar#keymaps-in-depth
+# * https://docs.pulsar-edit.dev/customizing-pulsar/customizing-keybindings/
+# * https://docs.pulsar-edit.dev/infrastructure/keymaps-in-depth/
 #
 # If you're having trouble with your keybindings not working, try the
 # Keybinding Resolver: `Cmd+.` on macOS and `Ctrl+.` on other platforms. See the
@@ -29,4 +29,4 @@
 # This file uses CoffeeScript Object Notation (CSON).
 # If you are unfamiliar with CSON, you can read more about it in the
 # Pulsar Launch Manual:
-# https://pulsar-edit.dev/docs/launch-manual/sections/using-pulsar/#configuring-with-cson
+# https://docs.pulsar-edit.dev/customizing-pulsar/configuring-with-cson/


### PR DESCRIPTION
The links in the main branch don't work anymore.