### PR TITLE
script: Fix ppm symlinking issues in Linux install/uninstall scripts

### DIFF
--- a/script/post-install.sh
+++ b/script/post-install.sh
@@ -18,8 +18,8 @@ case $executable in
     ;;
 esac
 
-SYMLINK_TARGET='/opt/${sanitizedProductName}/resources/app/ppm/bin/${ppm_executable}'
-SYMLINK_PATH='/usr/bin/${ppm_executable}'
+SYMLINK_TARGET="/opt/${sanitizedProductName}/resources/app/ppm/bin/${ppm_executable}"
+SYMLINK_PATH="/usr/bin/${ppm_executable}"
 
 if [ -L "$SYMLINK_PATH" ]
 then

--- a/script/post-uninstall-rpm.sh
+++ b/script/post-uninstall-rpm.sh
@@ -23,7 +23,7 @@ case $executable in
     ;;
 esac
 
-PPM_SYMLINK_PATH='/usr/bin/${ppm_executable}'
+PPM_SYMLINK_PATH="/usr/bin/${ppm_executable}"
 
 if [ -L "$PPM_SYMLINK_PATH" ]
 then

--- a/script/post-uninstall.sh
+++ b/script/post-uninstall.sh
@@ -16,7 +16,7 @@ case $executable in
     ;;
 esac
 
-PPM_SYMLINK_PATH='/usr/bin/${ppm_executable}'
+PPM_SYMLINK_PATH="/usr/bin/${ppm_executable}"
 
 if [ -L "$PPM_SYMLINK_PATH" ]
 then


### PR DESCRIPTION
Use double-quotes for bash parameter expansion (AKA string interpolation).

(We are apparently relying on `electron-builder` to preprocess some single-quoted string interpolations... Though the syntax is identical, we only have access to bash/Unix shell conventions elsewhere in the file. So, for instances where electron-builder is not preprocessing the given variable/string, including any variables originating in the scripts themselves, use double-quotes around parameter expansions, not single-quotes, per bash requirements.)

This should allow `ppm` to be successfully symlinked/un-symlinked, during install or uninstall of Pulsar, respectively.

Should hopefully fix: https://github.com/pulsar-edit/action-pulsar-dependency/issues/11

~~(Opening as draft to get some binaries built, and hopefully get a chance to verify the behavior is fixed.)~~

UPDATE: Tested and working for me in a Fedora 43 LiveUSB environment (see comment below). Ready for review.