### PR TITLE
Tree-sitter fixes, bonus 1.132 edition

### DIFF
--- a/packages/language-javascript/grammars/tree-sitter/highlights.scm
+++ b/packages/language-javascript/grammars/tree-sitter/highlights.scm
@@ -749,6 +749,9 @@
   "while"
 ] @keyword.control.loop._TYPE_.js
 
+((import_attribute "with" @keyword.control.with.js)
+  (#set! capture.final))
+
 "with" @keyword.control.with.js @invalid.deprecated.with.js
 
 ["async" "static"] @storage.modifier._TYPE_.js

--- a/packages/language-javascript/spec/fixtures/sample.js
+++ b/packages/language-javascript/spec/fixtures/sample.js
@@ -1,5 +1,10 @@
 // @ts-nocheck
 /* eslint-disable */
+
+import json from './test.json' with { type: 'json' };
+//                             ^^^^ keyword.control.with.js
+
+
 function diff(obj1, obj2, pathConverter) {
 // ^ storage.type.function
       // ^ entity.name.function.definition

--- a/packages/language-python/grammars/ts/highlights.scm
+++ b/packages/language-python/grammars/ts/highlights.scm
@@ -64,7 +64,7 @@
   (#set! capture.final true))
 
 
-; CLASSES
+; CONSTANTS
 ; =======
 
 ((identifier) @constant.other.python
@@ -87,6 +87,11 @@
   superclasses: (argument_list
     (identifier) @entity.other.inherited-class.python))
 
+; TYPES
+; =====
+
+(generic_type (identifier) @support.storage.type.generic.python)
+(type (identifier) @support.storage.type.python)
 
 ; FUNCTIONS
 ; =========
@@ -440,6 +445,9 @@
   "[" @punctuation.definition.list.begin.bracket.square.python
   "]" @punctuation.definition.list.end.bracket.square.python)
 
+(type_parameter
+  "[" @punctuation.definition.list.begin.bracket.square.python
+  "]" @punctuation.definition.list.end.bracket.square.python)
 
 (slice ":" @punctuation.separator.slice.colon.python)
 

--- a/packages/language-python/spec/fixtures/grammar/syntax_test_python.py
+++ b/packages/language-python/spec/fixtures/grammar/syntax_test_python.py
@@ -1,5 +1,14 @@
 # SYNTAX TEST "source.python"
 
+test_int: int = 1
+#         ^^^ support.storage.type.python
+test_string: str = "Hello world!"
+#            ^^^ support.storage.type.python
+list_of_ints: list[int] = [1, 2, 3]
+#             ^^^^ support.storage.type.generic.python
+#                  ^^^ support.storage.type.python
+
+
 
 def my_func(first, second=False, *third, **forth):
 # <- storage.type.function

--- a/packages/language-typescript/grammars/common/highlights.scm
+++ b/packages/language-typescript/grammars/common/highlights.scm
@@ -894,6 +894,11 @@
   "debugger"
 ] @keyword.control._TYPE_._LANG_
 
+((import_attribute "with" @keyword.control.with._LANG_)
+  (#set! capture.final))
+
+"with" @keyword.control.with._LANG_ @invalid.deprecated.with._LANG_
+
 
 ; REGEX
 ; =====

--- a/packages/language-typescript/spec/fixtures/sample.ts
+++ b/packages/language-typescript/spec/fixtures/sample.ts
@@ -1,6 +1,9 @@
 // @ts-nocheck
 /* eslint-disable */
 
+import json from './test.json' with { type: 'json' };
+//                             ^^^^ keyword.control.with.ts
+
 type World = "world";
 // <- storage.type.ts
 //   ^^^^^ support.storage.other.type.ts


### PR DESCRIPTION
A couple of late fixes deserved to make it into 1.132.0 just because of how simple they were to address: in both cases just adding a couple of scope names for things that were already parsed properly by our Tree-sitter parsers.

New grammar tests in both instances, so if CI is green, this should be good to merge!