### PR TITLE
CI: Bump 'nick-fields/retry' to v4.0.0 (exact SHA) due to Node 20 Actions deprecation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -155,7 +155,7 @@ jobs:
       # So we use the pipe to ensure we wait for output, but for the LIFE (#1350) I can't get output here.
 
     - name: Install Pulsar Dependencies
-      uses: nick-fields/retry@7152eba30c6575329ac0576536151aca5a72780e
+      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60
       with:
         timeout_minutes: 30
         max_attempts: 3
@@ -164,7 +164,7 @@ jobs:
         on_retry_command: rm -R node_modules
 
     - name: Rebuild Pulsar Dependencies for Electron
-      uses: nick-fields/retry@7152eba30c6575329ac0576536151aca5a72780e
+      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60
       with:
         timeout_minutes: 30
         max_attempts: 3
@@ -172,7 +172,7 @@ jobs:
         command: yarn build
 
     - name: Build ppm
-      uses: nick-fields/retry@7152eba30c6575329ac0576536151aca5a72780e
+      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60
       with:
         timeout_minutes: 30
         max_attempts: 3
@@ -200,7 +200,7 @@ jobs:
         APPLEID: ${{ secrets.APPLEID }}
         APPLEID_PASSWORD: ${{ secrets.APPLEID_PASSWORD }}
         TEAM_ID: ${{ secrets.TEAM_ID }}
-      uses: nick-fields/retry@7152eba30c6575329ac0576536151aca5a72780e
+      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60
       with:
         timeout_minutes: 31
         max_attempts: 7
@@ -208,7 +208,7 @@ jobs:
 
     - name: Build Pulsar Binaries (macOS) (Unsigned)
       if: ${{ runner.os == 'macOS' && github.event_name != 'push' }}
-      uses: nick-fields/retry@7152eba30c6575329ac0576536151aca5a72780e
+      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60
       with:
         timeout_minutes: 31
         max_attempts: 7
@@ -216,7 +216,7 @@ jobs:
 
     - name: Build Pulsar Binaries
       if: ${{ runner.os != 'macOS' }}
-      uses: nick-fields/retry@7152eba30c6575329ac0576536151aca5a72780e
+      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60
       with:
         timeout_minutes: 30
         max_attempts: 3


### PR DESCRIPTION
### What

Bumping the third-party ['nick-fields/retry'](https://github.com/nick-fields/retry) GitHub Action from [v3.0.0](https://github.com/nick-fields/retry/releases/tag/v3.0.0) ([`7152eba`](https://github.com/nick-fields/retry/commit/7152eba30c6575329ac0576536151aca5a72780e))  to --> [v4.0.0](https://github.com/nick-fields/retry/releases/tag/v4.0.0) ([`ad98453`](https://github.com/nick-fields/retry/commit/ad984534de44a9489a53aefd81eb77f87c70dc60))

### Why

The version of ['nick-fields/retry'](https://github.com/nick-fields/retry) we've been using runs on Node 20.

This version ([v4.0.0](https://github.com/nick-fields/retry/compare/v3.0.0...v4.0.0)) has been updated to use Node 24 under the hood.

Per GitHub:
> Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026.
> Node.js 20 will be removed from the runner on September 16th, 2026.

So, we need to do this sooner or later. May as well do it now.

### Verification

Works in CI, deprecation warning goes away in "Build Pulsar Binaries" workflow

_(Optionally see: https://github.com/nick-fields/retry/releases to verify SHAs of tags, or for more reference info.)_

___

### Note about minutiae

There is a non-end-user-relevant PR landed after the v4.0.0 tag: https://github.com/nick-fields/retry/compare/v4.0.0...master/

(It is `#166` at that repo.) I preferred pinning to the (exact, full-length explicit SHA of the) tagged v4.0.0 commit, but can pin to the current latest commit if reviewers feel that would be less confusing or help avoid prompts to update or some such. Said PR just updates _that repo's CI_ and would not affect us.