### PR TITLE
Bump `@pulsar-edit/superstring` to `3.0.5`

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@pulsar-edit/git-utils": "^7.0.1",
     "@pulsar-edit/pathwatcher": "^9.0.2",
     "@pulsar-edit/scandal": "^4.0.0",
-    "@pulsar-edit/superstring": "^3.0.4",
+    "@pulsar-edit/superstring": "^3.0.5",
     "@pulsar-edit/text-buffer": "^14.0.3",
     "about": "file:packages/about",
     "archive-view": "file:packages/archive-view",
@@ -318,6 +318,7 @@
     "nan": "2.19.0",
     "ctags": "https://github.com/pulsar-edit/node-ctags.git#c32ca6017dd3f4ea314d53b044225505820abbe3",
     "es5-ext": "https://github.com/pulsar-edit/es5-ext#169f6ae9b2675675269a0ba265f83c29c7b56244",
-    "@electron/remote": "2.1.2"
+    "@electron/remote": "2.1.2",
+    "@pulsar-edit/superstring": "3.0.5"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1732,10 +1732,10 @@
     split "^1.0.0"
     temp "^0.8.3"
 
-"@pulsar-edit/superstring@^3.0.4":
-  version "3.0.4"
-  resolved "https://registry.yarnpkg.com/@pulsar-edit/superstring/-/superstring-3.0.4.tgz#b6fa89cec8ebdb745c7d18c225b2663f1a6c518e"
-  integrity sha512-2gAZOOMCcwjLmFAojiBwyk/4aoj29jezZ80bH+7axjg8/6lFQk63L0Mu3+/lwSjDYMQ1XU6ebZGhBhHHtFSXYA==
+"@pulsar-edit/superstring@3.0.5", "@pulsar-edit/superstring@^3.0.4", "@pulsar-edit/superstring@^3.0.5":
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/@pulsar-edit/superstring/-/superstring-3.0.5.tgz#20e547a06a0692741f38f67e6522e2c68ed6d776"
+  integrity sha512-J92AD7eq7INlwpU6arJj5QBfbTBdW/c81hrmrG36hiubKkx+43NDT9y4+YR4n9SgAyMGuzLU/I9OX3n57njRog==
   dependencies:
     node-addon-api "^8.5.0"
 


### PR DESCRIPTION
Fixes #1438.

This is the fix for the crasher sometimes triggered by calling `TextBuffer::findWordsWithSubsequence` and `TextBuffer::setTextInRange` in rapid succession. We reproduced the crash and fixed it in [superstring#21](https://github.com/pulsar-edit/superstring/pull/21), then published `3.0.5` to NPM.

Instead of bumping everything that uses `superstring`, we'll use `resolutions` in `package.json` to ensure that all dependencies are aligned on the version of `superstring` being used. We can do proper version bumps on those other packages as occasions present themselves.