### PR TITLE
Fix language-gfm setext header symbol queries

### DIFF
--- a/packages/language-gfm/grammars/tree-sitter-markdown/tags.scm
+++ b/packages/language-gfm/grammars/tree-sitter-markdown/tags.scm
@@ -40,13 +40,13 @@
   (#set! symbol.prepend "······ "))
 
 ((setext_heading
-  heading_content: (_) @name) @definition.heading
-  (setext_h1_underline)
+  heading_content: (_) @name
+  (setext_h1_underline)) @definition.heading
   (#set! symbol.strip "(^\\s*|\\s*$)")
   (#set! symbol.prepend "· "))
 
 ((setext_heading
-  heading_content: (_) @name) @definition.heading
-  (setext_h2_underline)
+  heading_content: (_) @name
+  (setext_h2_underline)) @definition.heading
   (#set! symbol.strip "(^\\s*|\\s*$)")
   (#set! symbol.prepend "·· "))


### PR DESCRIPTION
This PR proposes a fix for the tree-sitter queries for setext-style headers in markdown files.

The setext header queries in `tags.scm` for the `language-gfm` package were incorrectly structured, which led to only ATX headers being listed in the symbols-view. With a small correction to the setext queries, so the nesting structure matches that produced by the grammar, the setext headers now correctly match, and are also listed.