### PR TITLE
[ci] Fix Windows Builds by manually installing the Win10 SDK

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -146,6 +146,14 @@ jobs:
         $pythonPath = (Get-Command python3)[0].Source
         echo "PYTHON=$pythonPath" >> $env:GITHUB_ENV
 
+    - name: Install Windows 10 SDK via Visual Studio
+      if: ${{ runner.os == 'Windows' }}
+      working-directory: 'C:\Program Files (x86)\Microsoft Visual Studio\Installer'
+      run: |
+        .\vs_installer.exe modify --installPath "C:\Program Files\Microsoft Visual Studio\2022\Enterprise" --add Microsoft.VisualStudio.Component.Windows10SDK.19041 --quiet --norestart --nocache | Out-Host
+      # Slight funk here, the command will act async if we don't wait for it's result. `--wait` isn't supported on `vs_installer.exe`
+      # So we use the pipe to ensure we wait for output, but for the LIFE (#1350) I can't get output here.
+
     - name: Install Pulsar Dependencies
       uses: nick-fields/retry@7152eba30c6575329ac0576536151aca5a72780e
       with:


### PR DESCRIPTION
Resolves #1349 

Between now and our last release GitHub changed `windows-latest` from `windows-2022` to `windows-2025`.

And in that change they removed all versions of the Windows SDK that aren't the newest Windows 11 ([`actions/runner-images#12677`](https://github.com/actions/runner-images/issues/12677)).

Which with our slightly older build chain we still do require the use of the Windows 10 SDK.

The most frustrating part here is that `electron-rebuild` was failing to build and more importantly **failing to tell us**.

With a snippet of the output of the [run for Pulsar v1.130.0](https://github.com/pulsar-edit/pulsar/actions/runs/18301771801/job/52111032615?pr=1348) having:

```

Run nick-fields/retry@7152eba30c6575329ac0576536151aca5a72780e
yarn run v1.22.22
$ electron-rebuild
- Searching dependency tree
✖ Rebuild Failed

An unhandled error occurred inside electron-rebuild
node-gyp failed to rebuild 'D:\a\pulsar\pulsar\node_modules\@pulsar-edit\fuzzy-native'.
For more information, rerun with the DEBUG environment variable set to "electron-rebuild".

Error: Could not find any Visual Studio installation to use



Error: node-gyp failed to rebuild 'D:\a\pulsar\pulsar\node_modules\@pulsar-edit\fuzzy-native'.
For more information, rerun with the DEBUG environment variable set to "electron-rebuild".

Error: Could not find any Visual Studio installation to use


    at NodeGyp.rebuildModule (D:\a\pulsar\pulsar\node_modules\electron-rebuild\lib\src\module-type\node-gyp.js:117:19)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
    at async ModuleRebuilder.rebuildNodeGypModule (D:\a\pulsar\pulsar\node_modules\electron-rebuild\lib\src\module-rebuilder.js:94:9)
    at async ModuleRebuilder.rebuild (D:\a\pulsar\pulsar\node_modules\electron-rebuild\lib\src\module-rebuilder.js:124:14)
    at async Rebuilder.rebuildModuleAt (D:\a\pulsar\pulsar\node_modules\electron-rebuild\lib\src\rebuild.js:145:13)
    at async Rebuilder.rebuild (D:\a\pulsar\pulsar\node_modules\electron-rebuild\lib\src\rebuild.js:108:17)
    at async D:\a\pulsar\pulsar\node_modules\electron-rebuild\lib\src\cli.js:154:9
error Command failed with exit code 4294967295.
```

After this output it continues on it's merry way building everything else that it can.

In order to fix this, instead of pinning us to `windows-2022` I instead opted to manually install the Windows 10 SDK during our build process. The step doesn't have any output but should take just over 10 minutes to install and seems to be able to build everything successfully. Although we will certainly want to test the generated bins before proper deployment, then of course we will need to release `1.130.1` to remediate this.

---

A huge thanks specifically to @scriptsforweirdos for reporting this bug so quickly and their offer to help troubleshoot.