### PR TITLE
Re-assert `core.setAutoHideMenuBar` after a call to `setFullScreen`…

### DIFF
--- a/src/atom-environment.js
+++ b/src/atom-environment.js
@@ -788,7 +788,11 @@ class AtomEnvironment {
 
   // Extended: Set the full screen state of the current window.
   setFullScreen(fullScreen = false) {
-    return this.applicationDelegate.setWindowFullScreen(fullScreen);
+    let result = this.applicationDelegate.setWindowFullScreen(fullScreen);
+    // On Linux, setting full screen (no matter the value) hides the menu bar.
+    // Hence we must re-assert this setting.
+    this.setAutoHideMenuBar(this.config.get('core.autoHideMenuBar'));
+    return result;
   }
 
   // Extended: Toggle the full screen state of the current window.


### PR DESCRIPTION
…so that the menu bar isn't automatically hidden on Linux.

Fixes #1448.

As part of the editor bootstrapping process, we declare a `BrowserWindow` in the main process. On supported platforms, we read `core.setAutoHideMenuBar`  rather early and set it on the `BrowserWindow`… and it sticks, but only for a moment! If we set it to `false`, the menu bar appears, then quickly disappears. Something later in the bootstrapping process causes the menu bar to go away.

That something turns out to be the [deserialization of window state](https://github.com/pulsar-edit/pulsar/blob/master/src/atom-environment.js#L1499). We remember whether the window was full-screen or not and pass the value to `setFullScreen`. For whatever reason, _even when we call `setFullScreen(false)`_, it seems to reset the menu bar setting; this is the exact line where the menu bar will disappear again.

To fix this, we can explicitly re-assert the config value at `core.autoHideMenuBar` after we call the main process `setFullScreen` method.

A more thorough (but more involved) fix would be to remember the state that we're currently in (auto-hide or no auto-hide) — which _technically_ can be out of sync with `core.autoHideMenuBar`. (An extension or some code in `init.js` can call `atom.setAutoHideMenuBar` directly; this calls the main-process method via delegate but does not interact with the config system.) But to do that properly would involve keeping track of the state on the client side and perhaps even the creation of an `atom.getAutoHideMenuBar` method, and I think that's overkill.

This should fix the issue and improve life for Linux Pulsar users.