### PR TITLE
[core] Add support for `data:image/svg+xml` in `ui.renderMarkdown`

### DIFF
--- a/spec/ui-spec.js
+++ b/spec/ui-spec.js
@@ -55,4 +55,21 @@ describe("Renders Markdown", () => {
     });
   });
 
+  describe("transforms images correctly", () => {
+    it("properly handles a standard PNG image", () => {
+      expect(atom.ui.markdown.render(
+        "![Alt Text](/image-link.png)",
+        { rootDomain: "https://github.com/pulsar-edit/pulsar" }
+      )).toBe('<p><img src="https://github.com/pulsar-edit/pulsar/raw/HEAD/image-link.png" alt="Alt Text"></p>\n');
+    });
+
+    it("handles 'data:image/svg+xml' images", () => {
+      expect(atom.ui.markdown.render(
+        "![Baseline icon](data:image/svg+xml;base64,SoMeBaSe64cArAcTerS+)"
+      )).toBe(
+        '<p><img src="data:image/svg+xml;base64,SoMeBaSe64cArAcTerS+" alt="Baseline icon"></p>\n'
+      );
+    });
+  });
+
 });

--- a/src/ui.js
+++ b/src/ui.js
@@ -117,6 +117,20 @@ function renderMarkdown(content, givenOpts = {}) {
 
   let md = new MarkdownIt(markdownItOpts);
 
+  // Support more image/link formats by default
+  const defaultValidateLink = md.validateLink;
+  md.validateLink = (url) => {
+    if (defaultValidateLink(url)) {
+      return true;
+    }
+
+    if (/^data:image\/svg\+xml;/.test(url)) {
+      return true;
+    }
+
+    return false;
+  };
+
   if (opts.useDefaultEmoji) {
     mdComponents.deps.markdownItEmoji ??= require("markdown-it-emoji");
     md.use(mdComponents.deps.markdownItEmoji, {});


### PR DESCRIPTION
This PR adds new image support in our instance of `markdown-it` by extending what links are validated.

While attempts have been made by a few others to add this support in the actual `markdown-it` repository, they've all been denied for various reasons and the official guidance is to add it user side.

I've also added some tests to ensure this functionality.

Closes #1437 