### PR TITLE
feat: Add `editor.largeFileThreshold` config for TextMate large file mode

### DIFF
--- a/spec/text-mate-language-mode-spec.js
+++ b/spec/text-mate-language-mode-spec.js
@@ -51,6 +51,48 @@ describe('TextMateLanguageMode', () => {
     });
   });
 
+  describe('core.largeFileThreshold config', () => {
+    afterEach(() => {
+      config.unset('core.largeFileThreshold');
+    });
+
+    it('uses the configured threshold to determine large file mode', () => {
+      config.set('core.largeFileThreshold', 0.001); // 1KB
+      const line = 'a b c d\n';
+      buffer = new TextBuffer(line.repeat(200)); // ~1.6KB
+      languageMode = new TextMateLanguageMode({
+        buffer,
+        config,
+        grammar: atom.grammars.grammarForScopeName('source.js')
+      });
+      expect(languageMode.largeFileMode).toBe(true);
+    });
+
+    it('disables automatic large file mode when threshold is 0', () => {
+      config.set('core.largeFileThreshold', 0);
+      const line = 'a b c d\n';
+      buffer = new TextBuffer(line.repeat(256 * 1024)); // 2MB
+      languageMode = new TextMateLanguageMode({
+        buffer,
+        config,
+        grammar: atom.grammars.grammarForScopeName('source.js')
+      });
+      expect(languageMode.largeFileMode).toBe(false);
+    });
+
+    it('respects explicit largeFileMode param over config', () => {
+      config.set('core.largeFileThreshold', 0);
+      buffer = new TextBuffer('small file');
+      languageMode = new TextMateLanguageMode({
+        buffer,
+        config,
+        grammar: atom.grammars.grammarForScopeName('source.js'),
+        largeFileMode: true
+      });
+      expect(languageMode.largeFileMode).toBe(true);
+    });
+  });
+
   describe('tokenizing', () => {
     describe('when the buffer is destroyed', () => {
       beforeEach(() => {

--- a/spec/text-mate-language-mode-spec.js
+++ b/spec/text-mate-language-mode-spec.js
@@ -51,13 +51,13 @@ describe('TextMateLanguageMode', () => {
     });
   });
 
-  describe('core.largeFileThreshold config', () => {
+  describe('editor.largeFileThreshold config', () => {
     afterEach(() => {
-      config.unset('core.largeFileThreshold');
+      config.unset('editor.largeFileThreshold');
     });
 
     it('uses the configured threshold to determine large file mode', () => {
-      config.set('core.largeFileThreshold', 0.001); // 1KB
+      config.set('editor.largeFileThreshold', 0.001); // 1KB
       const line = 'a b c d\n';
       buffer = new TextBuffer(line.repeat(200)); // ~1.6KB
       languageMode = new TextMateLanguageMode({
@@ -69,7 +69,7 @@ describe('TextMateLanguageMode', () => {
     });
 
     it('disables automatic large file mode when threshold is 0', () => {
-      config.set('core.largeFileThreshold', 0);
+      config.set('editor.largeFileThreshold', 0);
       const line = 'a b c d\n';
       buffer = new TextBuffer(line.repeat(256 * 1024)); // 2MB
       languageMode = new TextMateLanguageMode({
@@ -81,7 +81,7 @@ describe('TextMateLanguageMode', () => {
     });
 
     it('respects explicit largeFileMode param over config', () => {
-      config.set('core.largeFileThreshold', 0);
+      config.set('editor.largeFileThreshold', 0);
       buffer = new TextBuffer('small file');
       languageMode = new TextMateLanguageMode({
         buffer,

--- a/src/config-schema.js
+++ b/src/config-schema.js
@@ -345,13 +345,6 @@ const configSchema = {
         type: 'number',
         default: 40
       },
-      largeFileThreshold: {
-        description:
-          'Files larger than this size in megabytes will open in large file mode with syntax highlighting disabled. Only applies to TextMate grammars; Tree-sitter grammars handle large files efficiently without this limitation. Set to 0 to always enable syntax highlighting regardless of file size.',
-        type: 'number',
-        default: 2,
-        minimum: 0
-      },
       fileSystemWatcher: {
         description:
           'Choose the underlying implementation used to watch for filesystem changes. Emulating changes will miss any events caused by applications other than Pulsar, but may help prevent crashes or freezes.',
@@ -462,6 +455,13 @@ const configSchema = {
         type: ['string', 'null']
       },
       // These can be used as globals or scoped, thus defaults.
+      largeFileThreshold: {
+        description:
+          'Files larger than this size in megabytes will open in large file mode with syntax highlighting disabled. Only applies to TextMate grammars; Tree-sitter grammars handle large files efficiently without this limitation. Set to 0 to always enable syntax highlighting regardless of file size.',
+        type: 'number',
+        default: 2,
+        minimum: 0
+      },
       fontFamily: {
         type: 'string',
         default: 'Menlo, Consolas, DejaVu Sans Mono, monospace',

--- a/src/config-schema.js
+++ b/src/config-schema.js
@@ -345,6 +345,13 @@ const configSchema = {
         type: 'number',
         default: 40
       },
+      largeFileThreshold: {
+        description:
+          'Files larger than this size in megabytes will open in large file mode with syntax highlighting disabled. Only applies to TextMate grammars; Tree-sitter grammars handle large files efficiently without this limitation. Set to 0 to always enable syntax highlighting regardless of file size.',
+        type: 'number',
+        default: 2,
+        minimum: 0
+      },
       fileSystemWatcher: {
         description:
           'Choose the underlying implementation used to watch for filesystem changes. Emulating changes will miss any events caused by applications other than Pulsar, but may help prevent crashes or freezes.',

--- a/src/text-mate-language-mode.js
+++ b/src/text-mate-language-mode.js
@@ -30,16 +30,15 @@ class TextMateLanguageMode {
     this.id = params.id != null ? params.id : nextId++;
     this.buffer = params.buffer;
     this.config = params.config ?? atom.config;
-    const largeFileThreshold = this.config.get('core.largeFileThreshold') ?? 2;
-    this.largeFileMode =
-      params.largeFileMode != null
-        ? params.largeFileMode
-        : largeFileThreshold > 0 && this.buffer.buffer.getLength() >= largeFileThreshold * 1024 * 1024;
-
     this.grammar = params.grammar || NullGrammar;
     this.rootScopeDescriptor = new ScopeDescriptor({
       scopes: [this.grammar.scopeName]
     });
+    const largeFileThreshold = this.config.get('editor.largeFileThreshold', { scope: this.rootScopeDescriptor }) ?? 2;
+    this.largeFileMode =
+      params.largeFileMode != null
+        ? params.largeFileMode
+        : largeFileThreshold > 0 && this.buffer.buffer.getLength() >= largeFileThreshold * 1024 * 1024;
     this.disposables.add(
       this.grammar.onDidUpdate(() => this.retokenizeLines())
     );

--- a/src/text-mate-language-mode.js
+++ b/src/text-mate-language-mode.js
@@ -29,12 +29,12 @@ class TextMateLanguageMode {
     this.tokenizationStarted = false;
     this.id = params.id != null ? params.id : nextId++;
     this.buffer = params.buffer;
-    this.largeFileMode = params.largeFileMode;
     this.config = params.config ?? atom.config;
+    const largeFileThreshold = this.config.get('core.largeFileThreshold') ?? 2;
     this.largeFileMode =
       params.largeFileMode != null
         ? params.largeFileMode
-        : this.buffer.buffer.getLength() >= 2 * 1024 * 1024;
+        : largeFileThreshold > 0 && this.buffer.buffer.getLength() >= largeFileThreshold * 1024 * 1024;
 
     this.grammar = params.grammar || NullGrammar;
     this.rootScopeDescriptor = new ScopeDescriptor({

--- a/src/text-mate-language-mode.js
+++ b/src/text-mate-language-mode.js
@@ -36,9 +36,7 @@ class TextMateLanguageMode {
     });
     const largeFileThreshold = this.config.get('editor.largeFileThreshold', { scope: this.rootScopeDescriptor }) ?? 2;
     this.largeFileMode =
-      params.largeFileMode != null
-        ? params.largeFileMode
-        : largeFileThreshold > 0 && this.buffer.buffer.getLength() >= largeFileThreshold * 1024 * 1024;
+      params.largeFileMode ?? (largeFileThreshold > 0 && this.buffer.buffer.getLength() >= largeFileThreshold * 1024 * 1024);
     this.disposables.add(
       this.grammar.onDidUpdate(() => this.retokenizeLines())
     );


### PR DESCRIPTION
Add a new `core.largeFileThreshold` config setting to make the **TextMate grammar** large file mode threshold configurable.

Previously, the threshold was hardcoded at 2MB. Files larger than this would open with syntax highlighting disabled (large file mode). This PR allows users to customize this threshold in Settings.

## Changes

- Add `core.largeFileThreshold` config option in `config-schema.js` (default: 2MB)
- Update `text-mate-language-mode.js` to read threshold from config
- Add spec tests for the new config behavior

## Usage

In Settings → Core → **Large File Threshold**:
- Default: `2` (2MB, preserves existing behavior)
- Increase to allow syntax highlighting for larger files (e.g., `20` for 20MB)
- Set to `0` to never auto-enable large file mode