### PR TITLE
Guard against a user saving while the text buffer is conflicted…

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@pulsar-edit/pathwatcher": "^9.0.2",
     "@pulsar-edit/scandal": "^4.0.0",
     "@pulsar-edit/superstring": "^3.0.5",
-    "@pulsar-edit/text-buffer": "^14.0.3",
+    "@pulsar-edit/text-buffer": "^14.0.4",
     "about": "file:packages/about",
     "archive-view": "file:packages/archive-view",
     "async": "3.2.6",

--- a/packages/autosave/lib/autosave.js
+++ b/packages/autosave/lib/autosave.js
@@ -35,9 +35,14 @@ module.exports = {
   autosavePaneItem (paneItem, create = false) {
     if (!atom.config.get('autosave.enabled')) return
     if (!paneItem) return
-    if (typeof paneItem.getURI !== 'function' || !paneItem.getURI()) return
-    if (typeof paneItem.isModified !== 'function' || !paneItem.isModified()) return
-    if (typeof paneItem.getPath !== 'function' || !paneItem.getPath()) return
+    if (!paneItem.getURI?.()) return
+    if (!paneItem.isModified?.()) return
+    if (!paneItem.getPath?.()) return
+    // When conflicted files trigger a prompt, we don't want to attempt to save
+    // them automatically.
+    if (atom.config.get('core.promptOnConflict') && paneItem.isInConflict?.()) {
+      return
+    }
     if (!shouldSave(paneItem)) return
 
     try {

--- a/packages/autosave/spec/async-spec-helpers.js
+++ b/packages/autosave/spec/async-spec-helpers.js
@@ -32,26 +32,6 @@ exports.afterEach = function afterEach (fn) {
   }
 })
 
-exports.waitForCondition = function waitForCondition(fn) {
-  return new Promise((resolve, reject) => {
-    const interval = setInterval(() => {
-      if (fn()) {
-        resolve()
-        clearInterval(interval)
-        clearTimeout(timeout)
-      }
-    }, 100)
-    let timeout = setTimeout(() => {
-      reject(new Error(`Timeout waiting for condition`))
-      clearInterval(interval)
-    }, 4000)
-  })
-}
-
-exports.wait = function wait(ms) {
-  return new Promise(r => setTimeout(r, ms))
-}
-
 function waitsForPromise (fn) {
   const promise = fn()
   global.waitsFor('spec promise to resolve', function (done) {

--- a/packages/autosave/spec/async-spec-helpers.js
+++ b/packages/autosave/spec/async-spec-helpers.js
@@ -32,6 +32,26 @@ exports.afterEach = function afterEach (fn) {
   }
 })
 
+exports.waitForCondition = function waitForCondition(fn) {
+  return new Promise((resolve, reject) => {
+    const interval = setInterval(() => {
+      if (fn()) {
+        resolve()
+        clearInterval(interval)
+        clearTimeout(timeout)
+      }
+    }, 100)
+    let timeout = setTimeout(() => {
+      reject(new Error(`Timeout waiting for condition`))
+      clearInterval(interval)
+    }, 4000)
+  })
+}
+
+exports.wait = function wait(ms) {
+  return new Promise(r => setTimeout(r, ms))
+}
+
 function waitsForPromise (fn) {
   const promise = fn()
   global.waitsFor('spec promise to resolve', function (done) {

--- a/packages/autosave/spec/autosave-spec.js
+++ b/packages/autosave/spec/autosave-spec.js
@@ -1,5 +1,9 @@
 const fs = require('fs')
-const {it, fit, ffit, beforeEach} = require('./async-spec-helpers') // eslint-disable-line
+const {it, fit, ffit, beforeEach, waitForCondition, wait} = require('./async-spec-helpers') // eslint-disable-line
+
+async function waitForSave (saveFn) {
+  return waitForCondition(() => saveFn.callCount > 0)
+}
 
 describe('Autosave', () => {
   let workspaceElement, initialActiveItem, otherItem1, otherItem2
@@ -50,13 +54,16 @@ describe('Autosave', () => {
     })
 
     describe('when a pane loses focus', () => {
-      it('saves the item if autosave is enabled and the item has a uri', () => {
+      beforeEach(() => jasmine.useRealClock())
+
+      it('saves the item if autosave is enabled and the item has a uri', async () => {
         document.body.focus()
         expect(initialActiveItem.save).not.toHaveBeenCalled()
 
         workspaceElement.focus()
         atom.config.set('autosave.enabled', true)
         document.body.focus()
+        await waitForSave(initialActiveItem.save)
         expect(initialActiveItem.save).toHaveBeenCalled()
       })
 
@@ -90,7 +97,7 @@ describe('Autosave', () => {
     })
 
     describe('when a new pane is created', () => {
-      it('saves the item if autosave is enabled and the item has a uri', () => {
+      it('saves the item if autosave is enabled and the item has a uri', async () => {
         const leftPane = atom.workspace.getActivePane()
         const rightPane = leftPane.splitRight()
         expect(initialActiveItem.save).not.toHaveBeenCalled()
@@ -100,6 +107,7 @@ describe('Autosave', () => {
 
         atom.config.set('autosave.enabled', true)
         leftPane.splitRight()
+        await waitForSave(initialActiveItem.save)
         expect(initialActiveItem.save).toHaveBeenCalled()
       })
     })
@@ -124,7 +132,7 @@ describe('Autosave', () => {
       })
 
       describe('when the item is NOT the active item', () => {
-        it('does not save the item if autosave is enabled and the item has a uri', () => {
+        it('does not save the item if autosave is enabled and the item has a uri', async () => {
           let leftPane = atom.workspace.getActivePane()
           const rightPane = leftPane.splitRight({items: [otherItem1]})
           expect(initialActiveItem).not.toBe(atom.workspace.getActivePaneItem())
@@ -137,6 +145,7 @@ describe('Autosave', () => {
           rightPane.focus()
           expect(otherItem2).not.toBe(atom.workspace.getActivePaneItem())
           leftPane.destroyItem(otherItem2)
+          await waitForSave(otherItem2.save)
           expect(otherItem2.save).toHaveBeenCalled()
         })
       })
@@ -159,7 +168,7 @@ describe('Autosave', () => {
   })
 
   describe('when the window is blurred', () => {
-    it('saves all items', () => {
+    it('saves all items', async () => {
       atom.config.set('autosave.enabled', true)
 
       const leftPane = atom.workspace.getActivePane()
@@ -170,6 +179,10 @@ describe('Autosave', () => {
 
       window.dispatchEvent(new FocusEvent('blur'))
 
+      await Promise.all([
+        waitForSave(initialActiveItem.save),
+        waitForSave(otherItem1.save)
+      ])
       expect(initialActiveItem.save).toHaveBeenCalled()
       expect(otherItem1.save).toHaveBeenCalled()
     })
@@ -244,12 +257,14 @@ describe('Autosave', () => {
     atom.config.set('autosave.enabled', true)
 
     await atom.workspace.destroyActivePaneItem()
+    await waitForSave(initialActiveItem.save)
     expect(initialActiveItem.save).toHaveBeenCalled()
     expect(atom.notifications.addWarning.callCount > 0 || errorCallback.callCount > 0).toBe(true)
   })
 
   describe('dontSaveIf service', () => {
     it("doesn't save a paneItem if a predicate function registered via the dontSaveIf service returns true", async () => {
+      jasmine.useRealClock()
       atom.workspace.getActivePane().addItem(otherItem1)
       atom.config.set('autosave.enabled', true)
       const service = atom.packages.getActivePackage('autosave').mainModule.provideService()
@@ -259,7 +274,10 @@ describe('Autosave', () => {
       otherItem1.setText('bar')
 
       window.dispatchEvent(new FocusEvent('blur'))
-
+      await Promise.all([
+        waitForSave(otherItem1.save),
+        wait(200)
+      ])
       expect(initialActiveItem.save).not.toHaveBeenCalled()
       expect(otherItem1.save).toHaveBeenCalled()
     })

--- a/packages/autosave/spec/autosave-spec.js
+++ b/packages/autosave/spec/autosave-spec.js
@@ -1,9 +1,5 @@
 const fs = require('fs')
-const {it, fit, ffit, beforeEach, waitForCondition, wait} = require('./async-spec-helpers') // eslint-disable-line
-
-async function waitForSave (saveFn) {
-  return waitForCondition(() => saveFn.callCount > 0)
-}
+const {it, fit, ffit, beforeEach} = require('./async-spec-helpers') // eslint-disable-line
 
 describe('Autosave', () => {
   let workspaceElement, initialActiveItem, otherItem1, otherItem2
@@ -54,16 +50,13 @@ describe('Autosave', () => {
     })
 
     describe('when a pane loses focus', () => {
-      beforeEach(() => jasmine.useRealClock())
-
-      it('saves the item if autosave is enabled and the item has a uri', async () => {
+      it('saves the item if autosave is enabled and the item has a uri', () => {
         document.body.focus()
         expect(initialActiveItem.save).not.toHaveBeenCalled()
 
         workspaceElement.focus()
         atom.config.set('autosave.enabled', true)
         document.body.focus()
-        await waitForSave(initialActiveItem.save)
         expect(initialActiveItem.save).toHaveBeenCalled()
       })
 
@@ -97,7 +90,7 @@ describe('Autosave', () => {
     })
 
     describe('when a new pane is created', () => {
-      it('saves the item if autosave is enabled and the item has a uri', async () => {
+      it('saves the item if autosave is enabled and the item has a uri', () => {
         const leftPane = atom.workspace.getActivePane()
         const rightPane = leftPane.splitRight()
         expect(initialActiveItem.save).not.toHaveBeenCalled()
@@ -107,7 +100,6 @@ describe('Autosave', () => {
 
         atom.config.set('autosave.enabled', true)
         leftPane.splitRight()
-        await waitForSave(initialActiveItem.save)
         expect(initialActiveItem.save).toHaveBeenCalled()
       })
     })
@@ -132,7 +124,7 @@ describe('Autosave', () => {
       })
 
       describe('when the item is NOT the active item', () => {
-        it('does not save the item if autosave is enabled and the item has a uri', async () => {
+        it('does not save the item if autosave is enabled and the item has a uri', () => {
           let leftPane = atom.workspace.getActivePane()
           const rightPane = leftPane.splitRight({items: [otherItem1]})
           expect(initialActiveItem).not.toBe(atom.workspace.getActivePaneItem())
@@ -145,7 +137,6 @@ describe('Autosave', () => {
           rightPane.focus()
           expect(otherItem2).not.toBe(atom.workspace.getActivePaneItem())
           leftPane.destroyItem(otherItem2)
-          await waitForSave(otherItem2.save)
           expect(otherItem2.save).toHaveBeenCalled()
         })
       })
@@ -168,7 +159,7 @@ describe('Autosave', () => {
   })
 
   describe('when the window is blurred', () => {
-    it('saves all items', async () => {
+    it('saves all items', () => {
       atom.config.set('autosave.enabled', true)
 
       const leftPane = atom.workspace.getActivePane()
@@ -179,10 +170,6 @@ describe('Autosave', () => {
 
       window.dispatchEvent(new FocusEvent('blur'))
 
-      await Promise.all([
-        waitForSave(initialActiveItem.save),
-        waitForSave(otherItem1.save)
-      ])
       expect(initialActiveItem.save).toHaveBeenCalled()
       expect(otherItem1.save).toHaveBeenCalled()
     })
@@ -257,14 +244,12 @@ describe('Autosave', () => {
     atom.config.set('autosave.enabled', true)
 
     await atom.workspace.destroyActivePaneItem()
-    await waitForSave(initialActiveItem.save)
     expect(initialActiveItem.save).toHaveBeenCalled()
     expect(atom.notifications.addWarning.callCount > 0 || errorCallback.callCount > 0).toBe(true)
   })
 
   describe('dontSaveIf service', () => {
     it("doesn't save a paneItem if a predicate function registered via the dontSaveIf service returns true", async () => {
-      jasmine.useRealClock()
       atom.workspace.getActivePane().addItem(otherItem1)
       atom.config.set('autosave.enabled', true)
       const service = atom.packages.getActivePackage('autosave').mainModule.provideService()
@@ -274,10 +259,7 @@ describe('Autosave', () => {
       otherItem1.setText('bar')
 
       window.dispatchEvent(new FocusEvent('blur'))
-      await Promise.all([
-        waitForSave(otherItem1.save),
-        wait(200)
-      ])
+
       expect(initialActiveItem.save).not.toHaveBeenCalled()
       expect(otherItem1.save).toHaveBeenCalled()
     })

--- a/packages/autosave/spec/autosave-spec.js
+++ b/packages/autosave/spec/autosave-spec.js
@@ -111,7 +111,7 @@ describe('Autosave', () => {
         spyOn(initialActiveItem, 'isInConflict').andReturn(true)
       })
 
-      it('does not try save the item', async () => {
+      it('does not try to save the item', async () => {
         expect(initialActiveItem.isInConflict()).toBe(true)
         const newItem = await atom.workspace.createItemForURI('notyet.js')
         spyOn(newItem, 'isModified').andReturn(true)
@@ -133,6 +133,37 @@ describe('Autosave', () => {
           atom.config.set('autosave.enabled', true)
           document.body.focus()
           expect(initialActiveItem.save).not.toHaveBeenCalled()
+        })
+      })
+
+      describe('but core.promptOnConflict is false', () => {
+        beforeEach(() => {
+          atom.config.set('core.promptOnConflict', false)
+        })
+
+        it('does try to save the item', async () => {
+          expect(initialActiveItem.isInConflict()).toBe(true)
+          const newItem = await atom.workspace.createItemForURI('notyet.js')
+          spyOn(newItem, 'isModified').andReturn(true)
+          spyOn(newItem, 'isInConflict').andReturn(true)
+
+          atom.config.set('autosave.enabled', true)
+          spyOn(atom.workspace.getActivePane(), 'saveItem').andCallFake(() => Promise.resolve())
+          atom.workspace.getActivePane().addItem(newItem)
+
+          expect(atom.workspace.getActivePane().saveItem).toHaveBeenCalledWith(newItem)
+        })
+
+        describe('and a pane loses focus', () => {
+          it('saves the conflicted item if autosave is enabled', () => {
+            document.body.focus()
+            expect(initialActiveItem.save).not.toHaveBeenCalled()
+
+            workspaceElement.focus()
+            atom.config.set('autosave.enabled', true)
+            document.body.focus()
+            expect(initialActiveItem.save).toHaveBeenCalled()
+          })
         })
       })
     })

--- a/packages/autosave/spec/autosave-spec.js
+++ b/packages/autosave/spec/autosave-spec.js
@@ -5,6 +5,7 @@ describe('Autosave', () => {
   let workspaceElement, initialActiveItem, otherItem1, otherItem2
 
   beforeEach(async () => {
+    atom.config.set('core.promptOnConflict', true)
     workspaceElement = atom.views.getView(atom.workspace)
     jasmine.attachToDOM(workspaceElement)
 
@@ -101,6 +102,38 @@ describe('Autosave', () => {
         atom.config.set('autosave.enabled', true)
         leftPane.splitRight()
         expect(initialActiveItem.save).toHaveBeenCalled()
+      })
+    })
+
+    describe('when an item is conflicted', () => {
+      beforeEach(() => {
+        initialActiveItem.setText('i am modified')
+        spyOn(initialActiveItem, 'isInConflict').andReturn(true)
+      })
+
+      it('does not try save the item', async () => {
+        expect(initialActiveItem.isInConflict()).toBe(true)
+        const newItem = await atom.workspace.createItemForURI('notyet.js')
+        spyOn(newItem, 'isModified').andReturn(true)
+        spyOn(newItem, 'isInConflict').andReturn(true)
+
+        atom.config.set('autosave.enabled', true)
+        spyOn(atom.workspace.getActivePane(), 'saveItem').andCallFake(() => Promise.resolve())
+        atom.workspace.getActivePane().addItem(newItem)
+
+        expect(atom.workspace.getActivePane().saveItem).not.toHaveBeenCalledWith(newItem)
+      })
+
+      describe('and a pane loses focus', () => {
+        it('skips saving the conflicted item, even if autosave is enabled', () => {
+          document.body.focus()
+          expect(initialActiveItem.save).not.toHaveBeenCalled()
+
+          workspaceElement.focus()
+          atom.config.set('autosave.enabled', true)
+          document.body.focus()
+          expect(initialActiveItem.save).not.toHaveBeenCalled()
+        })
       })
     })
 

--- a/packages/tabs/lib/tab-view.js
+++ b/packages/tabs/lib/tab-view.js
@@ -149,9 +149,21 @@ class TabView {
       });
     }
 
+    if (typeof this.item.onDidConflict === 'function') {
+      const onDidConflictDisposable = this.item.onDidConflict(() => {
+        this.updateConflictedStatus();
+      });
+      if (Disposable.isDisposable(onDidConflictDisposable)) {
+        this.subscriptions.add(onDidConflictDisposable);
+      } else {
+        console.warn("::onDidConflict does not return a valid Disposable!", this.item);
+      }
+    }
+
     if (typeof this.item.onDidSave === 'function') {
       const onDidSaveDisposable = this.item.onDidSave(event => {
         this.terminatePendingState();
+        this.updateConflictedStatus();
         if (event.path !== this.path) {
           this.path = event.path;
           if (atom.config.get('tabs.enableVcsColoring')) { return this.setupVcsStatus(); }
@@ -313,6 +325,19 @@ class TabView {
     } else {
       return this.itemTitle.classList.add('hide-icon');
     }
+  }
+
+  updateConflictedStatus () {
+    if (this.item.isInConflict?.()) {
+      this.element.classList.add('conflicted');
+      this.isConflicted = true;
+    } else {
+      if (this.isConflicted) {
+        this.element.classList.remove('conflicted');
+      }
+      this.isConflicted = false;
+    }
+    return this.isConflicted;
   }
 
   updateModifiedStatus() {

--- a/spec/text-editor-spec.js
+++ b/spec/text-editor-spec.js
@@ -1,11 +1,13 @@
-const { timeoutPromise: wait } = require('./helpers/async-spec-helpers');
+const { timeoutPromise: wait, conditionPromise } = require('./helpers/async-spec-helpers');
 
+const { CompositeDisposable } = require('atom');
 const fs = require('fs');
 const path = require('path');
 const temp = require('temp').track();
 const dedent = require('dedent');
 const { clipboard } = require('electron');
 const os = require('os');
+const Pane = require('../src/pane');
 const TextEditor = require('../src/text-editor');
 const TextBuffer = require('@pulsar-edit/text-buffer');
 const TextMateLanguageMode = require('../src/text-mate-language-mode');
@@ -8353,6 +8355,127 @@ describe('TextEditor', () => {
         'property_identifier'
       ]);
     });
+  });
+
+  describe('when the file on disk is changed while we have pending modifications', () => {
+    let destination;
+    let disposables;
+    let promptOnConflictOutcome;
+    beforeEach(async () => {
+      jasmine.useRealClock();
+      let projectPath = temp.mkdirSync('project-with-file-modification');
+      destination = path.resolve(projectPath, 'sample.js');
+      fs.copyFileSync(
+        path.resolve(__dirname, 'fixtures', 'sample.js'),
+        destination
+      );
+      disposables?.dispose();
+      disposables = new CompositeDisposable();
+      atom.project.setPaths([projectPath]);
+      editor = await atom.workspace.open(destination);
+      buffer = editor.buffer;
+      editor.update({ autoIndent: false });
+
+      // Mock `Pane::promptOnConflict` in order to skip the presentation of the
+      // dialog. Instead, we can choose the outcome of the prompt on a per-call
+      // basis.
+      promptOnConflictOutcome = Promise.resolve();
+      if (!Pane.prototype.promptOnConflict.calls) {
+        spyOn(Pane.prototype, 'promptOnConflict').and.callFake(() => {
+          return promptOnConflictOutcome;
+        });
+      }
+
+      await atom.packages.activatePackage('language-javascript');
+      languageMode = buffer.getLanguageMode();
+      if ('useAsyncParsing' in languageMode) {
+        languageMode.useAsyncParsing = false;
+        languageMode.useAsyncIndent = false;
+      }
+      if (languageMode.ready) {
+        await languageMode.ready;
+      }
+      let contents = fs.readFileSync(destination, 'utf8').toString();
+
+      // Modify the buffer (replacing `var` with `let`) so that the buffer is
+      // dirty…
+      editor.setTextInBufferRange(
+        [[0, 0], [0, 3]],
+        'let'
+      );
+      expect(editor.isModified()).toBe(true);
+
+      // …then change the file on disk so that our modifications are orphaned.
+      fs.writeFileSync(destination, `${contents}\n\n// changed`);
+
+      // TEMP: The infrastructure is present to make this a more rigorous
+      // end-to-end test (temp directories, etc.) but `pathwatcher` seems to
+      // have trouble keeping up.
+      //
+      // Since the effect of conflict detection is to flip a particular flag on
+      // the `TextBuffer`, we'll flip it manually here. The purpose of these
+      // specs is to verify that the correct things happen _after_ a certain
+      // condition is met; it's the job of `TextBuffer`’s specs to prove that
+      // file-watching produces that condition.
+      editor.buffer.fileHasChangedSinceLastLoad = true;
+      expect(editor.isInConflict()).toBe(true);
+    });
+
+    afterEach(() => disposables?.dispose());
+
+    it('is considered to be in conflicted state, but will overwrite with user confirmation', async () => {
+      expect(editor.isInConflict()).toBe(true);
+
+      let uncommittedContents = editor.getText();
+
+      // We've got to save this editor via the `Pane::saveItem` interface to
+      // trigger this conflict warning.
+      let activePane = atom.workspace.getActivePane();
+      activePane.saveItem(editor);
+
+      // User should be shown the dialog…
+      await conditionPromise(() => {
+        return Pane.prototype.promptOnConflict.calls.count() > 0
+      });
+
+      await conditionPromise(() => !editor.isModified());
+
+      // …and whatever was in the buffer when we chose to overwrite should
+      // match what's now present on disk.
+      expect(
+        fs.readFileSync(destination, 'utf8').toString()
+      ).toBe(uncommittedContents);
+
+      // Now that we've written to disk, there's no longer a conflict.
+      expect(editor.isInConflict()).toBe(false);
+
+      // Saving the file to disk should flip this internal flag.
+      expect(editor.buffer.fileHasChangedSinceLastLoad).toBe(false);
+    });
+
+    it('is considered to be in conflicted state and will not overwrite if user declines', async () => {
+      let contentsOnDisk = fs.readFileSync(destination, 'utf8').toString();
+      expect(editor.isInConflict()).toBe(true);
+
+      promptOnConflictOutcome = Promise.reject({ path: destination });
+      let uncommittedContents = editor.getText();
+
+      let activePane = atom.workspace.getActivePane();
+      activePane.saveItem(editor);
+      await conditionPromise(() => {
+        return Pane.prototype.promptOnConflict.calls.count() > 0
+      });
+
+      expect(
+        fs.readFileSync(destination, 'utf8').toString()
+      ).toBe(contentsOnDisk);
+
+      expect(editor.getText()).toBe(uncommittedContents);
+
+      // Since we cancelled the write, the conflict state should still be
+      // present and unresolved.
+      expect(editor.isInConflict()).toBe(true);
+    })
   });
 
   describe('.shouldPromptToSave()', () => {

--- a/spec/text-editor-spec.js
+++ b/spec/text-editor-spec.js
@@ -8363,6 +8363,7 @@ describe('TextEditor', () => {
     let promptOnConflictOutcome;
     beforeEach(async () => {
       jasmine.useRealClock();
+      atom.config.set('core.promptOnConflict', true);
       let projectPath = temp.mkdirSync('project-with-file-modification');
       destination = path.resolve(projectPath, 'sample.js');
       fs.copyFileSync(
@@ -8423,7 +8424,7 @@ describe('TextEditor', () => {
 
     afterEach(() => disposables?.dispose());
 
-    it('is considered to be in conflicted state, but will overwrite with user confirmation', async () => {
+    it('is considered to be in a conflicted state, but will overwrite with user confirmation', async () => {
       expect(editor.isInConflict()).toBe(true);
 
       let uncommittedContents = editor.getText();
@@ -8480,7 +8481,47 @@ describe('TextEditor', () => {
       // Since we cancelled the write, the conflict state should still be
       // present and unresolved.
       expect(editor.isInConflict()).toBe(true);
-    })
+    });
+
+    describe('but core.promptOnConflict is false', () => {
+      beforeEach(() => {
+        atom.config.set('core.promptOnConflict', false);
+      });
+
+      it('is considered to be in a conflicted state, but will not prompt the user', async () => {
+        expect(editor.isInConflict()).toBe(true);
+        expect(atom.config.get('core.promptOnConflict')).toBe(false);
+
+        let uncommittedContents = editor.getText();
+
+        // We've got to save this editor via the `Pane::saveItem` interface to
+        // trigger this conflict warning.
+        let activePane = atom.workspace.getActivePane();
+        activePane.saveItem(editor);
+
+        await conditionPromise(() => !editor.isModified());
+
+        // User should not have been shown the dialog…
+        expect(Pane.prototype.promptOnConflict).not.toHaveBeenCalled();
+
+        // …yet whatever was in the buffer when we chose to overwrite should
+        // match what's now present on disk.
+        expect(
+          fs.readFileSync(destination, 'utf8').toString()
+        ).toBe(uncommittedContents);
+
+        // Now that we've written to disk, there's no longer a conflict.
+        expect(editor.isInConflict()).toBe(false);
+
+        // Saving the file to disk should flip this internal flag.
+        expect(editor.buffer.fileHasChangedSinceLastLoad).toBe(false);
+
+        await wait(2000);
+        // The flag should stay this way even if the save triggered the buffer's
+        // `onDidChange` handler.
+        expect(editor.buffer.fileHasChangedSinceLastLoad).toBe(false);
+      });
+    });
   });
 
   describe('.shouldPromptToSave()', () => {

--- a/spec/text-editor-spec.js
+++ b/spec/text-editor-spec.js
@@ -8451,6 +8451,11 @@ describe('TextEditor', () => {
 
       // Saving the file to disk should flip this internal flag.
       expect(editor.buffer.fileHasChangedSinceLastLoad).toBe(false);
+
+      await wait(2000);
+      // The flag should stay this way even if the save triggered the buffer's
+      // `onDidChange` handler.
+      expect(editor.buffer.fileHasChangedSinceLastLoad).toBe(false);
     });
 
     it('is considered to be in conflicted state and will not overwrite if user declines', async () => {

--- a/src/config-schema.js
+++ b/src/config-schema.js
@@ -133,6 +133,12 @@ const configSchema = {
         description:
           "When a window with no open tabs or panes is given the 'Close Tab' command, close that window."
       },
+      promptOnConflict: {
+        type: 'boolean',
+        title: 'Experimental: Prompt on Conflict',
+        default: false,
+        description: "Prompt before saving a file in a conflicted state, as happens when a file’s contents on disk are changed by another program while edits are pending."
+      },
       fileEncoding: {
         description:
           'Default character set encoding to use when reading and writing files.',

--- a/src/pane.js
+++ b/src/pane.js
@@ -6,7 +6,17 @@ const { createPaneElement } = require('./pane-element');
 
 let nextInstanceId = 1;
 
-class SaveCancelledError extends Error {}
+// Thrown when a user cancels a save operation.
+class SaveCancelledError extends Error {
+  name = 'SaveCancelledError';
+}
+
+// Thrown when a user cancels a save operation because of a buffer conflict.
+class SaveConflictedError extends Error {
+  name = 'SaveConflictedError';
+}
+
+
 
 // Extended: A container for presenting content in the center of the workspace.
 // Panes can contain multiple items, one of which is *active* at a given time.
@@ -886,6 +896,41 @@ module.exports = class Pane {
     );
   }
 
+  // Prompt the user about an item's conflicted state during an attempt to
+  // save. The user must decide whether to cancel the attempted save… or force
+  // it and overwrite what's on disk.
+  promptOnConflict(item) {
+    return new Promise((resolve, reject) => {
+      // Ensure the item implements an `isInConflict` method, and that it
+      // returns `true`.
+      if (!item.isInConflict?.()) {
+        return resolve(true);
+      }
+      // Figure out how to describe the buffer in the dialog.
+      const uri = item.getURI?.() ?? item.getUri?.() ?? null;
+      const title =
+        (typeof item.getTitle === 'function' && item.getTitle()) || uri;
+
+      this.applicationDelegate.confirm({
+        message: `'${title}' has changed on disk. Do you want to overwrite this file with your changes?`,
+        detail: 'The contents of the buffer may be stale.',
+
+        // TODO: Individual pane items may have additional strategies to
+        // contribute (e.g., conflict resolution view). Implement a way for
+        // them to contribute buttons to this dialog — and to handle them in
+        // the callback below.
+        buttons: ['Overwrite', 'Cancel']
+      }, (response) => {
+        switch (response) {
+          case 0:
+            return resolve(true);
+          case 1:
+            return reject(new SaveConflictedError('Save cancelled due to conflict'));
+        }
+      });
+    });
+  }
+
   promptToSaveItem(item, options = {}) {
     return new Promise((resolve, reject) => {
       if (
@@ -971,10 +1016,11 @@ module.exports = class Pane {
   // * `item` The item to save.
   // * `nextAction` (optional) {Function} which will be called with no argument
   //   after the item is successfully saved, or with the error if it failed.
-  //   The return value will be that of `nextAction` or `undefined` if it was not
-  //   provided
+  //   The return value will be that of `nextAction` or `undefined` if it was
+  //   not provided.
   //
-  // Returns a {Promise} that resolves when the save is complete
+  // Returns a {Promise} that resolves when the save is complete, or rejects if
+  // the save could not be completed.
   saveItem(item, nextAction) {
     if (!item) return Promise.resolve();
 
@@ -987,22 +1033,36 @@ module.exports = class Pane {
 
     if (itemURI != null) {
       if (typeof item.save === 'function') {
-        return promisify(() => item.save())
+        // If `isInConflict` is implemented, we call it first to figure out if
+        // it's safe to attempt to save.
+        let conflicted = item.isInConflict?.();
+
+        // If the item is conflicted, we'll show a dialog in order to decide
+        // how to proceed. The user may choose to overwrite (force the save) or
+        // cancel.
+        let preface = conflicted ? this.promptOnConflict(item) : Promise.resolve();
+
+        return preface
+          .then(() => item.save())
           .then(() => {
             if (nextAction) nextAction();
-          })
-          .catch(error => {
+          }).catch(error => {
             if (nextAction) {
               nextAction(error);
             } else {
               this.handleSaveError(error, item);
             }
+            // Re-propagate the error.
+            return Promise.reject(error);
           });
       } else if (nextAction) {
+        // Don't check if this item is in conflict; if it can't be saved,
+        // there's no hazard.
         nextAction();
         return Promise.resolve();
       }
     } else {
+      // The file has not been committed to disk, so there's conflict hazard.
       return this.saveItemAs(item, nextAction);
     }
   }
@@ -1013,8 +1073,8 @@ module.exports = class Pane {
   // * `item` The item to save.
   // * `nextAction` (optional) {Function} which will be called with no argument
   //   after the item is successfully saved, or with the error if it failed.
-  //   The return value will be that of `nextAction` or `undefined` if it was not
-  //   provided
+  //   The return value will be that of `nextAction` or `undefined` if it was
+  //   not provided.
   async saveItemAs(item, nextAction) {
     if (!item) return;
     if (typeof item.saveAs !== 'function') return;

--- a/src/pane.js
+++ b/src/pane.js
@@ -1046,10 +1046,15 @@ module.exports = class Pane {
         // If the item is conflicted, we'll show a dialog in order to decide
         // how to proceed. The user may choose to overwrite (force the save) or
         // cancel.
-        let preface = conflicted ? this.promptOnConflict(item) : Promise.resolve();
+        let preface = () => promisify(() => item.save());
+        if (conflicted) {
+          preface = () => {
+            return this.promptOnConflict(item)
+              .then(() => item.save());
+          };
+        }
 
-        return preface
-          .then(() => item.save())
+        return preface()
           .then(() => {
             if (nextAction) nextAction();
           }).catch(error => {

--- a/src/pane.js
+++ b/src/pane.js
@@ -899,8 +899,14 @@ module.exports = class Pane {
   // Prompt the user about an item's conflicted state during an attempt to
   // save. The user must decide whether to cancel the attempted save… or force
   // it and overwrite what's on disk.
+  //
+  // Resolves with boolean `true` when a save can proceed… or rejects with an
+  // error when the save is aborted.
   promptOnConflict(item) {
     return new Promise((resolve, reject) => {
+      // Don't prompt if the user hasn't opted into it.
+      if (!atom.config.get('core.promptOnConflict')) return resolve(true);
+
       // Ensure the item implements an `isInConflict` method, and that it
       // returns `true`.
       if (!item.isInConflict?.()) {
@@ -1062,7 +1068,8 @@ module.exports = class Pane {
         return Promise.resolve();
       }
     } else {
-      // The file has not been committed to disk, so there's conflict hazard.
+      // The file has not been committed to disk, so there's no conflict
+      // hazard.
       return this.saveItemAs(item, nextAction);
     }
   }

--- a/src/pane.js
+++ b/src/pane.js
@@ -1047,7 +1047,7 @@ module.exports = class Pane {
         // how to proceed. The user may choose to overwrite (force the save) or
         // cancel.
         let preface = () => promisify(() => item.save());
-        if (conflicted) {
+        if (conflicted && atom.config.get('core.promptOnConflict')) {
           preface = () => {
             return this.promptOnConflict(item)
               .then(() => item.save());

--- a/src/pane.js
+++ b/src/pane.js
@@ -1058,8 +1058,12 @@ module.exports = class Pane {
             } else {
               this.handleSaveError(error, item);
             }
-            // Re-propagate the error.
-            return Promise.reject(error);
+            // Re-propagate cancellation errors so callers know the save was
+            // aborted. Other errors are already handled by
+            // handleSaveError/nextAction above.
+            if (error instanceof SaveCancelledError || error instanceof SaveConflictedError) {
+              return Promise.reject(error);
+            }
           });
       } else if (nextAction) {
         // Don't check if this item is in conflict; if it can't be saved,

--- a/src/text-editor.js
+++ b/src/text-editor.js
@@ -1467,6 +1467,18 @@ module.exports = class TextEditor {
     return this.buffer.isModified();
   }
 
+  // Essential: Returns {Boolean} `true` if this editor's buffer is in conflict
+  // — that is, if the buffer is modified and those changes are based on buffer
+  // contents that do not match what is currently written to disk.
+  //
+  // This can happen if another process writes to a file after you start to
+  // edit it in Pulsar, but before you're able to save those changes. It can
+  // also happen if you switch branches in version control while a certain
+  // buffer has uncommitted changes.
+  isInConflict () {
+    return this.buffer.isInConflict();
+  }
+
   // Essential: Returns {Boolean} `true` if this editor has no content.
   isEmpty() {
     return this.buffer.isEmpty();

--- a/yarn.lock
+++ b/yarn.lock
@@ -1739,10 +1739,10 @@
   dependencies:
     node-addon-api "^8.5.0"
 
-"@pulsar-edit/text-buffer@^14.0.3":
-  version "14.0.3"
-  resolved "https://registry.yarnpkg.com/@pulsar-edit/text-buffer/-/text-buffer-14.0.3.tgz#b88823b185c1522d0411baff0a08c2e0e4a8f89f"
-  integrity sha512-+YUq3a+/+KoOHKE5SaKqchGgsKuACRD04PonqlpZjaEoGe4BIpMwr+8GbLrw/DpFKfv1urAemmgkEEFJEB9TEA==
+"@pulsar-edit/text-buffer@^14.0.4":
+  version "14.0.4"
+  resolved "https://registry.yarnpkg.com/@pulsar-edit/text-buffer/-/text-buffer-14.0.4.tgz#9bf03445ab8da000c9c986255654acf04433e6bb"
+  integrity sha512-KiC/uA7zdnoI2pI3AyoYYXAdL5h6LyHURHl/URxkViQPjGeFXr3vRr6cb9OxsS1NRM4fVFtEdHFG8T7aafDdUQ==
   dependencies:
     "@pulsar-edit/pathwatcher" "^9.0.2"
     "@pulsar-edit/superstring" "^3.0.4"


### PR DESCRIPTION
…by alerting them to the problem and giving them a choice between cancelling and overwriting the contents on disk.

This doesn't carry any cosmetic changes to the tabs, nor any change to the editor's behavior when the file on disk has been deleted. Those changes will come later.

This covers some of the enhancements mooted in #1040, but not all of them, so that issue will stay open even after this lands.

### The problem

Suppose, like me, your attention span is not your strongest suit. You change `git` branches one day and fail to notice that you have uncommitted changes in one of your text buffers. When the branch changes, the contents of that buffer's backing file change on disk… but we won't update the buffer contents to match, because that would clobber the uncommitted changes you've made. We can't “rebase” your changes onto the new base file contents, either. So what should we do?

Right now, this is a time bomb. We indicate that the file is in a modified state, but we don't even try to alert you to the fact that you might be saving over the changes that were just introduced by the branch switch.

Luckily, this scenario isn't catastrophic; that's what version control is for. But this same situation can happen _outside of_ version control; it's a hazard whenever another process can edit a file that you've got open in Pulsar.

### The solution

This PR is the first step toward fixing this! It implements the bare minimum of what we ought to do in this scenario: detect the conflicted state and prompt the user about it, allowing them to decide how we proceed. Right now, the options are “Overwrite” and “Cancel”; but as an eventual enhancement, we could introduce a conflict resolution view where the user can do a three-way merge. (This UI exists in the `github` package, but it should be broken out into its own package (or maybe a service?) so that it can be used in non-VCS contexts.)

<p><img width="295" height="274" alt="Screenshot 2026-03-12 at 2 43 43 PM" src="https://github.com/user-attachments/assets/4d690227-fa7a-40b3-9edd-3b5b58e0b157" /></p>

There is further work to be done around files that are _deleted_ by external processes, whether or not those buffers were modified; but those scenarios are more nuanced and less urgent to fix.

Because this is experimental (and because we should let users opt out of this behavior even once it's no longer experimental), I've created a `core.promptOnConflict` setting that applies to pane items in general. When it's `false`, the pre-existing behavior is unchanged. When it's `true`, attempting to save a file in a conflicted state will trigger an are-you-sure dialog. While it's experimental, the default will be `false` so that it's opt-in; but once we're confident it behaves the way we want, we can flip the default value to `true`.

~~Also yet to be done is _surfacing_ of these buffer states via the `tabs` package. We can detect the conflicted state of the buffer as soon as we notice the underlying file contents have changed; so there's no reason why we can't indicate it in the tab bar with some sort of symbol, or at least add a class name to the tab so that themes can decide if it warrants a different appearance in the first place.~~ EDIT: Now this PR also adds a class name to each tab element — `conflicted`, to match existing class names like `modified` that are conditionally applied. No built-in UI themes have yet been updated to leverage this style, but it's there for the future.

### Architecture

We particularly care about fixing this for all `TextEditor`s… but this prompt is owned by the `Pane` code, and it can theoretically work identically for any pane item, `TextEditor` or otherwise. This PR introduces `isInConflict` (already a method on `TextBuffer`, and now present on `TextEditor`) as a generic way of indicating whether the current pane item is in a conflicted state. When that method returns `true`, `Pane` puts a confirmation dialog up before it calls through to the pane item's `save` method.

This comports with the current approach to pane item management: we use the presence of certain methods to draw conclusions about what can be done with the pane. The [`AbstractPaneItem` interface in the `types` package](https://github.com/pulsar-edit/types/blob/main/src/pane.d.ts#L92) tries to catalog all the various methods that package authors can implement for various purposes; soon `isInConflict` will join this list!

And in the future, if there are other ways to resolve the conflict instead of just deciding which copy wins, then that can be decided on a pane-item–by–pane-item basis. Pane items could implement an additional method whose purpose is to offer a third option to be shown in that prompt — one that aborts the save operation, but also introduces some sort of side effect that sets the user up to resolve the conflict.

### Testing

I put the new specs in `text-editor-spec.js`, but they could arguably go into `pane-spec.js` for the reasons explained in the previous section.