### PR TITLE
[settings-view] Don't try to attach a listener…

### DIFF
--- a/packages/settings-view/lib/badge-view.js
+++ b/packages/settings-view/lib/badge-view.js
@@ -21,10 +21,12 @@ export default class BadgeView {
       shell.openExternal(anchor.href)
     }
 
-    this.refs.badgeLink.addEventListener('click', clickHandler)
-    this.disposables.add(new Disposable(() => {
-      this.refs.badgeLink.removeEventListener('click', clickHandler)
-    }))
+    if (this.hasLink()) {
+      this.refs.badgeLink.addEventListener('click', clickHandler)
+      this.disposables.add(new Disposable(() => {
+        this.refs.badgeLink.removeEventListener('click', clickHandler)
+      }))
+    }
   }
 
   destroy () {


### PR DESCRIPTION
…if the ref doesn't exist.

This one is my fault and I regret it.

### Impact

PR #1481 fixed issue #1480 by introducing an even larger bug. In improving how we behave when a package card has a badge with a link (e.g., one that links to the [admin actions](https://github.com/pulsar-edit/package-backend/blob/main/docs/reference/Admin_Actions.md) document), I broke the rendering of a greater number of packages that have no badge link at all.

The fix in #1481 assumes the presence of a node that may not exist.

### Testing

I'll happily update this PR with specs later on. But I did want to get the fix up ASAP so we can figure out next steps. (We've already landed a couple PRs that were envisioned for 1.132.0, so should we live with this until then? Or should we put out a 1.131.3?)

On the stable release: 

* Go to Settings -> Install
* Search for a package that was not around in the Atom days. (Try `language-proto-redux`, since that's one I just created today.)
* You should see an exception complaining about `addEventListener`, and the search result will fail to render.

On this PR, the same action should succeed.