### PR TITLE
Add "Regular Release Checklist" issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/regular-release-checklist.md
+++ b/.github/ISSUE_TEMPLATE/regular-release-checklist.md
@@ -1,0 +1,24 @@
+---
+name: Regular Release Checklist
+about: Checklist to ensure all Regular release steps are done and "deliverables" are
+  published
+title: Release Checklist for Regular Release v[version here, e.g. v1.130.0]
+labels: ''
+assignees: ''
+
+---
+
+# Regular Release v[version here, such as v1.130.0]
+
+- [ ] ChangeLog updated (`CHANGELOG.md` and `welcome` package)
+- [ ] Blurb Text Complete (Comment Below)
+- [ ] Version Bump PR Created
+- [ ] Binaries Uploaded to GitHub (Including renamed binaries, and SHASUM file)
+- [ ] Release Posted! 🎊
+- [ ] Update Chocolatey Release
+- [ ] Website Links updated
+- [ ] Blog Post
+- [ ] Discord Announcement
+- [ ] Reddit Announcement
+- [ ] Mastodon Announcement
+- [ ] Lemmy Announcement


### PR DESCRIPTION
From https://github.com/pulsar-edit/.github/blob/main/guides/release-checklist.md.

Should make it a lot more convenient to post the release checklist issues.

(Heck, we could automate opening the checklist issues, too. But this is a nice, convenient way to open them _manually,_ without having to know exactly where to look in the `pulsar-edit/.github` repo (hint: see link above).)