### PR TITLE
Fix incorrect interpretation of a line-number spec…

### DIFF
--- a/src/main-process/atom-application.js
+++ b/src/main-process/atom-application.js
@@ -1864,7 +1864,10 @@ module.exports = class AtomApplication extends EventEmitter {
     const normalizedPath = path.normalize(
       path.resolve(executedFrom, fs.normalize(result.pathToOpen))
     );
-    if (!url.parse(pathToOpen).protocol) {
+
+    if (!url.parse(result.pathToOpen).protocol) {
+      // If this isn't a URL, it's a file path. File paths need to be resolved
+      // and normalized, whereas we assume URLs are already unambiguous.
       result.pathToOpen = normalizedPath;
     }
 


### PR DESCRIPTION
…on the command line.

Fixes #1399.

I explained the bug [in this comment](https://github.com/pulsar-edit/pulsar/issues/1399#issuecomment-3712596915). This implements the described fix.

I was going to add a spec to cover this, but `spec/main-process/atom-application.test.js` seems to rely deeply on the idea that two subdirectories are created, and that all CLI tests will be invoked from their parent directory. Hence there's no way to test something like `pulsar FOO.md:10` within this structure; only, e.g., `pulsar a/FOO.md:10`.

This could be fixed, but I think it's better to fix the underlying issue than to hold it up while I try to re-examine the assumptions of the test framework.

## Manual testing

To ensure this is fixed, test the exact behavior that's failing on `master`:

* Invoke Pulsar from a directory with a root file, like a `README.md`, and include a line-number specification: `pulsar README.md:10`.
* Ensure that a window opens with one item: the `README.md`. The cursor should be on line 10.