### PR TITLE
[build] Ensure `locales` dir is included when building Pulsar

### DIFF
--- a/script/electron-builder.js
+++ b/script/electron-builder.js
@@ -135,6 +135,7 @@ let options = {
     "src/**/*",
     "static/**/*",
     "vendor/**/*",
+    "locales/*",
     "node_modules/**/*",
 
     // Core Repo Test Inclusions


### PR DESCRIPTION
Back in #1337 I fixed an issue that would cause a built Pulsar binary to not include our `locales` directory.
With Electron v30 going mainline, that change was lost in the shuffle.

Adding it back here should resolve instances of the following:
<img width="1050" height="220" alt="image" src="https://github.com/user-attachments/assets/92cc0441-49bc-4453-95ad-16cde395ba48" />
