### PR TITLE
status-bar: Add v2 service API with config-driven tile management

### DIFF
--- a/packages/grammar-selector/spec/grammar-selector-spec.js
+++ b/packages/grammar-selector/spec/grammar-selector-spec.js
@@ -116,8 +116,8 @@ describe('GrammarSelector', () => {
 
     beforeEach(async () => {
       statusBar = document.querySelector('status-bar');
-      [grammarTile] = statusBar.getLeftTiles().slice(-1);
-      grammarStatus = grammarTile.getItem();
+      grammarTile = statusBar.getLeftTiles().find(t => t.getItem().tagName === 'GRAMMAR-SELECTOR-STATUS');
+      grammarStatus = grammarTile?.getItem();
 
       // Wait for status bar service hook to fire
       while (!grammarStatus || !grammarStatus.textContent) {

--- a/packages/status-bar/README.md
+++ b/packages/status-bar/README.md
@@ -12,9 +12,82 @@ The status bar package accepts the following configuration values:
 
 * `status-bar.selectionCountFormat` &mdash; A string that describes the format to use for the selection count status bar tile. It defaults to `(%L, %C)`. In the format string, `%L` represents the 1-based line count and `%C` represents the 1-based character count.
 
+### Tile Priorities
+
+Each built-in tile has a configurable priority. The sign determines which side of the status bar the tile appears on, and the absolute value determines its position. Set to `0` to hide a tile.
+
+* `status-bar.launchModePriority` &mdash; Default: `-1`
+* `status-bar.fileInfoPriority` &mdash; Default: `-11`
+* `status-bar.cursorPositionPriority` &mdash; Default: `-12`
+* `status-bar.selectionCountPriority` &mdash; Default: `-13`
+* `status-bar.gitInfoPriority` &mdash; Default: `10`
+
+Priority layout:
+
+```
+LEFT EDGE ←  -1 -2 -10 -100  [0=hidden]  100 10 5 2 1  → RIGHT EDGE
+```
+
+Negative values place tiles on the left, positive on the right. Smaller absolute values are closer to the edge, larger values are closer to the center.
+
 ## API
 
-This package provides a service that you can use in other Pulsar packages. To use it, include `status-bar` in the `consumedServices` section of your `package.json`:
+This package provides a service that you can use in other Pulsar packages.
+
+### v2 API (recommended)
+
+The v2 API uses a single `addTile` method where the priority sign determines the side.
+
+```json
+{
+  "name": "my-package",
+  "consumedServices": {
+    "status-bar": {
+      "versions": {
+        "^2.0.0": "consumeStatusBar"
+      }
+    }
+  }
+}
+```
+
+```js
+module.exports = {
+  activate() { /* ... */ },
+
+  consumeStatusBar(statusBar) {
+    // Negative priority = left side, positive = right side, 0 = hidden
+    this.tile = statusBar.addTile({ item: myElement, priority: -50 });
+
+    // Or bind to a config key for reactive priority changes:
+    this.tile = statusBar.addTile({ item: myElement, priorityConfig: 'my-package.tilePriority' });
+  },
+
+  deactivate() {
+    this.tile?.destroy();
+    this.tile = null;
+  }
+};
+```
+
+The v2 `status-bar` API has two methods:
+
+  * `addTile({ item, priority })` &mdash; Add a tile to the status bar. Negative priority places it on the left, positive on the right. Priority `0` hides the tile. Optionally pass `priorityConfig` instead of `priority` to bind the tile's priority to a config key (the tile will automatically update when the config changes).
+  * `getTiles()` &mdash; Retrieve all tiles in visual order (left to right).
+
+The `item` parameter can be a DOM element or a model object for which a view provider has been registered in the view registry.
+
+`addTile` returns a `Tile` object with the following methods:
+
+  * `getPriority()` &mdash; Retrieve the tile's current priority. If using `priorityConfig`, reads the current value from config.
+  * `getItem()` &mdash; Retrieve the tile's item.
+  * `isVisible()` &mdash; Returns `true` if the tile is visible (priority is not `0`).
+  * `setPriority(newPriority)` &mdash; Change the tile's priority. The tile will be repositioned (or hidden if `0`). Can move tiles between left and right sides by changing the sign.
+  * `destroy()` &mdash; Remove the tile from the status bar and clean up any config observers.
+
+### v1 API (legacy)
+
+The v1 API uses separate methods for left and right tiles. Priority `0` is a valid position in v1.
 
 ```json
 {
@@ -29,33 +102,22 @@ This package provides a service that you can use in other Pulsar packages. To us
 }
 ```
 
-Then, in your package's main module, call methods on the service:
+```js
+module.exports = {
+  activate() { /* ... */ },
 
-```coffee
-module.exports =
-  activate: -> # ...
+  consumeStatusBar(statusBar) {
+    this.tile = statusBar.addLeftTile({ item: myElement, priority: 100 });
+  },
 
-  consumeStatusBar: (statusBar) ->
-    @statusBarTile = statusBar.addLeftTile(item: myElement, priority: 100)
-
-  deactivate: ->
-    # ...
-    @statusBarTile?.destroy()
-    @statusBarTile = null
+  deactivate() {
+    this.tile?.destroy();
+    this.tile = null;
+  }
+};
 ```
 
-The `status-bar` API has four methods:
-
-  * `addLeftTile({ item, priority })` - Add a tile to the left side of the status bar. Lower priority tiles are placed further to the left.
-  * `addRightTile({ item, priority })` - Add a tile to the right side of the status bar. Lower priority tiles are placed further to the right.
-
-The `item` parameter to these methods can be a DOM element, a [jQuery object](http://jquery.com), or a model object for which a view provider has been registered in the [the view registry](https://atom.io/docs/api/latest/ViewRegistry).
-
-  * `getLeftTiles()` - Retrieve all of the tiles on the left side of the status bar.
-  * `getRightTiles()` - Retrieve all of the tiles on the right side of the status bar
-
-All of these methods return `Tile` objects, which have the following methods:
-
-  * `getPriority()` - Retrieve the priority that was assigned to the `Tile` when it was created.
-  * `getItem()` - Retrieve the `Tile`'s item.
-  * `destroy()` - Remove the `Tile` from the status bar.
+  * `addLeftTile({ item, priority })` &mdash; Add a tile to the left side. Lower priority tiles are placed further to the left.
+  * `addRightTile({ item, priority })` &mdash; Add a tile to the right side. Lower priority tiles are placed further to the right.
+  * `getLeftTiles()` &mdash; Retrieve all tiles on the left side.
+  * `getRightTiles()` &mdash; Retrieve all tiles on the right side.

--- a/packages/status-bar/lib/cursor-position-view.js
+++ b/packages/status-bar/lib/cursor-position-view.js
@@ -13,7 +13,7 @@ class CursorPositionView {
 
     this.formatString = atom.config.get('status-bar.cursorPositionFormat') ?? '%L:%C';
 
-    this.activeItemSubscription = atom.workspace.onDidChangeActiveTextEditor(activeEditor => this.subscribeToActiveTextEditor());
+    this.activeItemSubscription = atom.workspace.onDidChangeActiveTextEditor(() => this.subscribeToActiveTextEditor());
 
     this.subscribeToConfig();
     this.subscribeToActiveTextEditor();

--- a/packages/status-bar/lib/file-info-view.js
+++ b/packages/status-bar/lib/file-info-view.js
@@ -1,5 +1,4 @@
 const { Disposable } = require('atom');
-const url = require('url');
 const fs = require('fs-plus');
 
 module.exports =
@@ -9,7 +8,7 @@ class FileInfoView {
     this.element.classList.add('file-info', 'inline-block');
 
     this.currentPath = document.createElement('a');
-    this.currentPath.classList.add('current-path');
+    this.currentPath.classList.add('current-path', 'inline-block');
     this.element.appendChild(this.currentPath);
     this.element.currentPath = this.currentPath;
 
@@ -77,9 +76,7 @@ class FileInfoView {
 
     // An item path could be a url, we only want to copy the `path` part
     if (path?.indexOf('://') > 0) {
-      ({
-        path
-      } = url.parse(path));
+      path = new URL(path).pathname;
     }
     return path;
   }

--- a/packages/status-bar/lib/file-info-view.js
+++ b/packages/status-bar/lib/file-info-view.js
@@ -1,4 +1,5 @@
 const { Disposable } = require('atom');
+const url = require('url');
 const fs = require('fs-plus');
 
 module.exports =
@@ -76,7 +77,7 @@ class FileInfoView {
 
     // An item path could be a url, we only want to copy the `path` part
     if (path?.indexOf('://') > 0) {
-      path = new URL(path).pathname;
+      path = url.parse(path).path;
     }
     return path;
   }

--- a/packages/status-bar/lib/git-view.js
+++ b/packages/status-bar/lib/git-view.js
@@ -1,5 +1,5 @@
 const _ = require("underscore-plus");
-const { CompositeDisposable, GitRepositoryAsync } = require("atom");
+const { CompositeDisposable } = require("atom");
 
 module.exports =
 class GitView {
@@ -80,7 +80,7 @@ class GitView {
     for (let repo of atom.project.getRepositories()) {
       if (repo != null) {
         this.repositorySubscriptions.add(
-          repo.onDidChangeStatus(({ path, status }) => {
+          repo.onDidChangeStatus(({ path }) => {
             if (path === this.getActiveItemPath()) {
               this.update();
             }

--- a/packages/status-bar/lib/launch-mode-view.js
+++ b/packages/status-bar/lib/launch-mode-view.js
@@ -1,4 +1,3 @@
-
 module.exports =
 class LaunchModeView {
   constructor(param) {

--- a/packages/status-bar/lib/main.js
+++ b/packages/status-bar/lib/main.js
@@ -37,38 +37,66 @@ module.exports = {
 
     const { safeMode, devMode } = atom.getLoadSettings();
     if (safeMode || devMode) {
-      const launchModeView = new LaunchModeView({safeMode, devMode});
-      this.statusBar.addLeftTile({item: launchModeView.element, priority: -1});
+      this.launchModeView = new LaunchModeView({safeMode, devMode});
+      this.launchModeTile = this.statusBar.addTile({
+        item: this.launchModeView.element,
+        priorityConfig: 'status-bar.launchModePriority'
+      });
     }
 
     this.fileInfo = new FileInfoView();
-    this.statusBar.addLeftTile({item: this.fileInfo.element, priority: 0});
+    this.fileInfoTile = this.statusBar.addTile({
+      item: this.fileInfo.element,
+      priorityConfig: 'status-bar.fileInfoPriority'
+    });
 
     this.cursorPosition = new CursorPositionView();
-    this.statusBar.addLeftTile({item: this.cursorPosition.element, priority: 1});
+    this.cursorPositionTile = this.statusBar.addTile({
+      item: this.cursorPosition.element,
+      priorityConfig: 'status-bar.cursorPositionPriority'
+    });
 
     this.selectionCount = new SelectionCountView();
-    this.statusBar.addLeftTile({item: this.selectionCount.element, priority: 2});
+    this.selectionCountTile = this.statusBar.addTile({
+      item: this.selectionCount.element,
+      priorityConfig: 'status-bar.selectionCountPriority'
+    });
 
     this.gitInfo = new GitView();
-    this.gitInfoTile = this.statusBar.addRightTile({item: this.gitInfo.element, priority: 0});
+    this.gitInfoTile = this.statusBar.addTile({
+      item: this.gitInfo.element,
+      priorityConfig: 'status-bar.gitInfoPriority'
+    });
   },
 
   deactivate() {
     this.statusBarVisibilitySubscription?.dispose();
     this.statusBarVisibilitySubscription = null;
 
+    this.gitInfoTile?.destroy();
+    this.gitInfoTile = null;
     this.gitInfo?.destroy();
     this.gitInfo = null;
 
+    this.fileInfoTile?.destroy();
+    this.fileInfoTile = null;
     this.fileInfo?.destroy();
     this.fileInfo = null;
 
+    this.cursorPositionTile?.destroy();
+    this.cursorPositionTile = null;
     this.cursorPosition?.destroy();
     this.cursorPosition = null;
 
+    this.selectionCountTile?.destroy();
+    this.selectionCountTile = null;
     this.selectionCount?.destroy();
     this.selectionCount = null;
+
+    this.launchModeTile?.destroy();
+    this.launchModeTile = null;
+    this.launchModeView?.destroy?.();
+    this.launchModeView = null;
 
     this.statusBarPanel?.destroy();
     this.statusBarPanel = null;
@@ -93,13 +121,20 @@ module.exports = {
     }
   },
 
+  provideStatusBarV2() {
+    return {
+      addTile: this.statusBar.addTile.bind(this.statusBar),
+      getTiles: this.statusBar.getTiles.bind(this.statusBar)
+    };
+  },
+
   provideStatusBar() {
     return {
       addLeftTile: this.statusBar.addLeftTile.bind(this.statusBar),
       addRightTile: this.statusBar.addRightTile.bind(this.statusBar),
       getLeftTiles: this.statusBar.getLeftTiles.bind(this.statusBar),
       getRightTiles: this.statusBar.getRightTiles.bind(this.statusBar),
-      disableGitInfoTile: this.gitInfoTile.destroy.bind(this.gitInfoTile)
+      disableGitInfoTile: () => this.gitInfoTile?.destroy()
     };
   },
 

--- a/packages/status-bar/lib/status-bar-view.js
+++ b/packages/status-bar/lib/status-bar-view.js
@@ -1,4 +1,3 @@
-const { Disposable } = require('atom');
 const Tile = require('./tile');
 
 module.exports =
@@ -48,45 +47,63 @@ class StatusBarView {
     this.element.remove();
   }
 
-  addLeftTile(options) {
-    let index;
-    const newItem = options.item;
-    const newPriority = options?.priority != null ? options?.priority : this.leftTiles[this.leftTiles.length - 1].priority + 1;
-    let nextItem = null;
-    for (index = 0; index < this.leftTiles.length; index++) {
-      const {priority, item} = this.leftTiles[index];
-      if (priority > newPriority) {
-        nextItem = item;
-        break;
-      }
-    }
-
-    const newTile = new Tile(newItem, newPriority, this.leftTiles);
-    this.leftTiles.splice(index, 0, newTile);
-    const newElement = atom.views.getView(newItem);
-    const nextElement = atom.views.getView(nextItem);
+  insertLeftTile(tile) {
+    let index = this.leftTiles.findIndex(t => t.priority < tile.priority);
+    if (index === -1) index = this.leftTiles.length;
+    this.leftTiles.splice(index, 0, tile);
+    const newElement = atom.views.getView(tile.item);
+    const nextElement = this.leftPanel.children[index];
     this.leftPanel.insertBefore(newElement, nextElement);
+  }
+
+  insertRightTile(tile) {
+    let index = this.rightTiles.findIndex(t => t.priority < tile.priority);
+    if (index === -1) index = this.rightTiles.length;
+    this.rightTiles.splice(index, 0, tile);
+    const newElement = atom.views.getView(tile.item);
+    const nextElement = this.rightPanel.children[index];
+    this.rightPanel.insertBefore(newElement, nextElement);
+  }
+
+  addLeftTile(options) {
+    const newItem = options.item;
+    const newPriority = options?.priority != null ? -options.priority : this.leftTiles[this.leftTiles.length - 1].priority - 1;
+    const newTile = new Tile(newItem, newPriority, this.leftTiles);
+    this.insertLeftTile(newTile);
     return newTile;
   }
 
   addRightTile(options) {
-    let index;
     const newItem = options.item;
     const newPriority = options?.priority != null ? options?.priority : this.rightTiles[0].priority + 1;
-    let nextItem = null;
-    for (index = 0; index < this.rightTiles.length; index++) {
-      const {priority, item} = this.rightTiles[index];
-      if (priority < newPriority) {
-        nextItem = item;
-        break;
-      }
-    }
-
     const newTile = new Tile(newItem, newPriority, this.rightTiles);
-    this.rightTiles.splice(index, 0, newTile);
-    const newElement = atom.views.getView(newItem);
-    const nextElement = atom.views.getView(nextItem);
-    this.rightPanel.insertBefore(newElement, nextElement);
+    this.insertRightTile(newTile);
+    return newTile;
+  }
+
+  insertTileV2(tile) {
+    if (tile.priority === 0) return;
+
+    const isLeft = tile.priority < 0;
+    const tiles = isLeft ? this.leftTiles : this.rightTiles;
+    const panel = isLeft ? this.leftPanel : this.rightPanel;
+
+    tile.collection = tiles;
+
+    let index = tiles.findIndex(t => t.priority < tile.priority);
+    if (index === -1) index = tiles.length;
+    tiles.splice(index, 0, tile);
+    panel.insertBefore(atom.views.getView(tile.item), panel.children[index]);
+  }
+
+  addTile(options) {
+    const reinsert = (tile) => this.insertTileV2(tile);
+    const newTile = new Tile(options.item, options?.priority ?? 0, this.leftTiles, {
+      hideOnZero: true,
+      reinsertFn: reinsert,
+      priorityConfig: options?.priorityConfig
+    });
+    this.insertTileV2(newTile);
     return newTile;
   }
 
@@ -96,6 +113,10 @@ class StatusBarView {
 
   getRightTiles() {
     return this.rightTiles;
+  }
+
+  getTiles() {
+    return [...this.leftTiles, ...this.rightTiles];
   }
 
   getActiveBuffer() {

--- a/packages/status-bar/lib/tile.js
+++ b/packages/status-bar/lib/tile.js
@@ -18,6 +18,8 @@ class Tile {
       this.priority = priority;
     }
 
+    this.hidden = false;
+
     if (this.hideOnZero && this.priority === 0) {
       atom.views.getView(this.item).style.display = 'none';
     }
@@ -35,8 +37,20 @@ class Tile {
   }
 
   isVisible() {
-    if (!this.hideOnZero) return true;
-    return this.priority !== 0;
+    if (this.hidden) return false;
+    if (this.hideOnZero && this.priority === 0) return false;
+    return true;
+  }
+
+  show() {
+    this.hidden = false;
+    if (this.hideOnZero && this.priority === 0) return;
+    atom.views.getView(this.item).style.display = '';
+  }
+
+  hide() {
+    this.hidden = true;
+    atom.views.getView(this.item).style.display = 'none';
   }
 
   setPriority(newPriority) {
@@ -51,7 +65,7 @@ class Tile {
 
     this.priority = newPriority;
 
-    if (this.hideOnZero && newPriority === 0) {
+    if (this.hidden || (this.hideOnZero && newPriority === 0)) {
       element.style.display = 'none';
     } else {
       element.style.display = '';

--- a/packages/status-bar/lib/tile.js
+++ b/packages/status-bar/lib/tile.js
@@ -1,10 +1,26 @@
-
 module.exports =
 class Tile {
-  constructor(item, priority, collection) {
+  constructor(item, priority, collection, { hideOnZero = false, reinsertFn = null, priorityConfig = null } = {}) {
     this.item = item;
-    this.priority = priority;
     this.collection = collection;
+    this.hideOnZero = hideOnZero;
+    this.reinsert = reinsertFn;
+    this.configDisposable = null;
+
+    this.priorityConfig = priorityConfig;
+
+    if (priorityConfig) {
+      this.priority = atom.config.get(priorityConfig);
+      this.configDisposable = atom.config.onDidChange(priorityConfig, ({newValue}) => {
+        this.setPriority(newValue);
+      });
+    } else {
+      this.priority = priority;
+    }
+
+    if (this.hideOnZero && this.priority === 0) {
+      atom.views.getView(this.item).style.display = 'none';
+    }
   }
 
   getItem() {
@@ -12,11 +28,43 @@ class Tile {
   }
 
   getPriority() {
+    if (this.priorityConfig) {
+      return atom.config.get(this.priorityConfig);
+    }
     return this.priority;
   }
 
+  isVisible() {
+    if (!this.hideOnZero) return true;
+    return this.priority !== 0;
+  }
+
+  setPriority(newPriority) {
+    if (!this.reinsert) return;
+    if (newPriority === this.priority) return;
+
+    const element = atom.views.getView(this.item);
+
+    const idx = this.collection.indexOf(this);
+    if (idx !== -1) this.collection.splice(idx, 1);
+    element.remove();
+
+    this.priority = newPriority;
+
+    if (this.hideOnZero && newPriority === 0) {
+      element.style.display = 'none';
+    } else {
+      element.style.display = '';
+    }
+
+    this.reinsert(this);
+  }
+
   destroy() {
-    this.collection.splice(this.collection.indexOf(this), 1);
+    this.configDisposable?.dispose();
+    this.configDisposable = null;
+    const idx = this.collection.indexOf(this);
+    if (idx !== -1) this.collection.splice(idx, 1);
     atom.views.getView(this.item).remove();
   }
 }

--- a/packages/status-bar/package.json
+++ b/packages/status-bar/package.json
@@ -17,6 +17,7 @@
     "status-bar": {
       "description": "A container for indicators at the bottom of the workspace",
       "versions": {
+        "2.0.0": "provideStatusBarV2",
         "1.1.0": "provideStatusBar",
         "0.58.0": "legacyProvideStatusBar"
       }
@@ -46,6 +47,36 @@
       "type": "string",
       "default": "(%L, %C)",
       "description": "Format for the selection count status bar element, where %L is the line count and %C is the character count"
+    },
+    "launchModePriority": {
+      "order": 10,
+      "type": "integer",
+      "default": -1,
+      "description": "Priority of the launch mode tile. Negative = left, positive = right, 0 = hidden."
+    },
+    "fileInfoPriority": {
+      "order": 11,
+      "type": "integer",
+      "default": -11,
+      "description": "Priority of the file info tile. Negative = left, positive = right, 0 = hidden."
+    },
+    "cursorPositionPriority": {
+      "order": 12,
+      "type": "integer",
+      "default": -12,
+      "description": "Priority of the cursor position tile. Negative = left, positive = right, 0 = hidden."
+    },
+    "selectionCountPriority": {
+      "order": 13,
+      "type": "integer",
+      "default": -13,
+      "description": "Priority of the selection count tile. Negative = left, positive = right, 0 = hidden."
+    },
+    "gitInfoPriority": {
+      "order": 14,
+      "type": "integer",
+      "default": 10,
+      "description": "Priority of the git info tile. Negative = left, positive = right, 0 = hidden."
     }
   }
 }

--- a/packages/status-bar/spec/status-bar-spec.js
+++ b/packages/status-bar/spec/status-bar-spec.js
@@ -91,7 +91,7 @@ describe("Status Bar package", function() {
     });
   });
 
-  describe("the 'status-bar' service", function() {
+  describe("the 'status-bar' v1 service", function() {
     it("allows tiles to be added, removed, and retrieved", function() {
       let dummyView = document.createElement("div");
       let tile = statusBarService.addLeftTile({item: dummyView});
@@ -111,11 +111,72 @@ describe("Status Bar package", function() {
     });
 
     it("allows the git info tile to be disabled", function() {
-      const getGitInfoTile = () => statusBar.getRightTiles().find(tile => tile.item.matches('.git-view'));
+      const getGitInfoTile = () => statusBar.getRightTiles().find(tile => tile.item.matches?.('.git-view'));
 
       expect(getGitInfoTile()).not.toBeUndefined();
       statusBarService.disableGitInfoTile();
       expect(getGitInfoTile()).toBeUndefined();
+    });
+  });
+
+  describe("the 'status-bar' v2 service", function() {
+    let statusBarV2Service = null;
+
+    beforeEach(function() {
+      statusBarV2Service = mainModule.provideStatusBarV2();
+    });
+
+    it("allows tiles to be added, removed, and retrieved", function() {
+      const dummyView = document.createElement("div");
+      const tile = statusBarV2Service.addTile({item: dummyView, priority: -10});
+      expect(statusBar).toContain(dummyView);
+      expect(statusBarV2Service.getTiles()).toContain(tile);
+      tile.destroy();
+      expect(statusBar).not.toContain(dummyView);
+      expect(statusBarV2Service.getTiles()).not.toContain(tile);
+    });
+
+    it("places tiles on the left for negative priority and right for positive", function() {
+      const leftView = document.createElement("div");
+      const rightView = document.createElement("div");
+
+      const leftTile = statusBarV2Service.addTile({item: leftView, priority: -10});
+      const rightTile = statusBarV2Service.addTile({item: rightView, priority: 10});
+
+      expect(statusBar.leftPanel).toContain(leftView);
+      expect(statusBar.rightPanel).toContain(rightView);
+    });
+
+    it("hides tiles with priority 0", function() {
+      const dummyView = document.createElement("div");
+      const tile = statusBarV2Service.addTile({item: dummyView, priority: 0});
+
+      expect(tile.isVisible()).toBe(false);
+      expect(dummyView.style.display).toBe('none');
+    });
+
+    it("supports setPriority to reposition tiles", function() {
+      const dummyView = document.createElement("div");
+      const tile = statusBarV2Service.addTile({item: dummyView, priority: -10});
+
+      expect(statusBar.leftPanel).toContain(dummyView);
+      tile.setPriority(10);
+      expect(statusBar.rightPanel).toContain(dummyView);
+      expect(tile.getPriority()).toBe(10);
+    });
+
+    it("supports setPriority to hide and show tiles", function() {
+      const dummyView = document.createElement("div");
+      const tile = statusBarV2Service.addTile({item: dummyView, priority: -10});
+
+      expect(tile.isVisible()).toBe(true);
+      tile.setPriority(0);
+      expect(tile.isVisible()).toBe(false);
+      expect(dummyView.style.display).toBe('none');
+
+      tile.setPriority(10);
+      expect(tile.isVisible()).toBe(true);
+      expect(dummyView.style.display).toBe('');
     });
   });
 });

--- a/packages/status-bar/spec/status-bar-view-spec.js
+++ b/packages/status-bar/spec/status-bar-view-spec.js
@@ -41,7 +41,7 @@ describe("StatusBarView", function() {
       expect(leftPanel.children[2].model).toBe(testItem2);
 
       expect(statusBarView.getLeftTiles()).toEqual([tile1, tile3, tile2]);
-      expect(tile1.getPriority()).toBe(10);
+      expect(tile1.getPriority()).toBe(-10);
       expect(tile1.getItem()).toBe(testItem1);
     });
 
@@ -112,5 +112,138 @@ describe("StatusBarView", function() {
       expect(rightPanel.children[0].model).toBe(testItem2);
       expect(rightPanel.children[1].model).toBe(testItem1);
     }));
+  });
+
+  describe("::addTile({item, priority})", function() {
+    it("places negative priority items on the left panel", function() {
+      const testItem1 = new TestItem(1);
+      const testItem2 = new TestItem(2);
+
+      const tile1 = statusBarView.addTile({item: testItem1, priority: -10});
+      const tile2 = statusBarView.addTile({item: testItem2, priority: -20});
+
+      expect(statusBarView.leftPanel.children[0].model).toBe(testItem1);
+      expect(statusBarView.leftPanel.children[1].model).toBe(testItem2);
+      expect(statusBarView.getLeftTiles()).toEqual([tile1, tile2]);
+    });
+
+    it("places positive priority items on the right panel", function() {
+      const testItem1 = new TestItem(1);
+      const testItem2 = new TestItem(2);
+
+      const tile1 = statusBarView.addTile({item: testItem1, priority: 20});
+      const tile2 = statusBarView.addTile({item: testItem2, priority: 10});
+
+      expect(statusBarView.rightPanel.children[0].model).toBe(testItem1);
+      expect(statusBarView.rightPanel.children[1].model).toBe(testItem2);
+      expect(statusBarView.getRightTiles()).toEqual([tile1, tile2]);
+    });
+
+    it("hides the item when priority is 0", function() {
+      const testItem = new TestItem(1);
+      const tile = statusBarView.addTile({item: testItem, priority: 0});
+
+      const element = atom.views.getView(testItem);
+      expect(element.style.display).toBe('none');
+      expect(tile.isVisible()).toBe(false);
+      expect(statusBarView.leftPanel.children.length).toBe(0);
+      expect(statusBarView.rightPanel.children.length).toBe(0);
+    });
+
+    it("allows the view to be removed", function() {
+      const testItem = new TestItem(1);
+      const tile = statusBarView.addTile({item: testItem, priority: -10});
+      tile.destroy();
+      expect(statusBarView.leftPanel.children.length).toBe(0);
+      expect(statusBarView.getLeftTiles()).not.toContain(tile);
+    });
+
+    describe("::setPriority()", function() {
+      it("repositions the tile when priority changes", function() {
+        const testItem1 = new TestItem(1);
+        const testItem2 = new TestItem(2);
+
+        const tile1 = statusBarView.addTile({item: testItem1, priority: -10});
+        const tile2 = statusBarView.addTile({item: testItem2, priority: -20});
+
+        expect(statusBarView.leftPanel.children[0].model).toBe(testItem1);
+        expect(statusBarView.leftPanel.children[1].model).toBe(testItem2);
+
+        tile2.setPriority(-5);
+        expect(statusBarView.leftPanel.children[0].model).toBe(testItem2);
+        expect(statusBarView.leftPanel.children[1].model).toBe(testItem1);
+      });
+
+      it("hides the tile when priority changes to 0", function() {
+        const testItem = new TestItem(1);
+        const tile = statusBarView.addTile({item: testItem, priority: -10});
+
+        expect(tile.isVisible()).toBe(true);
+        tile.setPriority(0);
+        expect(tile.isVisible()).toBe(false);
+        expect(atom.views.getView(testItem).style.display).toBe('none');
+      });
+
+      it("shows and repositions the tile when priority changes from 0", function() {
+        const testItem = new TestItem(1);
+        const tile = statusBarView.addTile({item: testItem, priority: 0});
+
+        expect(tile.isVisible()).toBe(false);
+        tile.setPriority(10);
+        expect(tile.isVisible()).toBe(true);
+        expect(atom.views.getView(testItem).style.display).toBe('');
+        expect(statusBarView.rightPanel.children[0].model).toBe(testItem);
+      });
+
+      it("can move a tile from left to right panel", function() {
+        const testItem = new TestItem(1);
+        const tile = statusBarView.addTile({item: testItem, priority: -10});
+
+        expect(statusBarView.leftPanel.children.length).toBe(1);
+        expect(statusBarView.rightPanel.children.length).toBe(0);
+
+        tile.setPriority(10);
+        expect(statusBarView.leftPanel.children.length).toBe(0);
+        expect(statusBarView.rightPanel.children.length).toBe(1);
+        expect(statusBarView.rightPanel.children[0].model).toBe(testItem);
+      });
+    });
+
+    describe("::isVisible()", function() {
+      it("returns true for non-zero priority", function() {
+        const tile = statusBarView.addTile({item: new TestItem(1), priority: -10});
+        expect(tile.isVisible()).toBe(true);
+      });
+
+      it("returns false for zero priority", function() {
+        const tile = statusBarView.addTile({item: new TestItem(1), priority: 0});
+        expect(tile.isVisible()).toBe(false);
+      });
+    });
+
+    describe("::getPriority()", function() {
+      it("returns the current priority", function() {
+        const tile = statusBarView.addTile({item: new TestItem(1), priority: -10});
+        expect(tile.getPriority()).toBe(-10);
+      });
+
+      it("returns the updated priority after setPriority", function() {
+        const tile = statusBarView.addTile({item: new TestItem(1), priority: -10});
+        tile.setPriority(20);
+        expect(tile.getPriority()).toBe(20);
+      });
+    });
+  });
+
+  describe("::getTiles()", function() {
+    it("returns all tiles from both panels", function() {
+      const leftTile = statusBarView.addTile({item: new TestItem(1), priority: -10});
+      const rightTile = statusBarView.addTile({item: new TestItem(2), priority: 10});
+
+      const allTiles = statusBarView.getTiles();
+      expect(allTiles).toContain(leftTile);
+      expect(allTiles).toContain(rightTile);
+      expect(allTiles.length).toBe(2);
+    });
   });
 });

--- a/packages/status-bar/styles/status-bar.less
+++ b/packages/status-bar/styles/status-bar.less
@@ -99,7 +99,12 @@ status-bar {
   .hide,
   .current-path:empty,
   .cursor-position:empty,
-  .selection-count:empty {
+  .selection-count:empty,
+  status-bar-launch-mode:empty,
+  status-bar-file:has(.current-path:empty),
+  status-bar-cursor:empty,
+  status-bar-selection:empty,
+  status-bar-git:empty {
     display: none;
   }
 


### PR DESCRIPTION
**tl;d**r: Use single config to manage visibility & position of status-bar-item in status-bar.

The new v2 status-bar service API allows packages to manage their tiles entirely through a single config key. By passing `priorityConfig` to `addTile`, tiles automatically reposition or hide themselves when the user changes the config value. The priority sign determines which side of the status bar the tile appears on (negative = left, positive = right), and setting priority to 0 hides the tile without destroying it.

All built-in tiles (file info, cursor position, selection count, git info, launch mode) now use this mechanism, giving users full control over tile placement and visibility from the settings panel.

The v1 API remains fully intact. Existing community packages using `addLeftTile`/`addRightTile` continue to work unchanged, because v1 and v2 tiles coexist in the same status bar.

The Tile class gains `setPriority()`, `isVisible()`, and `getPriority()` methods along with optional `priorityConfig` support that observes an Atom config key and reactively calls `setPriority()` on changes. `insertTileV2` in StatusBarView handles signed priority routing to the correct panel with consistent descending sort order. The v1 `addLeftTile` now negates priorities internally so both APIs share the same sorted arrays.

The package.json declares service version `2.0.0` pointing to `provideStatusBarV2()` which exposes only `addTile` and `getTiles`. Config schema entries for each built-in tile priority let users reorder, swap sides, or hide any tile.

CSS `:empty` and `:has()` selectors hide built-in status bar elements that have no content, preventing blank space from appearing when no editor is active. The deprecated `url.parse` call in file-info-view was replaced with `new URL().pathname`.
