### PR TITLE
Always show suggestions with `textEdit`s…

### DIFF
--- a/packages/autocomplete-plus/lib/autocomplete-manager.js
+++ b/packages/autocomplete-plus/lib/autocomplete-manager.js
@@ -401,7 +401,8 @@ class AutocompleteManager {
         results.push(suggestion)
       } else {
         const keepMatching = suggestion.ranges || suggestionPrefix[0].toLowerCase() === text[0].toLowerCase()
-        if (keepMatching && (score = atom.ui.fuzzyMatcher.score(text, suggestionPrefix)) > 0) {
+        let score = atom.ui.fuzzyMatcher.score(text, suggestionPrefix)
+        if (!!suggestion.textEdit || (keepMatching && score > 0)) {
           suggestion.score = score * suggestion.sortScore
           results.push(suggestion)
         }

--- a/packages/autocomplete-plus/spec/provider-api-spec.js
+++ b/packages/autocomplete-plus/spec/provider-api-spec.js
@@ -465,6 +465,35 @@ describe('Provider API', () => {
       expect(editor.getText()).toEqual("kb${1:yyy}ye, world\n")
     })
 
+    it('applies the textEdit if it is present', async () => {
+      testProvider = {
+        scopeSelector: '.source.js',
+        filterSuggestions: true,
+        getSuggestions () {
+          return [
+            {
+              text: 'ohai',
+              textEdit: {
+                range: [[2, 0], [2, 5]],
+                // Our new text will insert a newline, thereby changing the
+                // buffer range of one of our `additionalTextEdits`.
+                newText: 'kbye\n'
+              }
+            },
+            { text: 'ca.ts' },
+            { text: '::dogs'}
+          ]
+        }
+      }
+      registration = atom.packages.serviceHub.provide('autocomplete.provider', '5.1.0', testProvider)
+      editor.insertText('\nlorem\nhello, world\ndolor\n')
+
+      await triggerAutocompletion()
+      await confirmChoice(0)
+
+      expect(editor.getText()).toEqual("\nlorem\nkbye\n, world\ndolor\n")
+    })
+
     it('applies additional text edits if they are specified on the suggestion, even if their original buffer ranges are invalidated', async () => {
       testProvider = {
         scopeSelector: '.source.js',
@@ -489,7 +518,7 @@ describe('Provider API', () => {
           ]
         }
       }
-      registration = atom.packages.serviceHub.provide('autocomplete.provider', '5.0.0', testProvider)
+      registration = atom.packages.serviceHub.provide('autocomplete.provider', '5.1.0', testProvider)
       editor.insertText('\nlorem\nhello, world\ndolor\n')
 
       await triggerAutocompletion()


### PR DESCRIPTION
…instead of filtering them out.

`pulsar-ide-typescript` has a nice feature. Suppose you have this code, and `|` is the cursor position…

```ts
type Something = { foo: string };

function handlePossibleSomething(s?: Something) {
  s.f|
}
```

If you invoked autocompletion from that cursor position, `typescript-language-server` would typically not be able to suggest anything, since it doesn’t know whether `s` is `Something` or `undefined`. But there's a setting (enabled by default) that, in this situation, shows a `foo` suggestion — then, if inserted, changes `s.f` to `s?.foo`.

But this wasn’t being handled properly by `autocomplete-plus` because it does client-side filtering of the suggestion list and incorrectly thinks that this suggestion should be removed because of a mismatch between the replacement text and the expected filter text (`?.foo` doesn't start with `.f`). This logic is OK when it's a typical suggestion, but not when the suggestion carries a `textEdit` property instead of the rest of the token to be inserted.

The fix is not to try to filter out suggestions with `textEdit`s. It describes a text operation of more complexity than can be statically analyzed, so there's no simple way to check whether the suggestion is stale. If we're given this kind of suggestion from a provider, all we can do is assume it’s fresh and let the user decide.