### PR TITLE
Change timing of window focus when a new project is opened

### DIFF
--- a/src/main-process/atom-application.js
+++ b/src/main-process/atom-application.js
@@ -980,15 +980,18 @@ module.exports = class AtomApplication extends EventEmitter {
     );
     this.disposable.add(
       ipcHelpers.respondTo('show-window', window => {
-        // On macOS, opening a project from the terminal won't make this
-        // application frontmost on its own. We must bring the app to the
-        // foreground.
         window.show();
         let atomWindow = this.atomWindowForBrowserWindow(window);
         if (atomWindow?.preserveFocus) {
           atomWindow.preserveFocus = false;
           return;
         }
+        // On Linux, `window.show()` is enough to make the new window
+        // frontmost, at least on X11. (TODO: Investigate Wayland behavior.)
+        //
+        // On both Windows and macOS (despite their varying window management
+        // models!) we must also call `app.focus()` to ensure the frontmost
+        // Pulsar window is brought above windows from other applications.
         if (process.platform !== 'linux') {
           app.focus({ steal: true });
         }
@@ -1375,6 +1378,12 @@ module.exports = class AtomApplication extends EventEmitter {
         } else {
           openedWindow.focus();
         }
+        // On Linux, `window.show()` is enough to make the existing window
+        // frontmost, at least on X11. (TODO: Investigate Wayland behavior.)
+        //
+        // On both Windows and macOS (despite their varying window management
+        // models!) we must also call `app.focus()` to ensure the frontmost
+        // Pulsar window is brought above windows from other applications.
         if (process.platform !== 'linux') {
           app.focus({ steal: true });
         }

--- a/src/main-process/start.js
+++ b/src/main-process/start.js
@@ -105,8 +105,28 @@ module.exports = function start(resourcePath, devResourcePath, startTime) {
 
   // NB: This prevents Win10 from showing dupe items in the taskbar.
   app.setAppUserModelId(appUserModelId);
+
+  // Pulsar uses a custom mechanism for ensuring a single instance, so we don't
+  // need `app.requestSingleInstanceLock()`. But we call this method on Windows
+  // anyway in order to benefit from a side effect.
+  //
+  // Windows doesn't like it when applications try to move themselves to the
+  // front unilaterally. There are certain escape hatches, though; one process
+  // can give another process specific permission for the latter process to
+  // foreground itself while the former process is active.
+  //
+  // This happens automatically as part of the `requestSingleInstanceLock`
+  // machinery. Hence we ask for a single-instance lock on startup so that the
+  // _second_ instance, when the request is denied, will trigger the side
+  // effect that allows the original instance to foreground itself.
+  //
+  // The effects are not seen here, but rather in `atom-application.js`, where
+  // calls to `app.focus` will actually work instead of having no effect.
   if (process.platform === 'win32') {
     app.requestSingleInstanceLock();
+    // Add an explicit no-op listener here to ensure that this channel isn't
+    // used for communication — we already have a way for the second instance
+    // to communicate with the first.
     app.on('second-instance', () => {});
   }
 


### PR DESCRIPTION
Two changes:

* On macOS, this ensures the app is brought to the foreground whenever a specific window is opened or resurfaced.
* On other platforms, this ensures we don't try to activate the frontmost window too early, thereby promoting a window that _isn't_ the one we're in the process of opening.

This is related to #1218; I suppose we'll find out if it solves the thing once CI produces some binaries.