### PR TITLE
Allow customization of output targets in `script/electron-builder.js`…

### DIFF
--- a/script/electron-builder.js
+++ b/script/electron-builder.js
@@ -81,6 +81,56 @@ async function modifyMainPackageJson(
 // eslint-disable-next-line node/no-unpublished-require
 const builder = require('electron-builder');
 
+
+const LINUX_TARGETS = {
+  appimage: 'appimage',
+  deb: 'deb',
+  rpm: 'rpm',
+  targz: 'tar.gz'
+};
+
+// Allows a user to run (e.g.) `yarn dist targz` to build just one of the
+// output targets rather than all four.
+function inferLinuxTargetsFromArgs () {
+  let output = [];
+  let anyMatched = false;
+  for (let [key, value] of Object.entries(LINUX_TARGETS)) {
+    if (process.argv.includes(key)) {
+      anyMatched = true;
+      output.push({ target: value });
+    }
+  }
+  if (!anyMatched) {
+    return Object.values(LINUX_TARGETS).map(t => ({ target: t }));
+  }
+  if (process.platform === 'linux') {
+    console.log(`Targets specified; building only the following: ${output.map(o => o.target).join(', ')} `);
+  }
+  return output;
+}
+
+const WIN_TARGETS = ['nsis', 'zip'];
+
+// Allows a user to run (e.g.) `yarn dist nsis` to build just one of the two
+// output targets.
+function inferWindowsTargetsFromArgs () {
+  let output = [];
+  let anyMatched = false;
+  for (let value of WIN_TARGETS) {
+    if (process.argv.includes(value)) {
+      anyMatched = true;
+      output.push({ target: value });
+    }
+  }
+  if (!anyMatched) {
+    return WIN_TARGETS.map(t => ({ target: t }));
+  }
+  if (process.platform === 'win32') {
+    console.log(`Targets specified; building only the following: ${output.map(o => o.target).join(', ')} `);
+  }
+  return output;
+}
+
 const ARGS = yargs(hideBin(process.argv))
   .command('[platform]', 'build for a given platform', () => {
     return yargs.positional('platform', {
@@ -119,7 +169,6 @@ const ICONS = {
   svg: `resources/app-icons/${iconName}.svg`,
   icns: `resources/app-icons/${iconName}.icns`
 };
-
 
 let options = {
   appId: `dev.pulsar-edit.${baseName}`,
@@ -247,12 +296,7 @@ let options = {
     icon: "resources/icons",
     category: "Development",
     synopsis: "A community-led hyper-hackable text editor",
-    target: [
-      { target: 'appimage' },
-      { target: 'deb' },
-      { target: 'rpm' },
-      { target: 'tar.gz' }
-    ],
+    target: inferLinuxTargetsFromArgs(),
     extraResources: [
       {
         // Extra SVG icon included in the resources folder to give a chance to
@@ -316,10 +360,7 @@ let options = {
       { from: 'ppm/bin/ppm.cmd', to: `app/ppm/bin/${ppmBaseName}.cmd` },
       { from: 'ppm/bin/node.exe', to: `app/ppm/bin/node.exe` },
     ],
-    target: [
-      { target: 'nsis' },
-      { target: 'zip' }
-    ]
+    target: inferWindowsTargetsFromArgs()
   },
 
   nsis: {


### PR DESCRIPTION
…at least on Linux and Windows.

The [documentation already thinks this is possible](https://docs.pulsar-edit.dev/contributing-to-pulsar/building-pulsar/#building-binaries)! (Select the “Linux” tab if you're not on Linux.) The script doesn't support this, but it _ought_ to — especially on Linux, since building an AppImage is time-intensive. Better to change the code here than to change the docs.

We can control targets on Windows as well, so we might as well let them in on the fun and allow (e.g.) `yarn dist nsis` to opt into just the NSIS build and skip the portable target. (The current docs say `yarn dist portable` should be possible, but `electron-builder` calls this target `zip`, so I decided to keep it simple. Happy to keep it as `portable` if people prefer.)

If a user specifies targets that don't match their current platform, they will be ignored. Default behavior has not changed; if no applicable targets are provided, then the whole list of them should be generated.

Feel free to test this for your specific platform; I did sanity checking on Linux, but I didn't try to run each individual option in isolation.