### PR TITLE
Fix Windows context menu options not persisting across restarts

### DIFF
--- a/src/main-process/win-shell.js
+++ b/src/main-process/win-shell.js
@@ -1,4 +1,5 @@
 const Registry = require('winreg');
+const { execFile } = require('child_process');
 const Path = require('path');
 const { getAppName } = require('../get-app-details.js');
 
@@ -34,15 +35,17 @@ class ShellOption {
   register(callback) {
     let doneCount = this.parts.length;
     this.parts.forEach(part => {
-      let reg = new Registry({
-        hive: 'HKCU',
-        key: part.key != null ? `${this.key}\\${part.key}` : this.key
+      const keyPath = `HKCU${part.key != null ? `${this.key}\\${part.key}` : this.key}`;
+      const args = ['ADD', keyPath];
+      if (part.name === '') {
+        args.push('/ve');
+      } else {
+        args.push('/v', part.name);
+      }
+      args.push('/t', 'REG_SZ', '/d', part.value, '/f');
+      execFile('reg.exe', args, { shell: false }, () => {
+        if (--doneCount === 0) return callback();
       });
-      return reg.create(() =>
-        reg.set(part.name, Registry.REG_SZ, part.value, () => {
-          if (--doneCount === 0) return callback();
-        })
-      );
     });
   }
 


### PR DESCRIPTION
When I have enable the "Show in file/folder context menus" in Settings the entries appear correctly in File Explorer's context menu but do not work at all, and checkboxes revert to unchecked after Pulsar restart.

acc. Claude:
The root cause is in how `winreg` v1.2.1 spawns `reg.exe` internally: it uses `child_process.spawn` with `shell: true`, which routes the command through `cmd.exe`. The registry command values written by Pulsar contain both a quoted executable path and a `%1` file argument placeholder. When passed through `cmd.exe`, the multiple quoted groups break argument boundary parsing, and `%1` is expanded as a batch parameter (to an empty string). This causes `reg.exe` to exit with an "Invalid syntax" error, leaving the `command` subkey created but with an empty default value. The empty command means clicking the context menu entry does nothing. On the next restart, `isRegistered()` performs a strict string comparison between the stored value and the expected command string, which fails because the stored value is empty, so all checkboxes appear unchecked even though the keys exist in the registry. The fix replaces the winreg-based `register()` method with direct `child_process.execFile` calls using `shell: false`. This passes arguments to `reg.exe` as a proper array without any `cmd.exe` processing, so `%1` is preserved literally and quoted paths are handled correctly. Reading and deregistration continue to use `winreg` unchanged, as those code paths are not affected by the issue.

I have tested it in local build and works fine.