### PR TITLE
Resolve keyBindingCommand tooltip label lazily instead of at registration time

### DIFF
--- a/spec/tooltip-manager-spec.js
+++ b/spec/tooltip-manager-spec.js
@@ -244,6 +244,68 @@ describe('TooltipManager', () => {
         });
       });
 
+      describe('when the keymap changes after the tooltip is registered', () => {
+        it('shows the updated key binding when a string title is specified', () => {
+          const initialKeymap = atom.keymaps.add('initial', {
+            '.foo': { 'ctrl-x ctrl-z': 'test-command' }
+          });
+
+          manager.add(element, {
+            title: 'Title',
+            keyBindingCommand: 'test-command'
+          });
+
+          initialKeymap.dispose();
+          atom.keymaps.add('test', {
+            '.foo': { 'ctrl-x ctrl-y': 'test-command' }
+          });
+
+          hover(element, function() {
+            const tooltipElement = document.body.querySelector('.tooltip');
+            expect(tooltipElement).toHaveText(`Title ${ctrlX} ${ctrlY}`);
+          });
+        });
+
+        it('shows the updated key binding when no title is specified', () => {
+          const initialKeymap = atom.keymaps.add('initial', {
+            '.foo': { 'ctrl-x ctrl-z': 'test-command' }
+          });
+
+          manager.add(element, { keyBindingCommand: 'test-command' });
+
+          initialKeymap.dispose();
+          atom.keymaps.add('test', {
+            '.foo': { 'ctrl-x ctrl-y': 'test-command' }
+          });
+
+          hover(element, function() {
+            const tooltipElement = document.body.querySelector('.tooltip');
+            expect(tooltipElement).toHaveText(`${ctrlX} ${ctrlY}`);
+          });
+        });
+
+        it('shows the updated key binding when the title is a function', () => {
+          const initialKeymap = atom.keymaps.add('initial', {
+            '.foo': { 'ctrl-x ctrl-z': 'test-command' }
+          });
+
+          manager.add(element, {
+            title: () => 'Title',
+            keyBindingCommand: 'test-command'
+          });
+
+          initialKeymap.dispose();
+          atom.keymaps.add('test', {
+            '.foo': { 'ctrl-x ctrl-y': 'test-command' }
+          });
+
+          hover(element, function() {
+            const tooltipElement = document.body.querySelector('.tooltip');
+            expect(tooltipElement).toHaveText(`Title ${ctrlX} ${ctrlY}`);
+          });
+        });
+      });
+
       describe('when a keyBindingTarget is specified', () => {
         it('looks up the key binding relative to the target', () => {
           atom.keymaps.add('test', {

--- a/src/tooltip-manager.js
+++ b/src/tooltip-manager.js
@@ -126,23 +126,17 @@ module.exports = class TooltipManager {
     const { keyBindingCommand, keyBindingTarget } = options;
 
     if (keyBindingCommand != null) {
-      const bindings = this.keymapManager.findKeyBindings({
-        command: keyBindingCommand,
-        target: keyBindingTarget
-      });
-      const keystroke = getKeystroke(bindings);
-      if (options.title != null && keystroke != null) {
-        if (typeof options.title === 'function') {
-          const originalTitle = options.title;
-          options.title = function() {
-            return originalTitle.call(this) + ` ${keystroke}`;
-          };
-        } else {
-          options.title += ` ${keystroke}`;
-        }
-      } else if (keystroke != null) {
-        options.title = keystroke;
-      }
+      const keymapManager = this.keymapManager;
+      const baseTitle = options.title;
+      options.title = function() {
+        const bindings = keymapManager.findKeyBindings({
+          command: keyBindingCommand,
+          target: keyBindingTarget
+        });
+        const keystroke = getKeystroke(bindings);
+        const base = typeof baseTitle === 'function' ? baseTitle.call(this) : baseTitle;
+        return [base, keystroke].filter(Boolean).join(' ');
+      };
     }
 
     delete options.selector;


### PR DESCRIPTION
The `keyBindingCommand` option in `atom.tooltips.add` was resolved once at call time by querying `keymapManager.findKeyBindings` and baking the result into the title string. If the user's `keymap.cson` had not yet been loaded when the tooltip was registered, which is the case during package activation, the keystroke label was permanently absent. The quick fix is to disabling and re-enabling the package, because by then all keymaps were loaded.

A previous attempt (#1516) addressed the case where `title` is a function by wrapping it to append the keystroke, but the `findKeyBindings` call was still made eagerly at `add()` time. When the user keymap is not yet loaded at that point, `keystroke` is `null` and no wrapping occurs at all.

The fix moves the entire lookup inside a function that runs at tooltip-show time. Both string and function `title` options are unified into a single wrapper.
