### PR TITLE
Add `editor:select-subword` command

### DIFF
--- a/spec/text-editor-spec.js
+++ b/spec/text-editor-spec.js
@@ -2273,6 +2273,55 @@ describe('TextEditor', () => {
       });
     });
 
+    describe('.selectSubwordsContainingCursors()', () => {
+      it('selects the subword under the cursor in a camelCase identifier', () => {
+        editor.setText('getPreviousWord\n');
+        editor.setCursorBufferPosition([0, 1]);
+        editor.selectSubwordsContainingCursors();
+        expect(editor.getSelectedText()).toBe('get');
+
+        editor.setCursorBufferPosition([0, 5]);
+        editor.selectSubwordsContainingCursors();
+        expect(editor.getSelectedText()).toBe('Previous');
+
+        editor.setCursorBufferPosition([0, 12]);
+        editor.selectSubwordsContainingCursors();
+        expect(editor.getSelectedText()).toBe('Word');
+      });
+
+      it('selects the subword under the cursor in a snake_case identifier', () => {
+        editor.setText('get_previous_word\n');
+        editor.setCursorBufferPosition([0, 1]);
+        editor.selectSubwordsContainingCursors();
+        expect(editor.getSelectedText()).toBe('get');
+
+        editor.setCursorBufferPosition([0, 6]);
+        editor.selectSubwordsContainingCursors();
+        expect(editor.getSelectedText()).toBe('_previous');
+
+        editor.setCursorBufferPosition([0, 14]);
+        editor.selectSubwordsContainingCursors();
+        expect(editor.getSelectedText()).toBe('_word');
+      });
+
+      it('selects the digit sequence under the cursor', () => {
+        editor.setText('version123end\n');
+        editor.setCursorBufferPosition([0, 8]);
+        editor.selectSubwordsContainingCursors();
+        expect(editor.getSelectedText()).toBe('123');
+      });
+
+      it('handles multiple cursors across different subwords', () => {
+        editor.setText('getPreviousWord\n');
+        editor.setCursorBufferPosition([0, 1]);
+        editor.addCursorAtBufferPosition([0, 5]);
+        editor.addCursorAtBufferPosition([0, 12]);
+        editor.selectSubwordsContainingCursors();
+        const texts = editor.getSelections().map(s => s.getText());
+        expect(texts).toEqual(['get', 'Previous', 'Word']);
+      });
+    });
+
     describe('.selectToFirstCharacterOfLine()', () => {
       it("moves to the first character of the current line or the beginning of the line if it's already on the first character", () => {
         editor.setCursorScreenPosition([0, 5]);

--- a/src/register-default-commands.js
+++ b/src/register-default-commands.js
@@ -327,6 +327,9 @@ module.exports = function({commandRegistry, commandInstaller, config, notificati
     'editor:select-word': function() {
       return this.selectWordsContainingCursors();
     },
+    'editor:select-subword': function() {
+      return this.selectSubwordsContainingCursors();
+    },
     'editor:consolidate-selections': function(event) {
       if (!this.consolidateSelections()) {
         return event.abortKeyBinding();

--- a/src/selection.js
+++ b/src/selection.js
@@ -383,6 +383,19 @@ module.exports = class Selection {
     );
   }
 
+  // Public: Modifies the selection to encompass the current subword.
+  //
+  // Returns a {Range}.
+  selectSubword(options = {}) {
+    options.wordRegex = this.cursor.subwordRegExp();
+    this.setBufferRange(
+      this.cursor.getCurrentWordBufferRange(options),
+      options
+    );
+    this.wordwise = true;
+    this.initialScreenRange = this.getScreenRange();
+  }
+
   // Public: Modifies the selection to encompass the current word.
   //
   // Returns a {Range}.

--- a/src/text-editor.js
+++ b/src/text-editor.js
@@ -3822,6 +3822,11 @@ module.exports = class TextEditor {
     return this.expandSelectionsForward(selection => selection.selectWord());
   }
 
+  // Extended: Select the subword surrounding each cursor.
+  selectSubwordsContainingCursors() {
+    return this.expandSelectionsForward(selection => selection.selectSubword());
+  }
+
   // Selection Extended
 
   // Extended: For each selection, move its cursor to the preceding word boundary


### PR DESCRIPTION
Pulsar already supports subword-aware cursor movement (e.g. `editor:move-to-next-subword-boundary`, `editor:move-to-previous-subword-boundary`) and incremental selection (`editor:select-to-next-subword-boundary`, `editor:select-to-previous-subword-boundary`). However, there is no command to select the entire subword that the cursor currently sits on, which is the subword analog of the existing `editor:select-word` command.