### PR TITLE
[find-and-replace] Prevent addition of project results…

### DIFF
--- a/packages/find-and-replace/lib/project/results-model.js
+++ b/packages/find-and-replace/lib/project/results-model.js
@@ -3,7 +3,7 @@ const {Emitter, TextEditor, Range} = require('atom')
 const escapeHelper = require('../escape-helper')
 
 class Result {
-  static create (result) {
+  static create(result) {
     if (result && result.matches && result.matches.length) {
       const matches = []
 
@@ -62,13 +62,13 @@ class Result {
     }
   }
 
-  constructor (result) {
+  constructor(result) {
     _.extend(this, result)
   }
 }
 
 module.exports = class ResultsModel {
-  constructor (findOptions) {
+  constructor(findOptions) {
     this.onContentsModified = this.onContentsModified.bind(this)
     this.findOptions = findOptions
     this.emitter = new Emitter()
@@ -82,77 +82,77 @@ module.exports = class ResultsModel {
     this.clear()
   }
 
-  onDidClear (callback) {
+  onDidClear(callback) {
     return this.emitter.on('did-clear', callback)
   }
 
-  onDidClearSearchState (callback) {
+  onDidClearSearchState(callback) {
     return this.emitter.on('did-clear-search-state', callback)
   }
 
-  onDidClearReplacementState (callback) {
+  onDidClearReplacementState(callback) {
     return this.emitter.on('did-clear-replacement-state', callback)
   }
 
-  onDidSearchPaths (callback) {
+  onDidSearchPaths(callback) {
     return this.emitter.on('did-search-paths', callback)
   }
 
-  onDidErrorForPath (callback) {
+  onDidErrorForPath(callback) {
     return this.emitter.on('did-error-for-path', callback)
   }
 
-  onDidNoopSearch (callback) {
+  onDidNoopSearch(callback) {
     return this.emitter.on('did-noop-search', callback)
   }
 
-  onDidStartSearching (callback) {
+  onDidStartSearching(callback) {
     return this.emitter.on('did-start-searching', callback)
   }
 
-  onDidCancelSearching (callback) {
+  onDidCancelSearching(callback) {
     return this.emitter.on('did-cancel-searching', callback)
   }
 
-  onDidFinishSearching (callback) {
+  onDidFinishSearching(callback) {
     return this.emitter.on('did-finish-searching', callback)
   }
 
-  onDidStartReplacing (callback) {
+  onDidStartReplacing(callback) {
     return this.emitter.on('did-start-replacing', callback)
   }
 
-  onDidFinishReplacing (callback) {
+  onDidFinishReplacing(callback) {
     return this.emitter.on('did-finish-replacing', callback)
   }
 
-  onDidSearchPath (callback) {
+  onDidSearchPath(callback) {
     return this.emitter.on('did-search-path', callback)
   }
 
-  onDidReplacePath (callback) {
+  onDidReplacePath(callback) {
     return this.emitter.on('did-replace-path', callback)
   }
 
-  onDidAddResult (callback) {
+  onDidAddResult(callback) {
     return this.emitter.on('did-add-result', callback)
   }
 
-  onDidSetResult (callback) {
+  onDidSetResult(callback) {
     return this.emitter.on('did-set-result', callback)
   }
 
-  onDidRemoveResult (callback) {
+  onDidRemoveResult(callback) {
     return this.emitter.on('did-remove-result', callback)
   }
 
-  clear () {
+  clear() {
     this.clearSearchState()
     this.clearReplacementState()
     this.emitter.emit('did-clear', this.getResultsSummary())
   }
 
-  clearSearchState () {
+  clearSearchState() {
     this.pathCount = 0
     this.matchCount = 0
     this.regex = null
@@ -168,7 +168,7 @@ module.exports = class ResultsModel {
     this.emitter.emit('did-clear-search-state', this.getResultsSummary())
   }
 
-  clearReplacementState () {
+  clearReplacementState() {
     this.replacePattern = null
     this.replacedPathCount = null
     this.replacementCount = null
@@ -176,7 +176,7 @@ module.exports = class ResultsModel {
     this.emitter.emit('did-clear-replacement-state', this.getResultsSummary())
   }
 
-  shouldRerunSearch (findPattern, pathsPattern, options = {}) {
+  shouldRerunSearch(findPattern, pathsPattern, options = {}) {
     return (
       !options.onlyRunIfChanged ||
       findPattern == null ||
@@ -186,7 +186,7 @@ module.exports = class ResultsModel {
     )
   }
 
-  async search (findPattern, pathsPattern, replacePattern, options = {}) {
+  async search(findPattern, pathsPattern, replacePattern, options = {}) {
     if (!this.shouldRerunSearch(findPattern, pathsPattern, options)) {
       this.emitter.emit('did-noop-search')
       return Promise.resolve()
@@ -252,7 +252,7 @@ module.exports = class ResultsModel {
     }
   }
 
-  replace (pathsPattern, replacePattern, replacementPaths) {
+  replace(pathsPattern, replacePattern, replacementPaths) {
     if (!this.findOptions.findPattern || (this.regex == null)) { return }
 
     this.findOptions.set({replacePattern, pathsPattern})
@@ -285,19 +285,19 @@ module.exports = class ResultsModel {
     }).catch(e => console.error(e.stack))
   }
 
-  setActive (isActive) {
+  setActive(isActive) {
     if ((isActive && this.findOptions.findPattern) || !isActive) {
       this.active = isActive
     }
   }
 
-  getActive () { return this.active }
+  getActive() { return this.active }
 
-  getFindOptions () { return this.findOptions }
+  getFindOptions() { return this.findOptions }
 
-  getLastFindPattern () { return this.lastFindPattern }
+  getLastFindPattern() { return this.lastFindPattern }
 
-  getResultsSummary () {
+  getResultsSummary() {
     const findPattern = this.lastFindPattern != null ? this.lastFindPattern : this.findOptions.findPattern
     const { replacePattern } = this.findOptions
     return {
@@ -312,23 +312,23 @@ module.exports = class ResultsModel {
     }
   }
 
-  getPathCount () {
+  getPathCount() {
     return this.pathCount
   }
 
-  getMatchCount () {
+  getMatchCount() {
     return this.matchCount
   }
 
-  getPaths () {
+  getPaths() {
     return Object.keys(this.results)
   }
 
-  getResult (filePath) {
+  getResult(filePath) {
     return this.results[filePath]
   }
 
-  setResult (filePath, result) {
+  setResult(filePath, result) {
     if (result == null) {
       return this.removeResult(filePath)
     }
@@ -342,7 +342,17 @@ module.exports = class ResultsModel {
     this.emitter.emit('did-set-result', {filePath, result})
   }
 
-  addResult (filePath, result) {
+  shouldAddResult(filePath) {
+    // Ensure the given file path is suitable for inclusion in the current
+    // results view by checking it against any path patterns.
+    if (!this.findOptions.pathsPattern) return true;
+    const searchPaths = this.pathsArrayFromPathsPattern(this.findOptions.pathsPattern);
+    return atom.workspace.filePathMatchesPatterns(filePath, searchPaths);
+  }
+
+  addResult(filePath, result) {
+    if (!this.shouldAddResult(filePath, result)) return;
+
     this.pathCount++
     this.matchCount += result.matches.length
 
@@ -350,7 +360,7 @@ module.exports = class ResultsModel {
     this.emitter.emit('did-add-result', {filePath, result})
   }
 
-  removeResult (filePath) {
+  removeResult(filePath) {
     if (!this.results[filePath]) {
       return
     }
@@ -363,7 +373,7 @@ module.exports = class ResultsModel {
     this.emitter.emit('did-remove-result', {filePath, result})
   }
 
-  onContentsModified (editor) {
+  onContentsModified(editor) {
     if (!this.active || !this.regex || !editor.getPath()) { return }
 
     const matches = []
@@ -379,7 +389,7 @@ module.exports = class ResultsModel {
     this.emitter.emit('did-finish-searching', this.getResultsSummary())
   }
 
-  pathsArrayFromPathsPattern (pathsPattern) {
+  pathsArrayFromPathsPattern(pathsPattern) {
     return pathsPattern.trim().split(',').map((inputPath) => inputPath.trim())
   }
 }

--- a/spec/workspace-spec.js
+++ b/spec/workspace-spec.js
@@ -2214,6 +2214,49 @@ describe('Workspace', () => {
     });
   });
 
+  describe('::filePathMatchesPatterns', () => {
+    it('correctly applies scan path glob semantics against individual paths', () => {
+      const projectPath = path.join(__dirname, 'fixtures', 'workspace-scan');
+      atom.project.setPaths([projectPath]);
+
+      let pathA1 = path.join(projectPath, 'a-dir', 'sample1.js');
+      let pathB1 = path.join(projectPath, 'b-dir', 'sample1.js');
+
+      const positiveGlobs = ['b-dir', 'b-dir/*.js', 'b-dir/**/*.js'];
+      const negativeGlobs = ['!b-dir', '!b-dir/*.js', '!b-dir/**/*.js'];
+
+      expect(
+        atom.workspace.filePathMatchesPatterns(pathA1, [])
+      ).toBe(true);
+      expect(
+        atom.workspace.filePathMatchesPatterns(pathA1, [''])
+      ).toBe(true);
+      expect(
+        atom.workspace.filePathMatchesPatterns(pathA1, ['', ''])
+      ).toBe(true);
+      
+      expect(
+        atom.workspace.filePathMatchesPatterns(pathB1, ['b-dir/*.js'])
+      ).toBe(true);
+      expect(
+        atom.workspace.filePathMatchesPatterns(pathB1, ['!b-dir/*.js'])
+      ).toBe(false);
+
+      expect(
+        atom.workspace.filePathMatchesPatterns(pathA1, positiveGlobs)
+      ).toBe(false);
+      expect(
+        atom.workspace.filePathMatchesPatterns(pathB1, positiveGlobs)
+      ).toBe(true);
+      expect(
+        atom.workspace.filePathMatchesPatterns(pathA1, negativeGlobs)
+      ).toBe(true);
+      expect(
+        atom.workspace.filePathMatchesPatterns(pathB1, negativeGlobs)
+      ).toBe(false);
+    });
+  });
+
   for (const ripgrep of [true, false]) {
     describe(`::scan(regex, options, callback) { ripgrep: ${ripgrep} }`, () => {
       function scan(regex, options, iterator) {


### PR DESCRIPTION
…from editors whose paths are not matched by the current path inclusions.

Fixes #1379.

The `find-and-replace` package wants to do a good job. It wants to ensure that your project-wide search results are a _real-time_ reflection of the state of the workspace.

So when you search for `dev` in `site/templates`, it doesn't just do a one-off search. It also listens for changes to the active editor and keeps its results current in the results view. If `sites/templates/foo.ejs` didn't contain the string `dev` when you did the search… but then you edited the file and _added_ the word `dev` somewhere… it will pop up in the results!

This is handy _except_ when it shouldn't actually be there. The initial search — the one that happened in the background using either `ripgrep` or the other strategy (forget what it is) — took path inclusions/exclusions into account. The incremental re-search — the one that happens when you make changes to the active buffer — appears _not_ to consider those path patterns. So that's what we need to fix.

This is related to #1298. (I thought it might've been _caused_ by #1298, but I can't figure out how, so I think this has just always been an issue.) In both cases, we're bypassing the efficient project-wide search (with a dedicated tool) to perform a manual single-buffer search. In both cases, the bypass process ended up _also_ bypassing any path patterns that may have been specified, causing a bug.

We had to introduce some new logic to fix #1298, and luckily we're able to reuse it here. Since `atom.workspace` can already take our path pattern syntax and convert it into `minimatch` objects, all we need to do is expose the ability to ask “hypothetically, would path X be excluded by path pattern list Y?” from the `find-and-replace` package. I've added a new `atom.workspace.filePathMatchesPatterns` method to do just that.

The new method has specs to prove it works as intended.

Only a little new code is added in `find-and-replace` itself: before we add a set of results to the project-search results list, we ensure that the file path it came from matches our current path inclusions/exclusions list. In many cases, this checking is redundant, since `ripgrep` (or the other thing) will already be ignoring those paths… but that's OK.