### PR TITLE
Add exclusions borrowed from `node-prune`

### DIFF
--- a/script/electron-builder.js
+++ b/script/electron-builder.js
@@ -249,7 +249,6 @@ let options = {
     "!**/doc",
     "!**/website",
     "!**/images",
-    "!**/assets",
     "!**/example",
     "!**/examples",
     "!**/coverage",


### PR DESCRIPTION
This PR relates to #1404 and tests an idea I had in my musings in the comments there.

That we could borrow the exclusion logic used by [node-prune](https://github.com/tj/node-prune/tree/master) to help fill in any gaps we may have in our own logic during Pulsar's building process.

As such I've added in their exclusions that we don't already have, and will compare the built output via GitHub to see what we get. (Thus why this PR is a draft until that finishes).

For comparison we can use `PR#1830` of which we get the following built assets in GitHub Actions:
* macos-14 Binaries: `474 MB`
* ubuntu-latest Binaries: `784 MB`
* windows-latest Binaries: `562 MB`

I know the sizes listed on these assets isn't a perfect measure of final install size, but at the very least this may help to get an idea if this PR is doing anything substantial.