### PR TITLE
Implement pulsar-dev-container

### DIFF
--- a/container/Containerfile
+++ b/container/Containerfile
@@ -1,0 +1,21 @@
+FROM ubuntu:24.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV TZ=UTC
+
+RUN mkdir -p /opt/pulsar
+COPY install-build-dependencies.sh /opt/pulsar/
+RUN /opt/pulsar/install-build-dependencies.sh
+
+COPY install-run-dependencies.sh /opt/pulsar/
+RUN /opt/pulsar/install-run-dependencies.sh
+
+# Install the minimal X11 'xeyes' app to be able to debug systems that fail to
+# launch Pulsar due to X11/Wayland issues
+# hadolint ignore=DL3008,DL3059
+RUN apt-get install --yes --quiet --no-install-recommends x11-apps
+
+# Use ENTRYPOINT for the main executable and CMD for default arguments
+COPY pulsar-entrypoint.sh /opt/pulsar/
+ENTRYPOINT ["/opt/pulsar/pulsar-entrypoint.sh"]
+CMD []

--- a/container/README.md
+++ b/container/README.md
@@ -1,0 +1,5 @@
+# Pulsar development container
+
+The command `pulsar-dev-container` is designed as an easy way to start the
+Pulsar development version directly from the git repository, inside a
+loop-mounted container that has all dependencies installed.

--- a/container/install-build-dependencies.sh
+++ b/container/install-build-dependencies.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+#
+# Install all system dependencies needed to build Pulsar
+#
+
+if ! command -v apt-get > /dev/null
+then
+  echo "ERROR: This script can currently only run on systems with 'apt-get'"
+  exit 1
+fi
+
+packages=(
+  # Pulsar project main build tool. Installing it automatically pulls in 191
+  # MB of dependencies, including NodeJS.
+  yarnpkg
+
+  # 'yarn install' needs git to resolve multiple dependencies defined as git
+  # urls with git commit ids
+  git
+
+  # 'yarn build' needs 'node-gyp' build native binaries in NodeJS modules
+  # @pulsar-edit/fuzzy-native and @pulsar-edit/keyboard-layout
+  node-gyp
+
+  # @pulsar-edit/fuzzy-native native binary build dependencies (yes, it runs
+  # both Python and make)
+  python3-setuptools
+  make
+  g++
+
+  # @pulsar-edit/keyboard-layout native binary build dependencies
+  pkg-config
+  libwayland-dev
+  libxkbcommon-x11-dev
+  libxkbfile-dev
+)
+
+apt-get install --yes --quiet --update --no-install-recommends "${packages[@]}"
+
+# In Debian/Ubuntu, 'yarn' name is taken, so manually install a symlink to make 'yarn' refer to it
+ln -s /usr/bin/yarnpkg /usr/bin/yarn

--- a/container/install-run-dependencies.sh
+++ b/container/install-run-dependencies.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+#
+# Install all system dependencies needed to run Electron
+#
+
+if ! command -v apt-get > /dev/null
+then
+  echo "ERROR: This script can currently only run on systems with 'apt-get'"
+  exit 1
+fi
+
+# Electron dependencies mapped:
+# objdump -p  /tmp/pulsar/node_modules/electron/dist/electron | grep NEEDED
+# NEEDED               ld-linux-x86-64.so.2   (provided by glibc/core system)
+# NEEDED               libasound.so.2         libasound2t64
+# NEEDED               libatk-1.0.so.0        libatk1.0-0t64
+# NEEDED               libatk-bridge-2.0.so.0 libatk-bridge2.0-0t64
+# NEEDED               libatspi.so.0          libatspi2.0-0t64
+# NEEDED               libc.so.6              (provided by glibc/core system)
+# NEEDED               libcairo.so.2          libcairo2
+# NEEDED               libcups.so.2           libcups2t64
+# NEEDED               libdbus-1.so.3         dbus-tests
+# NEEDED               libdl.so.2             (provided by glibc/core system)
+# NEEDED               libdrm.so.2            libdrm2
+# NEEDED               libexpat.so.1          libexpat1
+# NEEDED               libffmpeg.so           qmmp
+# NEEDED               libgbm.so.1            libgbm1
+# NEEDED               libgcc_s.so.1          (provided by glibc/core system)
+# NEEDED               libgio-2.0.so.0        libglib2.0-0t64
+# NEEDED               libglib-2.0.so.0       libglib2.0-0t64
+# NEEDED               libgobject-2.0.so.0    libglib2.0-0t64
+# NEEDED               libgtk-3.so.0          libgtk-3-0t64
+# NEEDED               libm.so.6              (provided by glibc/core system)
+# NEEDED               libnspr4.so            libnspr4
+# NEEDED               libnss3.so             libnss3
+# NEEDED               libnssutil3.so         libnss3
+# NEEDED               libpango-1.0.so.0      libpango-1.0-0
+# NEEDED               libpthread.so.0        (provided by glibc/core system)
+# NEEDED               libsmime3.so           libnss3
+# NEEDED               libX11.so.6            libx11-6
+# NEEDED               libxcb.so.1            libxcb1
+# NEEDED               libXcomposite.so.1     libxcomposite1
+# NEEDED               libXdamage.so.1        libxdamage1
+# NEEDED               libXext.so.6           libxext6
+# NEEDED               libXfixes.so.3         libxfixes3
+# NEEDED               libxkbcommon.so.0      libxkbcommon0
+# NEEDED               libXrandr.so.2         libxrandr2
+
+packages=(
+  dbus-tests
+  libasound2t64
+  libatk-bridge2.0-0t64
+  libatk1.0-0t64
+  libatspi2.0-0t64
+  libcairo2
+  libcups2t64
+  libdrm2
+  libexpat1
+  libgbm1
+  libglib2.0-0t64
+  libgtk-3-0t64
+  libnspr4
+  libnss3
+  libpango-1.0-0
+  libx11-6
+  libxcb1
+  libxcomposite1
+  libxdamage1
+  libxext6
+  libxfixes3
+  libxkbcommon0
+  libxrandr2
+  qmmp
+)
+
+apt-get install --yes --quiet --update --no-install-recommends "${packages[@]}"

--- a/container/pulsar-dev-container.sh
+++ b/container/pulsar-dev-container.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+#
+# Script to make it easy to run the Pulsar project build and Pulsar without
+# having to pollute the host system, or read a too much docs
+#
+
+# Ensure script always from the container directory so all relative path
+# references are correct
+cd "$(dirname "$0")"
+
+# Check if any additional arguments were passed to this script
+if [ -z "$*" ]
+then
+  # Yarn subcommand 'run' is the standard tool to list all available targets
+  # and thus the default if no command was defined
+  command=(yarn run)
+  echo "INFO: No command was given, default to running '${command[*]}'"
+else
+  # If user passed a command, run it
+  command=("$@")
+  echo "INFO: Running command '${command[*]}'"
+fi
+
+# Containers need either Podman (preferred) or Docker to build and run
+if command -v podman > /dev/null
+then
+  echo "INFO: Using Podman to launch container"
+elif command -v docker > /dev/null
+then
+  echo "INFO: Using Podman to launch container"
+  alias podman=docker
+else
+  echo "ERROR: Neither 'podman' is 'docker' available, unable to use containers"
+  exit 1
+fi
+
+# Run the container build to ensure container exists and the layers in cache
+# have the latest versions of the files in this directory
+podman build -t pulsar-edit .
+
+# Ensure xhost allows X11 apps to launch from inside a local container
+XAUTHORIZATION="$(xhost | grep LOCAL)"
+if [ -z "$XAUTHORIZATION" ]
+then
+  echo "INFO: Enable local X connections to X11 apps can launch inside the container"
+  xhost +local:
+fi
+
+echo "INFO: The container will automatically terminate once the command exits"
+
+# Mount the Pulsar git repository inside the container and start it using the
+# special pulsar-entrypoint.sh script that will download and build all project
+# dependencies (NodeJS modules) in case the node_modules subdirectory does not
+# already exists or does not have sufficient contents
+#
+# NOTE! The 'privileged' is required for MESA/glx draw the Electron window
+podman run \
+  --rm \
+  --interactive \
+  --tty \
+  --privileged \
+  --network=host \
+  --shm-size=1G \
+  -e DISPLAY=$DISPLAY \
+  --volume=$PWD/..:/tmp/pulsar \
+  --workdir=/tmp/pulsar \
+  pulsar-edit "${command[@]}"

--- a/container/pulsar-entrypoint.sh
+++ b/container/pulsar-entrypoint.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+#
+# Install all NodeJS dependencies needed to build and run Pulsar, and build it
+#
+
+if [ ! -f node_modules ]
+then
+  echo "INFO: node_modules have not been installed -> installing now"
+  # Install all additional required NodeJS modules (~1000 MB)
+  yarn install
+fi
+
+if [ ! -f ./node_modules/.bin/electron-rebuild ]
+then
+  echo "INFO: Pulsar has not been built -> building now"
+  # Run 'electron-rebuild' as defined in package.json to build Pulsar
+  yarn build
+
+  # Even with all dependencies downloaded in `yarn install`, a network connection
+  # is still needed during `yarn build` as the package @pulsar-edit/fuzzy-native
+  # downloads the external dependency
+  # [https://www.electronjs.org/headers/v30.0.9/node-v30.0.9-headers.tar.gz]
+  # during the build.
+
+  if [ ! -f ppm/node_modules/git-utils/build/Release/git.node ]
+  then
+    echo "INFO: The Pulsar Package Manager has not been built -> building now"
+    # Using custom Yarn command (package.json: `cd ppm && yarn install`)
+    yarn build:apm
+
+    # In addition to standard NodeJS modules the above step also downloads the
+    # bundled
+    # [https://nodejs.org/download/release/v20.11.1/node-v20.11.1-headers.tar.gz] in
+    # addition to the ones defined explicitly in `ppm/package.json`.
+
+    # Note: The 'node script/postinstall.js' is not idempotent and it will rebuild
+    # the git-utils module from scratch on every run
+  fi
+fi
+
+if [ -n "$*" ]
+then
+  "$@"
+else
+  echo "ERROR: No command was passed to the container"
+fi


### PR DESCRIPTION
Make it easier for new contributors to get up-and-running quickly by introducing a single script that builds a container with all required dependencies, and allows to easily run any `yarn` command in the project.

You can test this by running e.g.

```
./container/pulsar-dev-container.sh
./container/pulsar-dev-container.sh yarn start
```

Demo:

https://github.com/user-attachments/assets/ba49f26c-f58b-44bb-a883-60ab0cce0fc0


