### PR TITLE
Cirrus: Update `brew uninstall node@20` to `brew uninstall node@24`

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -170,6 +170,7 @@ silicon_mac_task:
     ROLLING_UPLOAD_TOKEN: ENCRYPTED[f1d3ee8df7ee66f7e5b66cfa19dd5bbdcac9339b7394dc23a3e3d8888cd55321e8acbcc5897599ba70dc4be41f154448]
   prepare_script:
     - brew update
+    - brew uninstall node@24
     - brew install git python@$PYTHON_VERSION python-setuptools
     - git submodule init
     - git submodule update


### PR DESCRIPTION
Cirrus replaced deprecated Homebrew `node@20` package with non-deprecated Homebrew `node@24` in their base CI images. So, bump the `brew uninstall node@20` line to `brew uninstall node@24` instead. (This Homebrew copy of Node has caused us some issues before, so we have been removing it. We install Node 16 using https://github.com/tj/n, so we can get rid of this copy of Node from Homebrew.)

Note: trying to uninstall `node@20` when it wasn't already installed was causing an error:

```
brew uninstall node@20
Error: No such keg: /opt/homebrew/Cellar/node@20
```

(Avoid CI-run-breaking errors with this one weird trick!)

### Verification process

Gets all the way through preparation and building, passes visual tests... https://cirrus-ci.com/task/4843477726396416?logs=test#L69 Looking good! ✅

(Note: This was a macOS-only issue, so I canceled the Linux task to save credits. It was a Cirrus-only issue as well, so I cancelled all GitHub Actions CI workflows as well.)