### PR TITLE
Draft: Fixing macOS editor tests

### DIFF
--- a/spec/text-editor-spec.js
+++ b/spec/text-editor-spec.js
@@ -8386,6 +8386,7 @@ describe('TextEditor', () => {
 
     it('returns true when the window is closing if the file has changed on disk', async () => {
       jasmine.useRealClock();
+      await wait(1000);
 
       editor.setText('initial stuff');
       let destination = temp.openSync('test-file').path;
@@ -8398,6 +8399,7 @@ describe('TextEditor', () => {
       }));
       await wait(1000);
       fs.writeFileSync(editor.getPath(), 'new stuff');
+      await wait(1000);
       expect(
         editor.shouldPromptToSave({
           windowCloseRequested: true,

--- a/spec/text-editor-spec.js
+++ b/spec/text-editor-spec.js
@@ -8394,17 +8394,22 @@ describe('TextEditor', () => {
       // watching a new file. It's possible that this happens too quickly in CI
       // for the subscription to detect the writing of new contents.
       await editor.saveAs(destination);
+      expect(
+        fs.readFileSync(destination, 'utf8').toString()
+      ).toBe('initial stuff');
       await wait(1000);
-      expect(fs.readFileSync(destination, 'utf8').toString()).toBe('initial stuff');
-      await wait(500);
       try {
         console.warn('Is it ALREADY in conflict?', editor.buffer.isInConflict());
       } catch (err) {
         console.error('Debugging error:');
         console.error(err);
       }
+
       editor.setText('other stuff');
-      await wait(500);
+      let promise = new Promise(resolve => editor.onDidConflict(() => {
+        console.warn('On did conflict!');
+        resolve();
+      }));
       fs.writeFileSync(editor.getPath(), 'new stuff');
       try {
         console.warn('IS IN CONFLICT?', editor.buffer.isInConflict());

--- a/spec/text-editor-spec.js
+++ b/spec/text-editor-spec.js
@@ -8402,7 +8402,7 @@ describe('TextEditor', () => {
       await wait(1000);
       try {
         console.warn('IS IN CONFLICT?', editor.buffer.isInConflict());
-        console.warn('Is modified?', this.isModified(), 'Has multiple editors?', this.buffer.hasMultipleEditors());
+        console.warn('Is modified?', editor.isModified(), 'Has multiple editors?', editor.buffer.hasMultipleEditors());
         console.warn('State store is connected?', atom.stateStore.isConnected());
       } catch (err) {
         console.error('Debugging error:');

--- a/spec/text-editor-spec.js
+++ b/spec/text-editor-spec.js
@@ -8401,9 +8401,9 @@ describe('TextEditor', () => {
       fs.writeFileSync(editor.getPath(), 'new stuff');
       await wait(1000);
       try {
-        console.log('IS IN CONFLICT?', editor.buffer.isInConflict());
-        console.log('Is modified?', this.isModified(), 'Has multiple editors?', this.buffer.hasMultipleEditors());
-        console.log('State store is connected?', atom.stateStore.isConnected());
+        console.warn('IS IN CONFLICT?', editor.buffer.isInConflict());
+        console.warn('Is modified?', this.isModified(), 'Has multiple editors?', this.buffer.hasMultipleEditors());
+        console.warn('State store is connected?', atom.stateStore.isConnected());
       } catch (err) {
         console.error('Debugging error:');
         console.error(err);

--- a/spec/text-editor-spec.js
+++ b/spec/text-editor-spec.js
@@ -8400,6 +8400,14 @@ describe('TextEditor', () => {
       await wait(1000);
       fs.writeFileSync(editor.getPath(), 'new stuff');
       await wait(1000);
+      try {
+        console.log('IS IN CONFLICT?', editor.buffer.isInConflict());
+        console.log('Is modified?', this.isModified(), 'Has multiple editors?', this.buffer.hasMultipleEditors());
+        console.log('State store is connected?', atom.stateStore.isConnected());
+      } catch (err) {
+        console.error('Debugging error:');
+        console.error(err);
+      }
       expect(
         editor.shouldPromptToSave({
           windowCloseRequested: true,


### PR DESCRIPTION
We have two consistently flaky tests on macOS in the editor spec suite:

```
TextEditorComponent block decorations measures block decorations correctly when they are added before the component width has been updated
TextEditor .shouldPromptToSave() returns true when the window is closing if the file has changed on disk
```

The first one always seems to fail the first time, but also always seems to pass upon automatic retry. Would be nice to fix that, but it's not as urgent.

The second one always fails in CI, even in isolation, yet I can't get it to fail on my local macOS machine.

I'll be trying out different strategies to make this test less flaky. If anything looks promising, I'll take this out of draft.