### PR TITLE
Bump our versions of `atom-keymap` and `underscore-plus`…

### DIFF
--- a/package.json
+++ b/package.json
@@ -321,6 +321,6 @@
     "@electron/remote": "2.1.2",
     "@pulsar-edit/superstring": "3.0.5",
     "@pulsar-edit/pathwatcher": "9.0.3",
-    "**/underscore-plus": "npm:@pulsar-edit/underscore-plus@1.8.2"
+    "**/underscore-plus": "npm:@pulsar-edit/underscore-plus@1.8.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -321,6 +321,6 @@
     "@electron/remote": "2.1.2",
     "@pulsar-edit/superstring": "3.0.5",
     "@pulsar-edit/pathwatcher": "9.0.3",
-    "**/underscore-plus": "npm:@pulsar-edit/underscore-plus@1.8.1"
+    "**/underscore-plus": "npm:@pulsar-edit/underscore-plus@1.8.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@babel/core": "7.18.6",
     "@electron/remote": "2.1.2",
     "@formatjs/fast-memoize": "^2.2.6",
-    "@pulsar-edit/atom-keymap": "^9.0.3",
+    "@pulsar-edit/atom-keymap": "^9.1.0",
     "@pulsar-edit/fuzzy-native": "1.3.0",
     "@pulsar-edit/get-scrollbar-style": "^1.0.1",
     "@pulsar-edit/git-utils": "^7.0.1",
@@ -174,7 +174,7 @@
     "symbols-view": "file:./packages/symbols-view",
     "tabs": "file:packages/tabs",
     "temp": "0.9.4",
-    "terminal": "https://github.com/pulsar-edit/terminal#v0.2.0",
+    "terminal": "https://github.com/pulsar-edit/terminal#v0.3.2",
     "timecop": "file:./packages/timecop",
     "tree-view": "file:./packages/tree-view",
     "typescript": "^5.8.3",
@@ -244,7 +244,7 @@
     "symbol-provider-tree-sitter": "file:./packages/symbol-provider-tree-sitter",
     "symbols-view": "file:./packages/symbols-view",
     "tabs": "file:./packages/tabs",
-    "terminal": "0.2.0",
+    "terminal": "0.3.2",
     "timecop": "file:./packages/timecop",
     "tree-view": "file:./packages/tree-view",
     "update-package-dependencies": "file:./packages/update-package-dependencies",
@@ -320,6 +320,7 @@
     "es5-ext": "https://github.com/pulsar-edit/es5-ext#169f6ae9b2675675269a0ba265f83c29c7b56244",
     "@electron/remote": "2.1.2",
     "@pulsar-edit/superstring": "3.0.5",
-    "@pulsar-edit/pathwatcher": "9.0.3"
+    "@pulsar-edit/pathwatcher": "9.0.3",
+    "**/underscore-plus": "npm:@pulsar-edit/underscore-plus@1.8.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1669,10 +1669,10 @@
     "@types/node" "*"
     playwright-core "1.22.2"
 
-"@pulsar-edit/atom-keymap@^9.0.3":
-  version "9.0.3"
-  resolved "https://registry.yarnpkg.com/@pulsar-edit/atom-keymap/-/atom-keymap-9.0.3.tgz#5df0dec0d710e74639bfdfbd1b790a927035aeaf"
-  integrity sha512-Qh/PFAXA6xNBV6gZTYs7fQf7EwyHNf8Keh0U155XO+0JdRws68YlH07Doq0tqQVvURwU8RIZGNilK0BKkJpRUg==
+"@pulsar-edit/atom-keymap@^9.1.0":
+  version "9.1.0"
+  resolved "https://registry.yarnpkg.com/@pulsar-edit/atom-keymap/-/atom-keymap-9.1.0.tgz#574bd035d1d4b59b2445cc4ea1925513e6c992cf"
+  integrity sha512-BW7WvkyeXzcr6v2G97gIkxEnUIi/EoIUDHOLAyNqsRvMJcPxPajBDwM54rgCSPw1oeKSaaiHk56O46mlAyxcxg==
   dependencies:
     "@electron/rebuild" "^3.2.11"
     "@pulsar-edit/keyboard-layout" "^3.0.5"
@@ -2108,38 +2108,38 @@
   resolved "https://registry.yarnpkg.com/@xmldom/xmldom/-/xmldom-0.8.11.tgz#b79de2d67389734c57c52595f7a7305e30c2d608"
   integrity sha512-cQzWCtO6C8TQiYl1ruKNn2U6Ao4o4WBBcbL61yJl84x+j5sOWWFU9X7DpND8XZG3daDppSsigMdfAIl2upQBRw==
 
-"@xterm/addon-fit@0.9.0":
-  version "0.9.0"
-  resolved "https://registry.yarnpkg.com/@xterm/addon-fit/-/addon-fit-0.9.0.tgz#29846f08782c51ad85b949528c45b84ad4ec45d7"
-  integrity sha512-hDlPPbTVPYyvwXu/asW8HbJkI/2RMi0cMaJnBZYVeJB0SWP2NeESMCNr+I7CvBlyI0sAxpxOg8Wk4OMkxBz9WA==
+"@xterm/addon-fit@^0.11.0":
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/@xterm/addon-fit/-/addon-fit-0.11.0.tgz#ba4778b69fcc9044a060c2176bbe077657d7b37e"
+  integrity sha512-jYcgT6xtVYhnhgxh3QgYDnnNMYTcf8ElbxxFzX0IZo+vabQqSPAjC3c1wJrKB5E19VwQei89QCiZZP86DCPF7g==
 
-"@xterm/addon-ligatures@0.8.0":
-  version "0.8.0"
-  resolved "https://registry.yarnpkg.com/@xterm/addon-ligatures/-/addon-ligatures-0.8.0.tgz#d7f196c09edad0e7e45c691dce74f28bab683c37"
-  integrity sha512-hvClRA4a4saHXJV+Svxo6tC9NLN17coKbbFChhaQFvTe+TAx+G+LI1NytI8rmSIosOhg9m4uYB3J9o3Qyj4qxA==
+"@xterm/addon-ligatures@^0.10.0":
+  version "0.10.0"
+  resolved "https://registry.yarnpkg.com/@xterm/addon-ligatures/-/addon-ligatures-0.10.0.tgz#4d33c75828c8b155bdc23dfd1a7e6fe8d80bda51"
+  integrity sha512-/Few8ZSHMib7sGjRJoc5l7bCtEB9XJfkNofvPpOcWADxKaUl8og8P172j67OoACSNJAXqeCLIuvj8WFCBkcTxg==
   dependencies:
     font-finder "^1.1.0"
     font-ligatures "^1.4.1"
 
-"@xterm/addon-search@^0.15.0":
-  version "0.15.0"
-  resolved "https://registry.yarnpkg.com/@xterm/addon-search/-/addon-search-0.15.0.tgz#5c772d5f14c26546c4bfbeb0c3d4b3333057411f"
-  integrity sha512-ZBZKLQ+EuKE83CqCmSSz5y1tx+aNOCUaA7dm6emgOX+8J9H1FWXZyrKfzjwzV+V14TV3xToz1goIeRhXBS5qjg==
+"@xterm/addon-search@^0.16.0":
+  version "0.16.0"
+  resolved "https://registry.yarnpkg.com/@xterm/addon-search/-/addon-search-0.16.0.tgz#ddadcbc6e556e45fc4b153f8a0efdf2aa1456b82"
+  integrity sha512-9OeuBFu0/uZJPu+9AHKY6g/w0Czyb/Ut0A5t79I4ULoU4IfU5BEpPFVGQxP4zTTMdfZEYkVIRYbHBX1xWwjeSA==
 
-"@xterm/addon-web-links@0.10.0":
-  version "0.10.0"
-  resolved "https://registry.yarnpkg.com/@xterm/addon-web-links/-/addon-web-links-0.10.0.tgz#be3eccaf1cbd4063161458205cd4bbee2b0f34f9"
-  integrity sha512-QhrHCUr8w6ATGviyXwcAIM1qN3nD1hdxwMC8fsW7z/6aaQlb2nt7zmByJt4eOn7ZzrHOzczljqV5S2pkdQp2xw==
+"@xterm/addon-web-links@^0.12.0":
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/@xterm/addon-web-links/-/addon-web-links-0.12.0.tgz#bc34ae46f4c12012256d451ac2b9be791c0b6bfa"
+  integrity sha512-4Smom3RPyVp7ZMYOYDoC/9eGJJJqYhnPLGGqJ6wOBfB8VxPViJNSKdgRYb8NpaM6YSelEKbA2SStD7lGyqaobw==
 
-"@xterm/addon-webgl@0.17.0":
-  version "0.17.0"
-  resolved "https://registry.yarnpkg.com/@xterm/addon-webgl/-/addon-webgl-0.17.0.tgz#1da534456b7971ebb2f08c381d4732d1f104d7d8"
-  integrity sha512-KUH//EZCz7j1+IekW8sZzmcj/y9gOLf/HMcsWXjg0Xr5cT1lIBIIbbBlbf5kZ+XnA/8c1IuBm1vx+blzlfPk0g==
+"@xterm/addon-webgl@^0.19.0":
+  version "0.19.0"
+  resolved "https://registry.yarnpkg.com/@xterm/addon-webgl/-/addon-webgl-0.19.0.tgz#02533c3f7c0af3ac9a44bbb095cbd47d48e90c25"
+  integrity sha512-b3fMOsyLVuCeNJWxolACEUED0vm7qC0cy4wRvf3oURSzDTYVQiGPhTnhWZwIHdvC48Y+oLhvYXnY4XDXPoJo6A==
 
-"@xterm/xterm@5.4.0":
-  version "5.4.0"
-  resolved "https://registry.yarnpkg.com/@xterm/xterm/-/xterm-5.4.0.tgz#a35b585750ca492cbf2a4c99472c480d8c122840"
-  integrity sha512-GlyzcZZ7LJjhFevthHtikhiDIl8lnTSgol6eTM4aoSNLcuXu3OEhnbqdCVIjtIil3jjabf3gDtb1S8FGahsuEw==
+"@xterm/xterm@^6.0.0":
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/@xterm/xterm/-/xterm-6.0.0.tgz#93637b0f2ee3a70718b5746a27c9c506af16745b"
+  integrity sha512-TQwDdQGtwwDt+2cgKDLn0IRaSxYu1tSUjgKarSDkUM0ZNiSRXFpjxEsvc/Zgc5kq5omJ+V0a8/kIM2WD3sMOYg==
 
 abbrev@^1.0.0:
   version "1.1.1"
@@ -7954,7 +7954,7 @@ p-try@^2.0.0:
   version "1.3.0"
   dependencies:
     fs-plus "^3.0.0"
-    temp "^0.8.1"
+    temp "^0.9.0"
     underscore-plus "^1.0.0"
 
 package-json@^6.3.0:
@@ -9680,17 +9680,17 @@ temp@^0.8.1, temp@^0.8.3, temp@~0.8.0, temp@~0.8.1:
   dependencies:
     rimraf "~2.6.2"
 
-"terminal@https://github.com/pulsar-edit/terminal#v0.2.0":
-  version "0.2.0"
-  resolved "https://github.com/pulsar-edit/terminal#f00c44244cb567f53110a0f5f4029a51e8e49576"
+"terminal@https://github.com/pulsar-edit/terminal#v0.3.2":
+  version "0.3.2"
+  resolved "https://github.com/pulsar-edit/terminal#558dc4c23230cbf0db314cdd1d426df00cb73448"
   dependencies:
     "@electron/remote" "^2.1.2"
-    "@xterm/addon-fit" "0.9.0"
-    "@xterm/addon-ligatures" "0.8.0"
-    "@xterm/addon-search" "^0.15.0"
-    "@xterm/addon-web-links" "0.10.0"
-    "@xterm/addon-webgl" "0.17.0"
-    "@xterm/xterm" "5.4.0"
+    "@xterm/addon-fit" "^0.11.0"
+    "@xterm/addon-ligatures" "^0.10.0"
+    "@xterm/addon-search" "^0.16.0"
+    "@xterm/addon-web-links" "^0.12.0"
+    "@xterm/addon-webgl" "^0.19.0"
+    "@xterm/xterm" "^6.0.0"
     etch "^0.14.1"
     fs-extra "^11.3.2"
     ndjson "^2.0.0"
@@ -9974,17 +9974,22 @@ unbzip2-stream@1.4.3, unbzip2-stream@^1.4.3:
     buffer "^5.2.1"
     through "^2.3.8"
 
-underscore-plus@1.7.0, underscore-plus@1.x, underscore-plus@^1, underscore-plus@^1.0.0, underscore-plus@^1.0.6, underscore-plus@^1.6.3, underscore-plus@^1.7.0, underscore-plus@~1.x:
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/underscore-plus/-/underscore-plus-1.7.0.tgz#107f1900c520ac1fefe4edec6580a7ff08a99d0f"
-  integrity sha512-A3BEzkeicFLnr+U/Q3EyWwJAQPbA19mtZZ4h+lLq3ttm9kn8WC4R3YpuJZEXmWdLjYP47Zc8aLZm9kwdv+zzvA==
+underscore-plus@1.7.0, underscore-plus@1.x, underscore-plus@^1, underscore-plus@^1.0.0, underscore-plus@^1.0.6, underscore-plus@^1.6.3, underscore-plus@^1.7.0, "underscore-plus@npm:@pulsar-edit/underscore-plus@1.8.1", underscore-plus@~1.x:
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/@pulsar-edit/underscore-plus/-/underscore-plus-1.8.1.tgz#4819c2a0d89ad1095894385a7f44e3cef7ae92c3"
+  integrity sha512-XY4L5Tqz5YDv+h2VFM7y87QLZnyK5S01aT7tdVrsomwqMHQLchzOW6TQt2syfx69mcWVBJKn00jE/Y0Zlm/pmw==
   dependencies:
-    underscore "^1.9.1"
+    underscore "^1.10.2"
 
 "underscore@>= 1.3.1", underscore@>=1.3.1, underscore@^1.3.1, underscore@^1.9.1, underscore@~1.13.2:
   version "1.13.7"
   resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.13.7.tgz#970e33963af9a7dda228f17ebe8399e5fbe63a10"
   integrity sha512-GMXzWtsc57XAtguZgaQViUOzs0KTkk8ojr3/xAxXLITqf/3EMwxC0inyETfDFjH/Krbhuep0HNbbjI9i/q3F3g==
+
+underscore@^1.10.2:
+  version "1.13.8"
+  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.13.8.tgz#a93a21186c049dbf0e847496dba72b7bd8c1e92b"
+  integrity sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==
 
 undici-types@~5.26.4:
   version "5.26.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9974,10 +9974,10 @@ unbzip2-stream@1.4.3, unbzip2-stream@^1.4.3:
     buffer "^5.2.1"
     through "^2.3.8"
 
-underscore-plus@1.7.0, underscore-plus@1.x, underscore-plus@^1, underscore-plus@^1.0.0, underscore-plus@^1.0.6, underscore-plus@^1.6.3, underscore-plus@^1.7.0, "underscore-plus@npm:@pulsar-edit/underscore-plus@1.8.2", underscore-plus@~1.x:
-  version "1.8.2"
-  resolved "https://registry.yarnpkg.com/@pulsar-edit/underscore-plus/-/underscore-plus-1.8.2.tgz#8b86f1bf0590dec11b05ac6b9b5859c2a858c8ed"
-  integrity sha512-0vIq92Gp3QGc5G7J7X7noSsvfxgwkmZHhXkGUDKoU7bo69TaGshX3XIHSEl13Klvd1jyHKJJuaOEWA2XTeTXng==
+underscore-plus@1.7.0, underscore-plus@1.x, underscore-plus@^1, underscore-plus@^1.0.0, underscore-plus@^1.0.6, underscore-plus@^1.6.3, underscore-plus@^1.7.0, "underscore-plus@npm:@pulsar-edit/underscore-plus@1.8.3", underscore-plus@~1.x:
+  version "1.8.3"
+  resolved "https://registry.yarnpkg.com/@pulsar-edit/underscore-plus/-/underscore-plus-1.8.3.tgz#588ac69f214f3082684ace9f18352362bc490cd6"
+  integrity sha512-s4cbK1imHEvUJcPKdaoMz2fg49XWjlhqq0Qd0cvVREeswLKyKsMRH/GvvE9sxGfv1qIZaGRAWn/6y+8kViVP2Q==
   dependencies:
     underscore "^1.10.2"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -9974,10 +9974,10 @@ unbzip2-stream@1.4.3, unbzip2-stream@^1.4.3:
     buffer "^5.2.1"
     through "^2.3.8"
 
-underscore-plus@1.7.0, underscore-plus@1.x, underscore-plus@^1, underscore-plus@^1.0.0, underscore-plus@^1.0.6, underscore-plus@^1.6.3, underscore-plus@^1.7.0, "underscore-plus@npm:@pulsar-edit/underscore-plus@1.8.1", underscore-plus@~1.x:
-  version "1.8.1"
-  resolved "https://registry.yarnpkg.com/@pulsar-edit/underscore-plus/-/underscore-plus-1.8.1.tgz#4819c2a0d89ad1095894385a7f44e3cef7ae92c3"
-  integrity sha512-XY4L5Tqz5YDv+h2VFM7y87QLZnyK5S01aT7tdVrsomwqMHQLchzOW6TQt2syfx69mcWVBJKn00jE/Y0Zlm/pmw==
+underscore-plus@1.7.0, underscore-plus@1.x, underscore-plus@^1, underscore-plus@^1.0.0, underscore-plus@^1.0.6, underscore-plus@^1.6.3, underscore-plus@^1.7.0, "underscore-plus@npm:@pulsar-edit/underscore-plus@1.8.2", underscore-plus@~1.x:
+  version "1.8.2"
+  resolved "https://registry.yarnpkg.com/@pulsar-edit/underscore-plus/-/underscore-plus-1.8.2.tgz#8b86f1bf0590dec11b05ac6b9b5859c2a858c8ed"
+  integrity sha512-0vIq92Gp3QGc5G7J7X7noSsvfxgwkmZHhXkGUDKoU7bo69TaGshX3XIHSEl13Klvd1jyHKJJuaOEWA2XTeTXng==
   dependencies:
     underscore "^1.10.2"
 


### PR DESCRIPTION
…including pointing all usages of `underscore-plus` to our new fork at `@pulsar-edit/underscore-plus`.

@asiloisad made a suggestion a while ago that we should support the `cmdorctrl` modifier when describing keybindings; it would correspond to <kbd>Cmd</kbd> on macOS, but <kbd>Ctrl</kbd> on Linux and Windows. Amazingly, to support this simple idea means changing two different packages: `atom-keymap` (so that we know how to interpret `cmdorctrl` when loading keybindings) and `underscore-plus` (since that's the library responsible for taking a string like `ctrl-s` and “humanizing it” to `^S` in the command palette, among other places).

This is the first time we needed to make a change to `underscore-plus` in the Pulsar era, so we also needed to set up CI and the NPM publishing pipeline. That's all been done, so all that's left is to bump these two dependencies to their new versions.

Instead of `underscore-plus`, we should technically be importing from `@pulsar-edit/underscore-plus` in all instances. It's worth doing the work of renaming those usages, but it doesn't need to happen all at once! _Lots_ of built-in packages import `underscore-plus` instead of importing `underscore` directly. So in the interest of minimizing the disruptiveness of this PR (and surely getting some of it wrong), I instead added an entry in Yarn's `resolutions` field to resolve all requests for `underscore-plus` with the NPM version of `@pulsar-edit/underscore-plus` that we just published. We're still on major version 1, so they should all be compatible as far as semver is concerned.

If CI is happy, we should do a couple of manual sanity checks… but otherwise the proof is in a green test suite!

One way of testing manually would be to download the CI artifact, then add a new binding in your `keymap.cson`:

```coffeescript
'atom-workspace':
  'cmdorctrl-shift-y': 'about:view-release-notes`
```

Then, when you open the command palette, you should see **About: View Release Notes** at/near the top, and that list item should also display the binding you just added — correctly deciding between <kbd>Cmd</kbd> and <kbd>Ctrl</kbd> based on your platform. You should also be able to press the keystroke and have it trigger as expected.