### PR TITLE
Hide empty file-info element in status bar

### DIFF
--- a/packages/status-bar/lib/file-info-view.js
+++ b/packages/status-bar/lib/file-info-view.js
@@ -149,5 +149,7 @@ class FileInfoView {
     } else {
       this.currentPath.textContent = '';
     }
+
+    this.element.style.display = this.currentPath.textContent === '' ? 'none' : '';
   }
 }


### PR DESCRIPTION
Hide the `status-bar-file` element when no file path or title is available, preventing an empty element from taking up space in the status bar.

When there is no active pane item with a path or title (e.g. all tabs are closed), the `<a class="current-path">` child was hidden via the existing `.current-path:empty` CSS rule, but the parent `<status-bar-file>` element remained visible and occupied space in the status bar.

This adds a `style.display` toggle in `updatePathText()` to hide the entire element when the content is empty and restore it when content is available.