### PR TITLE
settings-view: rebrand README and Restart notification

### DIFF
--- a/packages/settings-view/README.md
+++ b/packages/settings-view/README.md
@@ -7,7 +7,7 @@ Edit core configuration settings, install and configure packages, and change the
 ## Usage
 You can open the Settings View by navigating to
 ***LNX***: _Edit > Preferences_ -
-***MAC***: _Atom > Preferences_ -
+***MAC***: _Pulsar > Preferences_ -
 ***WIN***: _File > Settings_.
 
 In order to install new packages and themes, click on the _Install_ section on the left-hand side.

--- a/packages/settings-view/lib/updates-panel.js
+++ b/packages/settings-view/lib/updates-panel.js
@@ -186,7 +186,7 @@ export default class UpdatesPanel {
     await queue.drain()
 
     if (successfulUpdatesCount > 0) {
-      const message = `Restart Atom to complete the update of ${successfulUpdatesCount} ${pluralize('package', successfulUpdatesCount)}:`
+      const message = `Restart Pulsar to complete the update of ${successfulUpdatesCount} ${pluralize('package', successfulUpdatesCount)}:`
       let detail = ''
       this.packageCards.forEach((card) => {
         let oldVersion = ''


### PR DESCRIPTION
README for settings-view and the "Restart" notification after updating packages are changed to say Pulsar.