### PR TITLE
CI: Split 'yarn build' and 'yarn build:apm' into separate steps

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -155,15 +155,21 @@ jobs:
         command: yarn install --ignore-engines
         on_retry_command: rm -R node_modules
 
-    - name: Build Pulsar
+    - name: Rebuild Pulsar Dependencies for Electron
       uses: nick-fields/retry@7152eba30c6575329ac0576536151aca5a72780e
       with:
         timeout_minutes: 30
         max_attempts: 3
         retry_on: error
-        command: |
-          yarn build
-          yarn run build:apm
+        command: yarn build
+
+    - name: Build ppm
+      uses: nick-fields/retry@7152eba30c6575329ac0576536151aca5a72780e
+      with:
+        timeout_minutes: 30
+        max_attempts: 3
+        retry_on: error
+        command: yarn build:apm
 
     - name: Cache Pulsar dependencies - Linux
       if: ${{ runner.os == 'Linux' }}


### PR DESCRIPTION
### Description

Split `yarn build` and `yarn build:apm` into separate CI steps.

### Motivation

It's important that the CI job does not continue if `yarn build` fails.

The previous syntax was running `yarn run build:apm` unconditionally after `yarn build`, regardless of exit status. So, a failure in `yarn build` would be followed by a `yarn run build:apm`, which could succeed, and the overall CI job could proceed with broken native C/C++ addon modules (effectively a broken app!) as if nothing had failed at any point. Not good!

Prevent broken app builds from passing in CI by ensuring these steps are each evaluated separately.

### Context (Related Issue)

Should prevent situations like #1349 from happening silently again.

### Verification Process

~~**CI should _fail_ on Windows at the `yarn build` step, since this branch does not have the fix from #1351.** Linux and macOS should _pass_ in CI.~~

~~**⚠️⚠️⚠️ If "Build Pulsar Binaries" CI passes on all three OSes, please do not merge! ⚠️⚠️⚠️**
This PR should fail in Windows CI! That's how we know this fix is working! Thank you for your understanding!!~~

EDIT: Hmm, this PR's CI appears to be using a temp merge of this branch and `master`, so that the fix from #1351 _is included after all._ I have spun up a CI run for _just this branch_ (no temp merge with the fix in it) which should _actually fail on Windows!_ Hopefully.

**_⚠️⚠️⚠️THIS RUN (SEE LINK -->) SHOULD FAIL ON WINDOWS TO VERIFY THE FIX, IRONICALLY⚠️⚠️⚠️: https://github.com/pulsar-edit/pulsar/actions/runs/18364151558_**

(CI should PASS on this PR itself, due to this PR's CI run having #1351 applied.)