### PR TITLE
Remove abandoned fstream dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,6 @@
     "focus-trap": "6.3.0",
     "fs-admin": "0.19.0",
     "fs-plus": "^3.1.1",
-    "fstream": "1.0.12",
     "fuzzy-finder": "file:packages/fuzzy-finder",
     "git-diff": "file:packages/git-diff",
     "github": "https://github.com/pulsar-edit/github#v0.37.0-pretranspiled",

--- a/spec/workspace-spec.js
+++ b/spec/workspace-spec.js
@@ -7,7 +7,6 @@ const Workspace = require('../src/workspace');
 const Project = require('../src/project');
 const platform = require('./helpers/platform');
 const _ = require('underscore-plus');
-const fstream = require('fstream');
 const fs = require('fs-plus');
 const AtomEnvironment = require('../src/atom-environment');
 const { conditionPromise, timeoutPromise } = require('./helpers/async-spec-helpers');
@@ -2614,13 +2613,7 @@ describe('Workspace', () => {
             );
             projectPath = path.join(temp.mkdirSync('atom'));
 
-            const writerStream = fstream.Writer(projectPath);
-            fstream.Reader(sourceProjectPath).pipe(writerStream);
-
-            await new Promise(resolve => {
-              writerStream.on('close', resolve);
-              writerStream.on('error', resolve);
-            });
+            fs.cpSync(sourceProjectPath, projectPath, { recursive: true });
 
             fs.renameSync(
               path.join(projectPath, 'git.git'),
@@ -2689,13 +2682,7 @@ describe('Workspace', () => {
             );
             projectPath = path.join(temp.mkdirSync('atom'));
 
-            const writerStream = fstream.Writer(projectPath);
-            fstream.Reader(sourceProjectPath).pipe(writerStream);
-
-            await new Promise(resolve => {
-              writerStream.on('close', resolve);
-              writerStream.on('error', resolve);
-            });
+            fs.cpSync(sourceProjectPath, projectPath, { recursive: true });
 
             fs.symlinkSync(
               path.join(__dirname, 'fixtures', 'dir', 'b'),
@@ -2744,13 +2731,7 @@ describe('Workspace', () => {
             );
             projectPath = path.join(temp.mkdirSync('atom'));
 
-            const writerStream = fstream.Writer(projectPath);
-            fstream.Reader(sourceProjectPath).pipe(writerStream);
-
-            await new Promise(resolve => {
-              writerStream.on('close', resolve);
-              writerStream.on('error', resolve);
-            });
+            fs.cpSync(sourceProjectPath, projectPath, { recursive: true });
 
             // Note: This won't create a hidden file on Windows, in order to more
             // accurately test this behaviour there, we should either use a package


### PR DESCRIPTION
Package `fstream` is an abandoned npm package (last published 2019 & deprecated) that was only used in `spec/workspace-spec.js` to copy fixture directories during test setup. Node's built-in `fs.cpSync` does the same thing in one line.