### PR TITLE
Use SHA256 Digest for RPM Build

### DIFF
--- a/script/electron-builder.js
+++ b/script/electron-builder.js
@@ -291,7 +291,7 @@ let options = {
     afterInstall: 'script/post-install.sh',
     afterRemove: 'script/post-uninstall-rpm.sh',
     compression: 'xz',
-    fpm: ['--rpm-rpmbuild-define=_build_id_links none']
+    fpm: ['--rpm-digest', 'sha256', '--rpm-rpmbuild-define=_build_id_links none']
   },
 
   linux: {


### PR DESCRIPTION
Adds arguments to FPM invocation in electron-builder script to use SHA256 package digests instead of the default (MD5) for RPMs.

This allows systems with FIPS mode enabled (fips=1 kernel argument) to install Pulsar RPMs via package managers without needing to ignore digests.

RPM has supported SHA256 since v4.6 so this would only break support on very old distros (RHEL/CentOS 5) using the RPMs.

Fixes #1016 