### PR TITLE
feat: add isPermanent config to control dock item persistence

### DIFF
--- a/packages/tree-view/lib/tree-view.js
+++ b/packages/tree-view/lib/tree-view.js
@@ -238,7 +238,7 @@ class TreeView {
   }
 
   isPermanentDockItem() {
-    return true;
+    return atom.config.get('tree-view.isPermanent');
   }
 
   getPreferredWidth() {

--- a/packages/tree-view/package.json
+++ b/packages/tree-view/package.json
@@ -81,6 +81,11 @@
       "type": "boolean",
       "default": false,
       "description": "When Pulsar is opened, the view is hidden."
+    },
+    "isPermanent": {
+      "type": "boolean",
+      "default": true,
+      "description": "When enabled, the tree view becomes a permanent dock item that cannot be closed."
     }
   }
 }


### PR DESCRIPTION
## Summary

- Adds `isPermanent` setting to control whether the tree-view is a permanent dock item
- Default is `true`, preserving existing behavior where the tree-view cannot be closed from the dock

## Motivation

Previously, `isPermanentDockItem()` was hardcoded to `return true`, meaning the tree-view could never be closed from the dock. Some users prefer the ability to close and reopen the tree-view like any other dock item. This setting gives users control over that behavior.

## Changes

- **package.json**: Added `isPermanent` boolean config entry (default `true`)
- **tree-view.js**: `isPermanentDockItem()` now reads from `tree-view.isPermanent` config