### PR TITLE
Honor `activatePane: false` when `workspace.open` split creates a new pane

### DIFF
--- a/spec/pane-spec.js
+++ b/spec/pane-spec.js
@@ -1236,6 +1236,15 @@ describe('Pane', () => {
         });
       });
 
+      describe('when `activate: false` is passed in the params', () => {
+        it('creates the new pane without activating it', () => {
+          pane1.activate();
+          const pane2 = pane1.splitRight({ activate: false });
+          expect(container.root.children).toContain(pane2);
+          expect(container.getActivePane()).toBe(pane1);
+        });
+      });
+
       describe('when the parent is a column', () => {
         it('replaces itself with a row and inserts a new pane to the right of itself', () => {
           pane1.splitDown();

--- a/spec/workspace-spec.js
+++ b/spec/workspace-spec.js
@@ -689,6 +689,36 @@ describe('Workspace', () => {
           });
         });
       });
+
+      describe("when 'activatePane' is false and the split creates a new pane", () => {
+        it("leaves the original pane active when splitting right", async () => {
+          const pane1 = workspace.getActivePane();
+
+          const editor = await workspace.open('a', {
+            split: 'right',
+            activatePane: false
+          });
+
+          const pane2 = workspace.getPanes().filter(p => p !== pane1)[0];
+          expect(pane2).toBeDefined();
+          expect(pane2.items).toEqual([editor]);
+          expect(workspace.getActivePane()).toBe(pane1);
+        });
+
+        it("leaves the original pane active when splitting down", async () => {
+          const pane1 = workspace.getActivePane();
+
+          const editor = await workspace.open('a', {
+            split: 'down',
+            activatePane: false
+          });
+
+          const pane2 = workspace.getPanes().filter(p => p !== pane1)[0];
+          expect(pane2).toBeDefined();
+          expect(pane2.items).toEqual([editor]);
+          expect(workspace.getActivePane()).toBe(pane1);
+        });
+      });
     });
 
     describe('when an initialLine and initialColumn are specified', () => {

--- a/src/pane.js
+++ b/src/pane.js
@@ -1249,6 +1249,7 @@ module.exports = class Pane {
   // * `params` (optional) {Object} with the following keys:
   //   * `items` (optional) {Array} of items to add to the new pane.
   //   * `copyActiveItem` (optional) {Boolean} true will copy the active item into the new split pane
+  //   * `activate` (optional) {Boolean} `false` will leave the currently active pane active instead of activating the new pane. Defaults to `true`.
   //
   // Returns the new {Pane}.
   splitLeft(params) {
@@ -1260,6 +1261,7 @@ module.exports = class Pane {
   // * `params` (optional) {Object} with the following keys:
   //   * `items` (optional) {Array} of items to add to the new pane.
   //   * `copyActiveItem` (optional) {Boolean} true will copy the active item into the new split pane
+  //   * `activate` (optional) {Boolean} `false` will leave the currently active pane active instead of activating the new pane. Defaults to `true`.
   //
   // Returns the new {Pane}.
   splitRight(params) {
@@ -1271,6 +1273,7 @@ module.exports = class Pane {
   // * `params` (optional) {Object} with the following keys:
   //   * `items` (optional) {Array} of items to add to the new pane.
   //   * `copyActiveItem` (optional) {Boolean} true will copy the active item into the new split pane
+  //   * `activate` (optional) {Boolean} `false` will leave the currently active pane active instead of activating the new pane. Defaults to `true`.
   //
   // Returns the new {Pane}.
   splitUp(params) {
@@ -1282,6 +1285,7 @@ module.exports = class Pane {
   // * `params` (optional) {Object} with the following keys:
   //   * `items` (optional) {Array} of items to add to the new pane.
   //   * `copyActiveItem` (optional) {Boolean} true will copy the active item into the new split pane
+  //   * `activate` (optional) {Boolean} `false` will leave the currently active pane active instead of activating the new pane. Defaults to `true`.
   //
   // Returns the new {Pane}.
   splitDown(params) {
@@ -1335,7 +1339,9 @@ module.exports = class Pane {
     if (params && params.moveActiveItem && this.activeItem)
       this.moveItemToPane(this.activeItem, newPane);
 
-    newPane.activate();
+    if (!params || params.activate !== false) {
+      newPane.activate();
+    }
     return newPane;
   }
 
@@ -1371,10 +1377,10 @@ module.exports = class Pane {
 
   // If the parent is a horizontal axis, returns its last child if it is a pane;
   // otherwise returns a new pane created by splitting this pane rightward.
-  findOrCreateRightmostSibling() {
+  findOrCreateRightmostSibling(params) {
     const rightmostSibling = this.findRightmostSibling();
     if (rightmostSibling === this) {
-      return this.splitRight();
+      return this.splitRight(params);
     } else {
       return rightmostSibling;
     }
@@ -1412,10 +1418,10 @@ module.exports = class Pane {
 
   // If the parent is a vertical axis, returns its last child if it is a pane;
   // otherwise returns a new pane created by splitting this pane bottomward.
-  findOrCreateBottommostSibling() {
+  findOrCreateBottommostSibling(params) {
     const bottommostSibling = this.findBottommostSibling();
     if (bottommostSibling === this) {
-      return this.splitDown();
+      return this.splitDown(params);
     } else {
       return bottommostSibling;
     }

--- a/src/workspace.js
+++ b/src/workspace.js
@@ -1301,18 +1301,19 @@ module.exports = class Workspace extends Model {
 
           const container = this.paneContainers[location] || this.getCenter();
           pane = container.getActivePane();
+          const splitParams = { activate: options.activatePane !== false };
           switch (options.split) {
             case 'left':
               pane = pane.findLeftmostSibling();
               break;
             case 'right':
-              pane = pane.findOrCreateRightmostSibling();
+              pane = pane.findOrCreateRightmostSibling(splitParams);
               break;
             case 'up':
               pane = pane.findTopmostSibling();
               break;
             case 'down':
-              pane = pane.findOrCreateBottommostSibling();
+              pane = pane.findOrCreateBottommostSibling(splitParams);
               break;
           }
         }


### PR DESCRIPTION
`atom.workspace.open(uri, { split: 'right', activatePane: false })` is documented to leave the original pane active, but when the split has to create a new pane, the new pane becomes active anyway. The same applies to `split: 'down'`.

The cause is `Pane::split`, which unconditionally calls `newPane.activate()` before returning. That call happens inside `findOrCreateRightmostSibling` / `findOrCreateBottommostSibling`, before `workspace.open` ever gets to check `options.activatePane`. So the option only worked when the target pane already existed.

The fix threads an `activate` flag through `Pane::split`, `splitLeft` / `splitRight` / `splitUp` / `splitDown`, and the two `findOrCreate*` helpers. It defaults to `true`, so existing callers and the `pane:split-*` commands are unchanged. `workspace.open` now derives `{ activate: options.activatePane !== false }` and passes it into the `findOrCreate*` call, bringing the runtime behavior in line with what the JSDoc has always promised.

I hit this in my `sofistik-tools` package, where a keybinding opens a SOFiSTiK help PDF in a right split while the user keeps typing in the source editor. Passing `activatePane: false` had no effect the first time the viewer was opened (new pane had to be created), so focus jumped out of the editor. On subsequent calls, when the viewer pane already existed, focus stayed put as expected. That inconsistency is what pointed at this bug.
