### PR TITLE
Linux: Remove `--no-sandbox` flag usage

### DIFF
--- a/integration/helpers.js
+++ b/integration/helpers.js
@@ -9,14 +9,13 @@ async function openAtom(profilePath, videoName) {
   env.ATOM_HOME = path.join("tmp", profilePath)
 
   const config = {
-    args: ["--no-sandbox", "."],
+    args: ["."],
     cwd: ".",
     env: env,
     timeout: 50000
   }
   if(env.BINARY_NAME) {
     config.executablePath = env.BINARY_NAME
-    config.args = ["--no-sandbox"]
   }
 
   if(process.env.CI) {

--- a/package.json
+++ b/package.json
@@ -290,7 +290,7 @@
   "scripts": {
     "build": "electron-rebuild",
     "build:apm": "cd ppm && yarn install",
-    "start": "electron --no-sandbox --enable-logging . -f",
+    "start": "electron --enable-logging . -f",
     "dist": "node script/electron-builder.js",
     "js-docs": "jsdoc2md --files src --configure docs/.jsdoc.json > ./docs/Pulsar-API-Documentation.md",
     "private-js-docs": "jsdoc2md --private --files src --configure docs/.jsdoc.json > ./docs/Source-Code-Documentation.md",

--- a/pulsar.sh
+++ b/pulsar.sh
@@ -274,7 +274,7 @@ elif [ $OS == 'Linux' ]; then
   fi
 
   if [ $EXPECT_OUTPUT ]; then
-    "$PULSAR_EXECUTABLE" --executed-from="$(pwd)" --pid=$$ "$@" --no-sandbox
+    "$PULSAR_EXECUTABLE" --executed-from="$(pwd)" --pid=$$ "$@"
     ATOM_EXIT=$?
     if [ ${ATOM_EXIT} -eq 0 ] && [ -n "${EXIT_CODE_OVERRIDE}" ]; then
       exit "${EXIT_CODE_OVERRIDE}"
@@ -283,7 +283,7 @@ elif [ $OS == 'Linux' ]; then
     fi
   else
     (
-    nohup "$PULSAR_EXECUTABLE" --executed-from="$(pwd)" --pid=$$ "$@" --no-sandbox > "$ATOM_HOME/nohup.out" 2>&1
+    nohup "$PULSAR_EXECUTABLE" --executed-from="$(pwd)" --pid=$$ "$@" > "$ATOM_HOME/nohup.out" 2>&1
     if [ $? -ne 0 ]; then
       cat "$ATOM_HOME/nohup.out"
       exit $?

--- a/resources/linux/pulsar.desktop.in
+++ b/resources/linux/pulsar.desktop.in
@@ -2,7 +2,7 @@
 Name=<%= appName %>
 Comment=<%= description %>
 GenericName=Text Editor
-Exec=env ATOM_DISABLE_SHELLING_OUT_FOR_ENVIRONMENT=false <%= installDir %>/bin/<%= appFileName %> --no-sandbox %F
+Exec=env ATOM_DISABLE_SHELLING_OUT_FOR_ENVIRONMENT=false <%= installDir %>/bin/<%= appFileName %> %F
 Icon=<%= iconPath %>
 Type=Application
 StartupNotify=true


### PR DESCRIPTION
This workaround had been justified by a compatibility issue in Chromium, present in Electron versions less than 13.5.0 or less than 14.0.0.

The flag shouldn't be needed anymore, now that Pulsar is on Electron 30. It'll be good to turn sandboxing back on, for whatever good it does, and also to be back on a default setting again. The less workarounds, the better.

One instance (possibly _the_ most important instance, at a glance?) of this flag had already been removed from `script/electron-builder.js` in https://github.com/pulsar-edit/pulsar/pull/1367, but it doesn't hurt to be thorough. Shouldn't, at least.

### Context

See: https://github.com/atom/atom/issues/23036