### PR TITLE
[autocomplete-plus] Allow matching suggestions to stay in the list after filtering…

### DIFF
--- a/packages/autocomplete-plus/package.json
+++ b/packages/autocomplete-plus/package.json
@@ -125,6 +125,13 @@
       "default": false,
       "order": 9
     },
+    "firstCharacterMustMatch": {
+      "title": "Enforce First-Character Match",
+      "description": "When this is enabled, the first character of the suggestion option must match the first character the user types, even when using fuzzy searching.",
+      "type": "boolean",
+      "default": false,
+      "order": 9.5
+    },
     "minimumWordLength": {
       "description": "Only autocomplete when you've typed at least this many characters. Note: May not affect external providers.",
       "type": "integer",


### PR DESCRIPTION
…even if the first character of the suggestion does not match the first character of what the user typed.

This was a strange decision from 2015 (or earlier) whose rationale has not been unearthed, and it does not play well with the sophisticated autocompletion techniques used by certain language servers. It means that a completion option would've been excluded in certain cases even if it had a positive score from the fuzzy-matching algorithm.

This will change completion behavior! If any user wishes to return to the previous behavior, they can set `autocomplete-plus.firstCharacterMustMatch` to `true` in the package config.

Fixes #1427.