### PR TITLE
Update to a version of `pathwatcher`…

### DIFF
--- a/package.json
+++ b/package.json
@@ -320,6 +320,6 @@
     "es5-ext": "https://github.com/pulsar-edit/es5-ext#169f6ae9b2675675269a0ba265f83c29c7b56244",
     "@electron/remote": "2.1.2",
     "@pulsar-edit/superstring": "3.0.5",
-    "@pulsar-edit/pathwatcher": "https://github.com/pulsar-edit/node-pathwatcher#c1e13d69b93ea93afd29217307185167f9414f03"
+    "@pulsar-edit/pathwatcher": "9.0.3"
   }
 }


### PR DESCRIPTION
…that uses `kqueue` on macOS instead of `FSEvents`. 

If all goes well, this could fix #1459. At the very least, it should return `pathwatcher` behavior to something much closer to what it was before we had to rewrite it.

Opened as a draft for now; those affected by #1459 can try the binaries produced by this PR’s CI job.

_([node-pathwatcher#4](https://github.com/pulsar-edit/node-pathwatcher/pull/4) has some background on this change.)_
