### PR TITLE
[markdown-preview] Fix failure to serialize to HTML…

### DIFF
--- a/packages/markdown-preview/styles/markdown-preview.less
+++ b/packages/markdown-preview/styles/markdown-preview.less
@@ -6,7 +6,10 @@
 
   // Hide a `pre` that comes directly after an `atom-text-editor` because the
   // `atom-text-editor` is the syntax-highlighted representation.
-  atom-text-editor + pre {
+  //
+  // When we generate HTML via “Copy HTML” or “Save as HTML,” we add an
+  // attribute to the PRE so that this style rule is neutralized.
+  atom-text-editor + pre:not([data-serialized]) {
     display: none;
   }
 


### PR DESCRIPTION
…when the document contains certain kinds of code blocks.

This fixes #1044.

When we serialize the Markdown preview to HTML, we want to incorporate the syntax highlighting — so we yoink it out of the editor instead of just taking the PRE element as-is.

In order to do that safely, we have to wait until an editor component is ready to be read from — we don't want to try to read it while it's in the middle of an update. So we politely ask to be notified the next time the component is done updating.

But what if the component isn't in the middle of an update? In theory, `getNextUpdatePromise()` should either (a) schedule an update just to create a promise that will soon be fulfilled, or (b) return `Promise.resolve()` so that the promise is immediately fulfilled. (Offhand I don't remember which one is supposed to happen.) But when the editor uses a TextMate grammar, _neither_ thing happens. So those promises don't get fulfilled and the command just never completes.

This is a complicated thing to dig into. As an alternative, I threw in a fallback code path that impatiently plows ahead if the update doesn't happen within 500ms. Going that long without an update makes it pretty unlikely that we'd catch the editor in the middle of an update if we proceeded with reading its contents.

While testing this fix, I found a different issue: some styles introduced in #984 (and meant to apply only in the preview pane) were being copied during HTML generation and were having unwanted side effects in the resulting markup. Namely: if there were N consecutive PRE elements (with no elements in between), all PREs after the first were hidden. I fixed this by adding a `data-` attribute to the `PRE` elements in generated HTML so we could tell them apart from the ones in the preview pane.

## Testing

To replicate this, you must have at least one plain-text code block; or else one code block that will use a TextMate grammar, like Less or CoffeeScript. (Plain text in Pulsar still uses a TextMate style “null” grammar and is therefore susceptible to this bug.)

First, create some Markdown like…

<pre>
# Test

```
testing
```
</pre>

Then either invoke the **Markdown Preview: Copy HTML** command… or show the preview pane, right-click on it, and choose **Save as HTML**.

On `master` and in the latest release (and many releases before that), neither action would complete. On this PR branch, both actions should generate HTML.