### PR TITLE
script: Fix pulsar and ppm removal from PATH during upgrade with .rpms

### DIFF
--- a/script/electron-builder.js
+++ b/script/electron-builder.js
@@ -288,7 +288,7 @@ let options = {
   },
   rpm: {
     afterInstall: 'script/post-install.sh',
-    afterRemove: 'script/post-uninstall.sh',
+    afterRemove: 'script/post-uninstall-rpm.sh',
     compression: 'xz',
     fpm: ['--rpm-rpmbuild-define=_build_id_links none']
   },


### PR DESCRIPTION
Fixes issue https://github.com/pulsar-edit/pulsar/issues/544 again.

This issue was perhaps inadvertently reintroduced during refactors of the `script/electron-builder.js` config script for the big Electron 30 PR (https://github.com/pulsar-edit/pulsar/pull/1367).

### Verification

#### Background (optional reading for historical context)

I had a suspicion this bug could have possibly come back while reading over the diff of https://github.com/pulsar-edit/pulsar/pull/1367, but I didn't follow up at the time, since there was some indication the two postinstall scripts might have been intentionally unified in that PR. Just recently I was running from a Fedora LiveUSB to test Pulsar anyway, so I decided to check the somewhat obscure matter of the in-place upgrade behavior and be sure. (It is the kind of thing that could easily go under the radar for some time.)

Indeed, the behavior described in https://github.com/pulsar-edit/pulsar/issues/544 is back. That is to say, I personally confirm bug https://github.com/pulsar-edit/pulsar/issues/544 has returned.

Looking forward as I type this: To confirm _the fix,_ I can test this PR's CI binary once it finishes building.

---

#### Steps

**To verify the bug exists:**

- Installing the latest Rolling `.rpm` should add `ppm` and `pulsar` the the PATH.
- _Reinstalling_ that same `.rpm` over itself should trigger the `post-uninstall` scriptlet _after_ the `post-install` scriptlet; **If `ppm` and `pulsar` are removed from the PATH at this point, it confirms the bug.**

**To verify the fix works,** uninstall Pulsar, and then the above steps should be repeated with _this PR's CI binary,_ and **`ppm` and `pulsar` should remain on the PATH**, both after initial install with no Pulsar installed beforehand, and after in-place upgrade (installing this PR's CI binary `.rpm` over itself).