### PR TITLE
Fix some outdated links to atom api and old pulsar docs

### DIFF
--- a/dot-atom/init.js
+++ b/dot-atom/init.js
@@ -14,4 +14,4 @@
 //
 // See the Pulsar Launch manual for more information on this file and how to
 // customize it.
-// https://pulsar-edit.dev/docs/launch-manual/sections/core-hacking/#the-init-file
+// https://docs.pulsar-edit.dev/customizing-pulsar/the-init-file/

--- a/dot-atom/keymap.cson
+++ b/dot-atom/keymap.cson
@@ -24,7 +24,7 @@
 # If you're having trouble with your keybindings not working, try the
 # Keybinding Resolver: `Cmd+.` on macOS and `Ctrl+.` on other platforms. See the
 # Debugging Guide for more information:
-# * https://pulsar-edit.dev/docs/launch-manual/sections/core-hacking/#check-your-keybindings
+# * https://docs.pulsar-edit.dev/troubleshooting-pulsar/checking-your-keybindings/
 #
 # This file uses CoffeeScript Object Notation (CSON).
 # If you are unfamiliar with CSON, you can read more about it in the

--- a/dot-atom/snippets.cson
+++ b/dot-atom/snippets.cson
@@ -18,4 +18,4 @@
 # This file uses CoffeeScript Object Notation (CSON).
 # If you are unfamiliar with CSON, you can read more about it in the
 # Pulsar Launch Manual:
-# https://pulsar-edit.dev/docs/launch-manual/sections/using-pulsar/#configuring-with-cson
+# https://docs.pulsar-edit.dev/customizing-pulsar/configuring-with-cson/

--- a/src/config-schema.js
+++ b/src/config-schema.js
@@ -1,5 +1,5 @@
 // This is loaded by atom-environment.coffee. See
-// https://atom.io/docs/api/latest/Config for more information about config TODO: Link to Pulsar API site when documented
+// https://docs.pulsar-edit.dev/api/pulsar/latest/ for more information about config
 // schemas.
 const configSchema = {
   core: {

--- a/src/config.js
+++ b/src/config.js
@@ -487,7 +487,7 @@ class Config {
   //   * `scope` (optional) {ScopeDescriptor} describing a path from
   //     the root of the syntax tree to a token. Get one by calling
   //     {editor.getLastCursor().getScopeDescriptor()}. See {::get} for examples.
-  //     See [the scopes docs](https://pulsar-edit.dev/docs/launch-manual/sections/behind-pulsar#scoped-settings-scopes-and-scope-descriptors)
+  //     See [the scopes docs](https://docs.pulsar-edit.dev/infrastructure/scoped-settings/)
   //     for more information.
   // * `callback` {Function} to call when the value of the key changes.
   //   * `value` the new value of the key
@@ -506,7 +506,7 @@ class Config {
       scopeDescriptor = options.scope;
     } else {
       console.error(
-        'An unsupported form of Config::observe is being used. See https://atom.io/docs/api/latest/Config for details'
+        'An unsupported form of Config::observe is being used. See https://docs.pulsar-edit.dev/api/pulsar/latest/Config/ for details'
       );
       return;
     }
@@ -531,7 +531,7 @@ class Config {
   //   * `scope` (optional) {ScopeDescriptor} describing a path from
   //     the root of the syntax tree to a token. Get one by calling
   //     {editor.getLastCursor().getScopeDescriptor()}. See {::get} for examples.
-  //     See [the scopes docs](https://pulsar-edit.dev/docs/launch-manual/sections/behind-pulsar#scoped-settings-scopes-and-scope-descriptors)
+  //     See [the scopes docs](https://docs.pulsar-edit.dev/infrastructure/scoped-settings/)
   //     for more information.
   // * `callback` {Function} to call when the value of the key changes.
   //   * `event` {Object}
@@ -613,7 +613,7 @@ class Config {
   //   * `scope` (optional) {ScopeDescriptor} describing a path from
   //     the root of the syntax tree to a token. Get one by calling
   //     {editor.getLastCursor().getScopeDescriptor()}
-  //     See [the scopes docs](https://pulsar-edit.dev/docs/launch-manual/sections/behind-pulsar#scoped-settings-scopes-and-scope-descriptors)
+  //     See [the scopes docs](https://docs.pulsar-edit.dev/infrastructure/scoped-settings/)
   //     for more information.
   //
   // Returns the value from Pulsar's default settings, the user's configuration
@@ -720,7 +720,7 @@ class Config {
   //   setting to the default value.
   // * `options` (optional) {Object}
   //   * `scopeSelector` (optional) {String}. eg. '.source.ruby'
-  //     See [the scopes docs](https://pulsar-edit.dev/docs/launch-manual/sections/behind-pulsar#scoped-settings-scopes-and-scope-descriptors)
+  //     See [the scopes docs](https://docs.pulsar-edit.dev/infrastructure/scoped-settings/)
   //     for more information.
   //   * `source` (optional) {String} The name of a file with which the setting
   //     is associated. Defaults to the user's config file.


### PR DESCRIPTION
Just some minor updates to some links found in the main pulsar codebase.

There are plenty of other old references, branding and formatting that need to be fixed or unified but this PR targets just a few of the more obvious ones that will be exposed to users (particularly new ones).