### PR TITLE
Fix tree-view crash when dock pane is split

### DIFF
--- a/packages/tree-view/lib/tree-view-package.js
+++ b/packages/tree-view/lib/tree-view-package.js
@@ -23,6 +23,7 @@ class TreeViewPackage {
     const treeView = this.getTreeViewInstance()
     const showOnAttach = !atom.workspace.getActivePaneItem()
     this.treeViewOpenPromise = atom.workspace.open(treeView, {
+      searchAllPanes: true,
       activatePane: showOnAttach,
       activateItem: showOnAttach
     })


### PR DESCRIPTION
## Root Cause

During startup, the tree-view item may be deserialized into a specific pane within a split dock (e.g. pane B). When `activate()` then calls `workspace.open(treeView, ...)` without `searchAllPanes: true`, the workspace resolves the target pane via `paneContainerForURI()` → `container.getActivePane()`, which returns the **active** pane in the dock (pane A), not necessarily the one holding the deserialized tree-view (pane B).

Since `pane.addItem()` only guards against duplicates within its **own** items array, the item passes the local check on pane A but fails the global `ItemRegistry` check — because it was already registered when deserialized into pane B.

## Fix

Add `searchAllPanes: true` to the `workspace.open` call in `activate()`. This makes the workspace use `paneForItem(item)`, which searches all panes across all containers, correctly locating the already-deserialized item regardless of which pane in a split dock holds it.