### PR TITLE
Fix keyBindingCommand breaking function-based tooltip titles

### DIFF
--- a/spec/tooltip-manager-spec.js
+++ b/spec/tooltip-manager-spec.js
@@ -214,6 +214,36 @@ describe('TooltipManager', () => {
           });
         }));
 
+      describe('when the title is a function', () => {
+        it('calls the function and appends the key binding to the result', () => {
+          atom.keymaps.add('test', {
+            '.foo': { 'ctrl-x ctrl-y': 'test-command' }
+          });
+
+          manager.add(element, {
+            title: () => 'Title',
+            keyBindingCommand: 'test-command'
+          });
+
+          hover(element, function() {
+            const tooltipElement = document.body.querySelector('.tooltip');
+            expect(tooltipElement).toHaveText(`Title ${ctrlX} ${ctrlY}`);
+          });
+        });
+
+        it('calls the function without appending anything when no key binding is found', () => {
+          manager.add(element, {
+            title: () => 'Title',
+            keyBindingCommand: 'test-command'
+          });
+
+          hover(element, function() {
+            const tooltipElement = document.body.querySelector('.tooltip');
+            expect(tooltipElement.textContent).toBe('Title');
+          });
+        });
+      });
+
       describe('when a keyBindingTarget is specified', () => {
         it('looks up the key binding relative to the target', () => {
           atom.keymaps.add('test', {

--- a/src/tooltip-manager.js
+++ b/src/tooltip-manager.js
@@ -132,9 +132,16 @@ module.exports = class TooltipManager {
       });
       const keystroke = getKeystroke(bindings);
       if (options.title != null && keystroke != null) {
-        options.title += ` ${getKeystroke(bindings)}`;
+        if (typeof options.title === 'function') {
+          const originalTitle = options.title;
+          options.title = function() {
+            return originalTitle.call(this) + ` ${keystroke}`;
+          };
+        } else {
+          options.title += ` ${keystroke}`;
+        }
       } else if (keystroke != null) {
-        options.title = getKeystroke(bindings);
+        options.title = keystroke;
       }
     }
 


### PR DESCRIPTION
When `keyBindingCommand` was provided alongside a function `title`, the keystroke string was appended using `+=` which coerced the function to its source code string representation rather than calling it. The tooltip would display the raw function body instead of its return value. Two specs are added.

<img width="187" height="107" alt="image" src="https://github.com/user-attachments/assets/a5a4b6b0-5243-4c13-bf2b-2ace165b27cb" />