### PR TITLE
[find-and-replace] Fix project search regression…

### DIFF
--- a/packages/find-and-replace/lib/project/results-model.js
+++ b/packages/find-and-replace/lib/project/results-model.js
@@ -351,7 +351,6 @@ module.exports = class ResultsModel {
   // manual fashion, so we need this check to to be able to filter those
   // buffers properly.
   shouldAddResult(filePath) {
-    // return true;
     let { pathsPattern } = this.findOptions
     if (!pathsPattern) return true
 

--- a/packages/find-and-replace/lib/project/results-model.js
+++ b/packages/find-and-replace/lib/project/results-model.js
@@ -401,7 +401,11 @@ module.exports = class ResultsModel {
   }
 
   pathsArrayFromPathsPattern(pathsPattern) {
-    return pathsPattern.trim().split(',').map((inputPath) => inputPath.trim())
+    return pathsPattern
+      .trim()
+      .split(',')
+      .filter(p => !!p)
+      .map((inputPath) => inputPath.trim())
   }
 }
 

--- a/packages/find-and-replace/spec/results-model-spec.js
+++ b/packages/find-and-replace/spec/results-model-spec.js
@@ -122,6 +122,22 @@ describe("ResultsModel", () => {
         expect(result).not.toBeUndefined();
       });
 
+      it('should correctly show results when the path pattern points to a directory', async () => {
+        await resultsModel.search('quicksort =', 'sub', '')
+        let result = resultsModel.getResult(
+          path.resolve(__dirname, 'fixtures', 'another-project-root', 'sub', 'sample.js')
+        );
+        expect(result).not.toBeUndefined();
+      })
+
+      it('should correctly show results when the path pattern points to a directory (with trailing slash)', async () => {
+        await resultsModel.search('quicksort =', 'sub/', '')
+        let result = resultsModel.getResult(
+          path.resolve(__dirname, 'fixtures', 'another-project-root', 'sub', 'sample.js')
+        );
+        expect(result).not.toBeUndefined();
+      })
+
       it("should correctly show results when the path pattern points to a file", async () => {
         await resultsModel.search('quicksort =', 'sub/sample.js', '')
         let result = resultsModel.getResult(

--- a/packages/find-and-replace/spec/results-model-spec.js
+++ b/packages/find-and-replace/spec/results-model-spec.js
@@ -156,6 +156,33 @@ describe("ResultsModel", () => {
 
     })
 
+    describe("when a file is modified before the search starts", () => {
+      let editor, modifiedPath;
+      beforeEach(async () => {
+        atom.project.setPaths([
+          path.join(__dirname, "fixtures/project"),
+        ]);
+        resultsModel = new ResultsModel(new FindOptions({}));
+        modifiedPath = path.resolve(__dirname, "fixtures", "project", "sample.js");
+        editor = await atom.workspace.open(modifiedPath);
+        editor.setCursorBufferPosition([0, 0]);
+        editor.insertText(' ');
+        expect(editor.isModified()).toBe(true);
+      })
+
+      afterEach(() => {
+        if (editor.isModified()) editor.undo();
+      })
+
+      it('still appears in search results', async () => {
+        jasmine.useRealClock();
+        await resultsModel.search('var quicksort =', '', '');
+        expect(
+          resultsModel.getResult(modifiedPath)
+        ).not.toBe(undefined);
+      })
+    })
+
     describe("when a file is modified after the search finishes", () => {
       let editor, modifiedPath;
       let modifyEditor = () => {};

--- a/src/workspace.js
+++ b/src/workspace.js
@@ -42,6 +42,17 @@ function filePathMatchesGlob(filePath, matcher) {
   return matcher.negate ? true : false;
 }
 
+// Trim trailing path separators from the ends of patterns. This makes it so
+// that `foo/` and `foo` are treated identically.
+function normalizePattern (rawPath) {
+  // The path separator is `\` on Windows, but we also allow usage of `/`;
+  // hence we check for both here.
+  if (rawPath.endsWith(path.sep) || rawPath.endsWith('/')) {
+    return rawPath.substring(0, rawPath.length - 1);
+  }
+  return rawPath;
+}
+
 // Given a path pattern like `foo/bar/baz` and a list of the current root path
 // basenames, reinterprets the path pattern and decides which root(s) it refers
 // to.
@@ -102,7 +113,8 @@ function getBasenamesFromProjectRoots () {
 
 const CACHED_MINIMATCH_INSTANCES = new Map();
 
-function minimatchInstanceForPattern(pattern) {
+function minimatchInstanceForPattern(rawPattern) {
+  let pattern = normalizePattern(rawPattern);
   if (!CACHED_MINIMATCH_INSTANCES.has(pattern)) {
     let instance = new Minimatch(pattern, { flipNegate: true });
     CACHED_MINIMATCH_INSTANCES.set(pattern, instance);

--- a/src/workspace.js
+++ b/src/workspace.js
@@ -2423,9 +2423,12 @@ module.exports = class Workspace extends Model {
 
     const searchPromise = Promise.all(allSearches);
 
-    let defaultMatchers = options.paths ?
-      options.paths.map((inclusion) => minimatchInstanceForPattern(inclusion)) :
-      null;
+    let defaultMatchers = null;
+    if (options.paths) {
+      defaultMatchers = options.paths
+        .filter(p => !!p)
+        .map(inclusion => minimatchInstanceForPattern(inclusion));
+    }
 
     const customMatchers = new Map();
     for (let [dir, inclusions] of customInclusionsForDirectory) {

--- a/src/workspace.js
+++ b/src/workspace.js
@@ -2438,6 +2438,7 @@ module.exports = class Workspace extends Model {
     let defaultMatchers = null;
     if (options.paths) {
       defaultMatchers = options.paths
+        // Filter out "empty string" ("") path segments that somehow make it here
         .filter(p => !!p)
         .map(inclusion => minimatchInstanceForPattern(inclusion));
     }


### PR DESCRIPTION
…when searching modified buffers.

Even after adding all those specs in #1455, somehow this regressed.

When we search the entire project for a string, we outsource the vast majority of the task to a background job that uses either `scandal` or `ripgrep`. But since those tools can only search what's on disk, we must scour the workspace for modified buffers and search those manually. We even have different code paths for whether the buffer was modified before or after the search was done.

The last few times we've touched `find-and-replace` it's largely had to do with the complexity of this modified buffer search. It used to ignore path inclusions and exclusions, but we've addressed that… except somewhere along the way it regressed for this simple case:

* Open a project with files `a.txt` and `b.txt`.
* Give each one idential dummy (`Lorem ipsum dolor sit amet…`) text and save them both.
* Open `a.txt` and add a space at the end of the file so it's considered a modified buffer.
* Do a project-wide search for `dolor` and leave the file/directory pattern blank.
* You'll see `b.txt` in the results, but not `a.txt`.

This happens because

* We are zealous about making sure that `a.txt`, as a modified buffer, matches the specified file/directory pattern before we consider whether it should show up in the project search results…
* …so when we loop through open modified buffers, we take the buffer's path and try to match it against the specified path inclusions/exclusions…
* …but we're incorrectly interpreting a blank exclusions field as a matcher for a pattern of `""` (an empty string).

This last step is where we incorrectly exclude the buffer because we think its path does not match.

The fix — one I've applied both in `Workspace::scan` and the originating `find-and-replace` code from `results-model.js` — is to filter out empty patterns, treating them as invalid.

### Testing

A new test covers this scenario; I'm surprised there wasn't one before. The test is in the first commit; this allows you to checkout just that commit and run the spec in order to demonstrate the failure. The next commit fixes it and makes the new spec pass.