### PR TITLE
settings-view: Improve search accuracy with native fuzzyMatcher

### DIFF
--- a/packages/settings-view/lib/search-settings-panel.js
+++ b/packages/settings-view/lib/search-settings-panel.js
@@ -141,7 +141,7 @@ export default class SearchSettingsPanel extends CollapsibleSectionPanel {
 
           let schema = this.settingsSchema[setting].properties[item];
 
-          schema.rank = this.generateRanks(text, schema.title, schema.description, setting, item)
+          schema.rank = this.generateRanks(searchTerm, schema.title, schema.description, setting, item)
 
           schema.path = `${setting}.${item}`
 
@@ -159,40 +159,19 @@ export default class SearchSettingsPanel extends CollapsibleSectionPanel {
   }
 
   generateRanks (searchText, title, description, settingName, settingItem) {
-    // In charge of generating each setting entry's rank
-    let rankedTitle = this.getScore(this.handleSettingsString(searchText), this.handleSettingsString(title))
-    let rankedDescription = this.getScore(this.handleSettingsString(searchText), this.handleSettingsString(description))
-    let rankedSettingName = this.getScore(this.handleSettingsString(searchText), this.handleSettingsString(settingName))
-    let rankedSettingItem = this.getScore(this.handleSettingsString(searchText), this.handleSettingsString(settingItem))
+    let candidate = [settingName, settingItem, title]
+      .filter(Boolean).join(' ');
 
-    let rank = {
-      title: rankedTitle,
-      description: rankedDescription,
-      settingName: rankedSettingName,
-      settingItem: rankedSettingItem
-    };
+    let result = this.getScore(candidate, searchText);
 
-    // Now to calculate the total score of the search resutls.
-    // The total score will be a sume of all individual scores,
-    // with weighted bonus' for higher matches depending on where the match was
-    let titleBonus = (rank.title.score > 0.8) ? 0.2 : 0;
-    let perfectTitleBonus = (rank.title.score === 1) ? 0.2 : 0;
-    let descriptionBonus = (rank.description.score > 0.5) ? 0.1 : 0;
-    let perfectDescriptionBonus = (rank.title.score === 1) ? 0.1 : 0;
-    let settingNameBonus = (rank.settingName.score > 0.8) ? 0.2 : 0;
-    let perfectSettingNameBonus = (rank.settingName.score === 1) ? 0.3 : 0;
-    let settingItemBonus = (rank.settingItem.score > 0.8) ? 0.2 : 0;
-    let perfectSettingItemBonus = (rank.settingItem.score === 1) ? 0.1 : 0;
+    // Only use description as a tiebreaker when primary fields already match
+    let descBonus = 0;
+    if (result.score > 0 && description) {
+      let descResult = this.getScore(description, searchText);
+      descBonus = descResult.score * 0.01;
+    }
 
-    let totalScore =
-      rank.title.score + titleBonus + perfectTitleBonus
-      + rank.description.score + descriptionBonus + perfectDescriptionBonus
-      + rank.settingName.score + settingNameBonus + perfectSettingNameBonus
-      + rank.settingItem.score + settingItemBonus + perfectSettingItemBonus;
-
-    rank.totalScore = totalScore;
-
-    return rank;
+    return { totalScore: result.score + descBonus, matchIndexes: result.matchIndexes };
   }
 
   processRanks (ranks) {
@@ -223,51 +202,15 @@ export default class SearchSettingsPanel extends CollapsibleSectionPanel {
 
   }
 
-  getScore (s1, s2) {
-    // s1 is the text we are calculating the score against
-    // s2 is the text the user typed
-    // Below is an exact implmentation of Longest Common Subsequence
-
-    let height = s1.length + 1;
-    let width = s2.length + 1;
-    let matrix = Array(height)
-      .fill(0)
-      .map(() => Array(width).fill(0));
-
-    for (let row = 1; row < height; row++) {
-      for (let col = 1; col < width; col++) {
-        if (s1[row - 1] == s2[col - 1]) {
-          matrix[row][col] = matrix[row - 1][col - 1] + 1;
-        } else {
-          matrix[row][col] = Math.max(matrix[row][col - 1], matrix[row - 1][col]);
-        }
-      }
+  getScore (candidate, query) {
+    if (!candidate || !query) {
+      return { score: 0, matchIndexes: [] };
     }
-
-    let longest = this.lcsTraceback(matrix, s1, s2, height, width);
-    // Now longest is a literal string of the longest common subsequence.
-    // We will now assign a score to help ranking, but will still return the
-    // text sequence, in case we want to use that for display purposes
-    return {
-      score: longest.length / s1.length,
-      sequence: longest
-    };
-  }
-
-  lcsTraceback (matrix, s1, s2, height, width) {
-    if (height === 0 || width === 0) {
-      return "";
+    const result = atom.ui.fuzzyMatcher.match(candidate, query, { recordMatchIndexes: true });
+    if (result) {
+      return { score: result.score, matchIndexes: result.matchIndexes };
     }
-    if (s1[height - 1] == s2[width - 1]) {
-      return (
-        this.lcsTraceback(matrix, s1, s2, height - 1, width - 1) +
-          (s1[height - 1] ? s1[height - 1] : "")
-      );
-    }
-    if (matrix[height][width - 1] > matrix[height - 1][width]) {
-      return this.lcsTraceback(matrix, s1, s2, height, width - 1);
-    }
-    return this.lcsTraceback(matrix, s1, s2, height - 1, width);
+    return { score: 0, matchIndexes: [] };
   }
 
   // Boiler Plate Functions

--- a/packages/settings-view/lib/search-settings-panel.js
+++ b/packages/settings-view/lib/search-settings-panel.js
@@ -56,14 +56,7 @@ export default class SearchSettingsPanel extends CollapsibleSectionPanel {
             <div className='section-heading icon icon-search-save'>
               Search Pulsar's Settings
             </div>
-            <div className='alert alert-warning icon icon-info'>
-              This feature is experimental.<br />
-              If you have feedback/suggestions, or you encounter any issues, feel free to report them here:&nbsp;
-              <a href="https://github.com/orgs/pulsar-edit/discussions/150" style="text-decoration: underline;">
-                https://github.com/orgs/pulsar-edit/discussions/150
-              </a>
-            </div>
-            <div className='editor-container'>
+<div className='editor-container'>
               <TextEditor ref='searchEditor' mini placeholderText='Start Searching for Settings' />
             </div>
 

--- a/packages/settings-view/lib/search-settings-panel.js
+++ b/packages/settings-view/lib/search-settings-panel.js
@@ -56,7 +56,7 @@ export default class SearchSettingsPanel extends CollapsibleSectionPanel {
             <div className='section-heading icon icon-search-save'>
               Search Pulsar's Settings
             </div>
-<div className='editor-container'>
+            <div className='editor-container'>
               <TextEditor ref='searchEditor' mini placeholderText='Start Searching for Settings' />
             </div>
 

--- a/packages/settings-view/package.json
+++ b/packages/settings-view/package.json
@@ -17,9 +17,11 @@
     },
     "searchSettingsMinimumScore": {
       "title": "Search Settings Minimum Score to Display Results",
-      "description": "Set the minimum similarity score required for a setting to appear in the search results, when searching for settings.",
-      "type": "integer",
-      "default": 2
+      "description": "Set the minimum similarity score required for a setting to appear in the search results, when searching for settings. Score range is 0.0 to 1.0.",
+      "type": "number",
+      "default": 0.05,
+      "minimum": 0,
+      "maximum": 1
     },
     "searchSettingsMetadata": {
       "title": "Display Search Settings Metadata along with Search Results",

--- a/packages/settings-view/spec/search-settings-panel-spec.js
+++ b/packages/settings-view/spec/search-settings-panel-spec.js
@@ -37,17 +37,26 @@ describe("SearchSettingsPanel", () => {
       let obj = searchSettingsPanel.getScore("hello world", "hello");
       expect(typeof obj === "object").toBe(true);
       expect(typeof obj.score === "number").toBe(true);
-      expect(typeof obj.sequence === "string").toBe(true);
+      expect(Array.isArray(obj.matchIndexes)).toBe(true);
     });
 
-    it("Returns the expected sequence", () => {
+    it("Returns a positive score for a matching query", () => {
       let obj = searchSettingsPanel.getScore("hello world", "hello");
-      expect(obj.sequence).toBe("hello");
+      expect(obj.score).toBeGreaterThan(0);
+      expect(obj.matchIndexes.length).toBeGreaterThan(0);
     });
 
-    it("Returns the expected score", () => {
-      let obj = searchSettingsPanel.getScore("bank", "ba");
-      expect(obj.score).toBe(0.5)
+    it("Returns zero score for non-matching query", () => {
+      let obj = searchSettingsPanel.getScore("hello", "xyz");
+      expect(obj.score).toBe(0);
+      expect(obj.matchIndexes.length).toBe(0);
+    });
+
+    it("Returns zero score for empty inputs", () => {
+      let obj = searchSettingsPanel.getScore(null, "hello");
+      expect(obj.score).toBe(0);
+      obj = searchSettingsPanel.getScore("hello", null);
+      expect(obj.score).toBe(0);
     });
 
   });
@@ -68,19 +77,10 @@ describe("SearchSettingsPanel", () => {
         "tabSetting"
       );
 
-      expect(typeof obj.title === "object").toBe(true);
-      expect(typeof obj.title.score === "number").toBe(true);
-      expect(typeof obj.title.sequence === "string").toBe(true);
-      expect(typeof obj.description === "object").toBe(true);
-      expect(typeof obj.description.score === "number").toBe(true);
-      expect(typeof obj.description.sequence === "string").toBe(true);
-      expect(typeof obj.settingName === "object").toBe(true);
-      expect(typeof obj.settingName.score === "number").toBe(true);
-      expect(typeof obj.settingName.sequence === "string").toBe(true);
-      expect(typeof obj.settingItem === "object").toBe(true);
-      expect(typeof obj.settingItem.score === "number").toBe(true);
-      expect(typeof obj.settingItem.sequence === "string").toBe(true);
       expect(typeof obj.totalScore === "number").toBe(true);
+      expect(obj.totalScore).toBeGreaterThan(0);
+      expect(Array.isArray(obj.matchIndexes)).toBe(true);
+      expect(obj.matchIndexes.length).toBeGreaterThan(0);
     });
   });
 


### PR DESCRIPTION
The settings search tab used algorithm that produced poor results — it didn't penalize gaps between matched characters, had no word boundary awareness, and long descriptions could easily dominate unrelated queries. This replaces it with Pulsar's native `atom.ui.fuzzyMatcher`.

- Score primarily on namespace, setting key, and title; use description only as a small tiebreaker (1% weight) when primary fields already match
- Update minimum score config from integer (default 2) to number range 0.0–1.0 (default 0.05) to match fuzzyMatcher's score range
- Remove the "experimental" warning banner from the search tab — the feature has been stable long enough
- Update specs for new scoring return structure

Some results examples:

<img width="863" height="631" alt="image" src="https://github.com/user-attachments/assets/bcc59711-5367-41f5-a900-f72d09a1975a" />

<img width="863" height="631" alt="image" src="https://github.com/user-attachments/assets/806db696-30d0-4287-8362-6a7a01992d3b" />

<img width="863" height="631" alt="image" src="https://github.com/user-attachments/assets/612e8c6c-6ee7-4215-a2d8-c96820901458" />

<img width="863" height="631" alt="image" src="https://github.com/user-attachments/assets/e86519a1-8cbd-4cac-bba6-3eff8f0b7333" />
