### PR TITLE
[find-and-replace] Ensure a pattern without any path separators…

### DIFF
--- a/spec/workspace-spec.js
+++ b/spec/workspace-spec.js
@@ -2287,6 +2287,13 @@ describe('Workspace', () => {
       ).toBe(true);
 
       expect(
+        atom.workspace.filePathMatchesPatterns(pathA1, ['!*.js'])
+      ).toBe(false);
+      expect(
+        atom.workspace.filePathMatchesPatterns(pathB1, ['!*.js'])
+      ).toBe(false);
+
+      expect(
         atom.workspace.filePathMatchesPatterns(pathA1, positiveGlobs)
       ).toBe(false);
       expect(

--- a/spec/workspace-spec.js
+++ b/spec/workspace-spec.js
@@ -2280,6 +2280,13 @@ describe('Workspace', () => {
       ).toBe(false);
 
       expect(
+        atom.workspace.filePathMatchesPatterns(pathA1, ['*.js'])
+      ).toBe(true);
+      expect(
+        atom.workspace.filePathMatchesPatterns(pathB1, ['*.js'])
+      ).toBe(true);
+
+      expect(
         atom.workspace.filePathMatchesPatterns(pathA1, positiveGlobs)
       ).toBe(false);
       expect(

--- a/src/workspace.js
+++ b/src/workspace.js
@@ -2659,7 +2659,6 @@ module.exports = class Workspace extends Model {
         // These patterns implicitly exclude our root altogether.
         return false;
       }
-      console.log('Filtered patterns:', filteredPatterns);
       patterns = filteredPatterns;
     }
 

--- a/src/workspace.js
+++ b/src/workspace.js
@@ -50,7 +50,16 @@ function normalizePattern (rawPath) {
   if (rawPath.endsWith(path.sep) || rawPath.endsWith('/')) {
     return rawPath.substring(0, rawPath.length - 1);
   }
-  return rawPath;
+  // If a user searches for (e.g.) `*.js`, we want to search all `.js` files
+  // anywhere in the project, not just in the root. That means we should treat
+  // patterns as implicitly prepending `**/` if they contain no path separators.
+  //
+  // NOTE: This is stricter than VS Code's approach, which is to prepend `**/`
+  // to _all_ patterns unless the user specifically opts out by starting a
+  // path with `/`. This would make plenty of sense for us, but would be a
+  // change in behavior, so for now we're going with this as a compromise.
+  if (rawPath.includes(`${path.sep}`)) return rawPath;
+  return `**${path.sep}${rawPath}`;
 }
 
 // Given a path pattern like `foo/bar/baz` and a list of the current root path

--- a/src/workspace.js
+++ b/src/workspace.js
@@ -42,7 +42,7 @@ function filePathMatchesGlob(filePath, matcher) {
   return matcher.negate ? true : false;
 }
 
-// Transform it prior to handing it off to `minimatch`.
+// Transform a pattern prior to handing it off to `minimatch`.
 function normalizePattern (rawPath) {
   // Strip any trailing path separator.
   // The path separator is `\` on Windows, but we also allow usage of `/`;

--- a/src/workspace.js
+++ b/src/workspace.js
@@ -42,14 +42,23 @@ function filePathMatchesGlob(filePath, matcher) {
   return matcher.negate ? true : false;
 }
 
-// Trim trailing path separators from the ends of patterns. This makes it so
-// that `foo/` and `foo` are treated identically.
+// Transform it prior to handing it off to `minimatch`.
 function normalizePattern (rawPath) {
+  // Strip any trailing path separator.
   // The path separator is `\` on Windows, but we also allow usage of `/`;
   // hence we check for both here.
   if (rawPath.endsWith(path.sep) || rawPath.endsWith('/')) {
-    return rawPath.substring(0, rawPath.length - 1);
+    rawPath = rawPath.substring(0, rawPath.length - 1);
   }
+
+  // Keep any path negation separate from the rest, since it needs to stay at
+  // the beginning no matter what.
+  let negation = '';
+  if (rawPath.startsWith('!')) {
+    rawPath = rawPath.slice(1);
+    negation = '!';
+  }
+
   // If a user searches for (e.g.) `*.js`, we want to search all `.js` files
   // anywhere in the project, not just in the root. That means we should treat
   // patterns as implicitly prepending `**/` if they contain no path separators.
@@ -58,8 +67,8 @@ function normalizePattern (rawPath) {
   // to _all_ patterns unless the user specifically opts out by starting a
   // path with `/`. This would make plenty of sense for us, but would be a
   // change in behavior, so for now we're going with this as a compromise.
-  if (rawPath.includes(`${path.sep}`)) return rawPath;
-  return `**${path.sep}${rawPath}`;
+  let prefix = (rawPath.includes(path.sep) || rawPath.includes('/')) ? '' : `**${path.sep}`;
+  return `${negation}${prefix}${rawPath}`;
 }
 
 // Given a path pattern like `foo/bar/baz` and a list of the current root path
@@ -2650,6 +2659,7 @@ module.exports = class Workspace extends Model {
         // These patterns implicitly exclude our root altogether.
         return false;
       }
+      console.log('Filtered patterns:', filteredPatterns);
       patterns = filteredPatterns;
     }
 


### PR DESCRIPTION
…will be applied against only the filename rather than the entire path.

For example: `*.js` should search all JavaScript files, not just the ones at the project root.

Yet again I have failed to account for an edge case. I won't link to the long saga of fixes related to `find-and-replace` and the interpretation of path inclusions/exclusions, but here's the short version:

* We use three different approaches for project-wide file search (either `scandal` or `ripgrep` for most files, then a manual buffer-by-buffer search for any open buffers with changes not yet committed to disk)
* Each approach is free to interpret the patterns however it wants (and the manual search used to ignore them!)
* This was chaos and meant that you'd get different results depending on your configuration and whether a buffer was modified (even if the modification had nothing to do with the matching text)
* The fix is to assume the job of matching project paths against globs and ensuring that all would-be results have to pass that test…
* …but the flexibility of how paths can be specified in Pulsar makes it tricky to replicate the semantics we had before

Most of the times I've had to revisit this in other PRs involve scenarios where this new glob/path enforcement was too strict.

---

In this case, I missed almost the simplest of all patterns. The placeholder text on the paths field even uses `*.js` as an example of what you can search for!

The fix is pretty easy, but it involves making some decisions:

1. In order for `minimatch` to replicate the behavior we want for `*.js`, we can have it transform the pattern to `**/*.js` — meaning “any file that ends in `.js` regardless of depth.” This is the right call for `*.js` and I'd be tempted to say it's the right call for _all patterns_, regardless of how simple or complex they are… but if we do that, it leads to slightly surprising results. (Suppose you've got a project with `./foo/bar/baz.js` and `./zort/foo/bar/baz.js`. Typing `foo/bar` into the paths field strongly implies that you want to search _only_ within `./foo/bar`; but if we prepend `**/` to that pattern, we'd search within `./zort/foo/bar` as well!) So instead we'll be conservative and prepend `**/` _only_ when the path pattern doesn't contain a path separator (`/` on macOS and Linux and `\` on Windows — though we're thorough on Windows and check both kinds of slash in all instances).
2. The other option is to prepend `**/` to all patterns by default, yet introduce some other sort of convention that lets a user opt into more strictness. This is what VS Code does (at least according to Claude); in the example above, a user could specify `/foo/bar` to search within only `./foo/bar` and ignore `./zort/foo/bar`. This would be quite easy to support in Pulsar, but users are likely not used to it, so if we decide to do this it should be after deliberation rather than as part of a bugfix.

So I've gone with option 1 here, but am open to option 2 in the future. (Option 2 would also require that we change how the tree view’s “Search in Folder” context menu option behaves.)

### Testing

New tests in `workspace-spec.js` illustrate the behavior change. I didn't manage to split out all the tests into their own commit, but I did verify that those new tests all fail on `master` and pass on this PR branch.