### PR TITLE
Cirrus: bump node from v16 to v20

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -6,7 +6,7 @@ env:
 # linux_task:
 #   alias: linux
 #   container:
-#     image: node:16-slim
+#     image: node:20-buster-slim
 #     memory: 8G
 #   prepare_script:
 #     - apt-get update
@@ -59,7 +59,7 @@ arm_linux_task:
   only_if: $CIRRUS_CRON != "" || $CIRRUS_TAG != ""
   skip: $CIRRUS_CHANGE_IN_REPO == $CIRRUS_LAST_GREEN_CHANGE
   arm_container:
-    image: node:16-slim
+    image: node:20-buster-slim
     memory: 8G
   env:
     USE_SYSTEM_FPM: 'true'

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -179,7 +179,7 @@ silicon_mac_task:
     - mkdir tj_n && cd tj_n
     - curl -L https://github.com/tj/n/archive/0ce85771fdff8f4b3e09ade700461b4f58a64444.tar.gz -O
     - tar xf 0ce85771fdff8f4b3e09ade700461b4f58a64444.tar.gz
-    - sudo bash ./n-0ce85771fdff8f4b3e09ade700461b4f58a64444/bin/n 16
+    - sudo bash ./n-0ce85771fdff8f4b3e09ade700461b4f58a64444/bin/n 20
     - cd ..
     - sudo npm install -g yarn
     - sed -i -e "s/[0-9]*-dev/`date -u +%Y%m%d%H`/g" package.json


### PR DESCRIPTION
### Background

We are getting the following error in Cirrus:

> error which@5.0.0: The engine "node" is incompatible with this module. Expected version "^18.17.0 || >=20.5.0". Got "16.20.2"

(`which@5.0.0` is only in this repo's `yarn.lock` as of https://github.com/pulsar-edit/pulsar/pull/1373 landing about a week ago.)

The error indicates we need Node 18 or newer. I checked and our Cirrus tasks are still using Node 16. So...

### Fix

Update node from v16 to v20 in Cirrus

- For Linux, used a node 20-based (but still Debian buster-based) Docker image
  - For reference, see here for confirmation that the previous `node:16-slim` image was Debian Buster-based: https://github.com/docker-library/docs/blob/dbdc7a97f0f8f07263890d9f1a50b7f51ddc0c84/node/README.md#supported-tags-and-respective-dockerfile-links (scroll down to see that `16-slim` is an alias for `16-buster-slim`).
- For macOS, updated the node install during `prepare_script` from v16 to v20

### Alternative approaches

1) Could install Node 20.16.0 in `silicon_mac_task`, rather than installing Node "20" (latest minor/patch).

This would make it easier to catch this sort of bump being needed when doing a "find-in-project 20.16.0." 

But it'd be clunkier to set that up for Linux (Node is pre-provided in the `node:20-buster-slim` Docker image), and this gives parity across ARM Linux and ARM macOS, I guess...? And only specifying major Node version to exist on the PATH during builds has already been how we've been doing it on Cirrus this whole time. So, eh.

2) Could use a different Docker image for Linux...

It'd just be more work/steps to set it up, and I do want to use an old distro such as Debian Buster for `glibc`-related compatibility reasons with various old distros. So this is already what I'd want.

### Verification process

Looks good in a one-off test on Cirrus: https://cirrus-ci.com/build/4853885069688832 ✅ 