### PR TITLE
Cirrus: Pin fpm gem to ~> 1.16.0

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -99,7 +99,7 @@ arm_linux_task:
                 libffi-dev
                 zlib1g-dev
     - gem install dotenv -v '~>  2.8'
-    - gem install fpm
+    - gem install fpm -v '~> 1.16.0'
     - git submodule init
     - git submodule update
     - sed -i -e "s/[0-9]*-dev/`date -u +%Y%m%d%H`/g" package.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 - [meta] remove legacy atom project md files [@wesinator](https://github.com/pulsar-edit/pulsar/pull/1330)
 - Update keymap documentation links [@williamtheaker](https://github.com/pulsar-edit/pulsar/pull/1339)
 - [core & timecop] Locale loading Statistics [@confused-Techie](https://github.com/pulsar-edit/pulsar/pull/1338)
+- Cirrus: Pin fpm gem to ~> 1.16.0 [@DeeDeeG](https://github.com/pulsar-edit/pulsar/pull/1347)
 - Ensure `watchPath` "de-normalizes" filesystem event paths if opted into so that users of `watchPath` don't have to do their own realpath resolution [@savetheclocktower](https://github.com/pulsar-edit/pulsar/pull/1286)
 
 ## 1.129.0


### PR DESCRIPTION
The newer version of fpm (1.17.0) uses some Ruby language features which apparently aren't supported in Ruby 2.5 (which is rather old, but is the version of Ruby we have on the Debian Docker image we use in Cirrus CI at the moment).

Pin the fpm gem to effectively 1.16.x, to retain compatibility with our relatively old version of Ruby in CI.