### PR TITLE
[meta] Exclude blockmaps again

### DIFF
--- a/script/electron-builder.js
+++ b/script/electron-builder.js
@@ -391,6 +391,10 @@ let options = {
     // Hardcoding it here means it will always be used as generated from the
     // AppID 'dev.pulsar-edit.pulsar'. If this value ever changes, a PR to
     // GitHub Desktop must be made with the updated value.
+    //
+    // We delete this value when building PulsarNext so that it’s regenerated
+    // based on the app ID. Otherwise the OS might consider it equivalent to
+    // stable Pulsar in some ways.
     include: "resources/win/installer.nsh",
     warningsAsErrors: false,
     differentialPackage: false


### PR DESCRIPTION
Seems in all the churn we've seen making PulsarNext mainline, the options to exclude blockmaps got lost.

So I've followed what we did in #1139 and added those options back in. 
As well as removed an outdated TODO comment