### PR TITLE
Enhance documentation for `atom.commands.dispatch()` method

### DIFF
--- a/src/command-registry.js
+++ b/src/command-registry.js
@@ -290,7 +290,7 @@ module.exports = class CommandRegistry {
   //
   // * `target` The DOM node at which to start bubbling the command event.
   // * `commandName` {String} indicating the name of the command to dispatch.
-  // * `detail` {any} Any value that will be assigned to the event's `.detail` property. Pass an object with multiple properties if you need multiple command arguments.
+  // * `detail` Any value that will be assigned to the event's `.detail` property. Pass an object with multiple properties if you need multiple command arguments.
   dispatch(target, commandName, detail) {
     const event = new CustomEvent(commandName, { bubbles: true, detail });
     Object.defineProperty(event, 'target', { value: target });


### PR DESCRIPTION
Add comments to clarify that `atom.commands.dispatch()` can pass arguments to commands.

I haven't tested it yet, but this `detail` arg seems to allow for the following ability:

```js
atom.commands.add(`selector`, {
  'my:custom-command': event => console.log(event.detail),
})
```

And this:

```js
atom.commands.onDidDispatch(event => {
  console.log(event.type, event.detail)
});
```

Technically we can dispatch a command like this too:

```js
class MyCustomEvent extends Event {
  foo = 123
  bar = 456

  constructor(foo, bar) {
    this.foo = foo ?? this.foo
    this.bar = bar ?? this.bar
    super('my:custom-command')
  }
}

const event = MyCustomEvent(42, 84)

Object.defineProperty(event, 'target', { value: atom.workspace.element });
atom.commands.handleCommandEvent(event);
```

and the command handler could use those properties:


```js
atom.commands.add('selector', {
  'my:custom-command': ({foo, bar}) => console.log(foo, bar), // logs "42 84"
})
```

A separate PR should be able to add arg support for key maps if it doesn't exist already (or document that if it does). For keymaps, the `.detail` property makes sense, as there'd be no way to handle custom event classes via static JSON (unless we maintained a map of class by their class name, and use their class name in the JSON).