### PR TITLE
Fix deprecated electron.remote usage in reopen-project-menu-manager

### DIFF
--- a/src/reopen-project-menu-manager.js
+++ b/src/reopen-project-menu-manager.js
@@ -75,7 +75,7 @@ module.exports = class ReopenProjectMenuManager {
   async applyWindowsJumpListRemovals() {
     if (process.platform !== 'win32') return;
     if (this.app === undefined) {
-      this.app = require('electron').remote.app;
+      this.app = require('@electron/remote').app;
     }
 
     const removed = this.app
@@ -96,7 +96,7 @@ module.exports = class ReopenProjectMenuManager {
   updateWindowsJumpList() {
     if (process.platform !== 'win32') return;
     if (this.app === undefined) {
-      this.app = require('electron').remote.app;
+      this.app = require('@electron/remote').app;
     }
 
     this.app.setJumpList([


### PR DESCRIPTION
Replace `require('electron').remote.app` with `require('@electron/remote').app` in `src/reopen-project-menu-manager.js`. The `deprecation-cop` is satisfy.