### PR TITLE
Remove reliance on `title` key of a setting to avoid using locale labels

### DIFF
--- a/packages/settings-view/lib/search-setting-view.js
+++ b/packages/settings-view/lib/search-setting-view.js
@@ -18,7 +18,7 @@ export default class SearchSettingView {
   }
 
   render () {
-    const title = this.setting.title ?? getSettingTitle(this.setting.path, this.setting.path.split(".")[1]);
+    const title = getSettingTitle(this.setting.path, this.setting.path.split(".")[1]);
     const path = atom.config.get("settings-view.searchSettingsMetadata") ? this.setting.path + ": " : "";
     const description = this.setting.description ?? "";
     const packageName = this.setting.path.split(".")[0];


### PR DESCRIPTION
It was brought to my attention on Discord that when using the settings search if a setting appears that has a title key as a `LocaleLabel` it isn't translated.

This PR removes our intention to always trust the title key and instead always rely on the `rich-title.js` utility. Which itself will already try to use the `title` key if present, and supports translation of the keys in any case.