### PR TITLE
Migrate to python3 style super for new class snippets in language-python

### DIFF
--- a/packages/language-python/snippets/language-python.cson
+++ b/packages/language-python/snippets/language-python.cson
@@ -55,7 +55,7 @@
     'body': 'self.fail(\'${1:message}\')$0'
   'New Class':
     'prefix': 'class'
-    'body': 'class ${1:ClassName}(${2:object}):\n\t"""${3:docstring for $1.}"""\n\n\tdef __init__(self, ${4:arg}):\n\t\t${5:super($1, self).__init__()}\n\t\tself.arg = arg\n\t\t$0'
+    'body': 'class ${1:ClassName}(${2:object}):\n\t"""${3:docstring for $1.}"""\n\n\tdef __init__(self, ${4:arg}):\n\t\t${5:super().__init__()}\n\t\tself.arg = arg\n\t\t$0'
   'New Method':
     'prefix': 'defs'
     'body': 'def ${1:mname}(self, ${2:arg}):\n\t${3:pass}'


### PR DESCRIPTION
The language-python snippets seem to be somewhat outdated when it comes to declaring new classes. My main source for this is [this post on stackoverflow](https://stackoverflow.com/questions/576169/understanding-python-super-with-init-methods) and my own testing 

This PR proposes to change the default snippet to python3 style
```
#Old Python2 Style super

class ClassName(object):
    """docstring for ."""

    def __init__(self, arg):
        super(ClassName, self).__init__()
        self.arg = arg

#Python3 Style Super      
class ClassName(object):
    """docstring for ."""

    def __init__(self, arg):
        super().__init__()
        self.arg = arg
``` 
This can of course be fixed by users with their own snippets as I've done, but I thought I'd submit a PR for other users
