### PR TITLE
Remove deprecated keyword from atom-ui styles

### DIFF
--- a/static/atom-ui/styles/inputs.less
+++ b/static/atom-ui/styles/inputs.less
@@ -286,7 +286,7 @@ input.input-toggle {
 .input-search {
   .input-block-mixin();
   &&::-webkit-search-cancel-button {
-    -webkit-appearance: searchfield-cancel-button;
+    -webkit-appearance: none;
   }
 
   & when (@use-custom-controls) {


### PR DESCRIPTION
Dev tools complain about:

> The keyword 'searchfield-cancel-button' used on the 'appearance' property was deprecated and has now been removed. It will no longer have any effect.

This is something that used to add a cancel button into search bars but has been deprecated and removed in chromium and was something inherited from Bootstrap 3 which atom-ui is based on.

https://chromium-review.googlesource.com/q/searchfield-cancel-button

From what I can find this was finally removed in chromium 124 which the current version of Pulsar is also using.

Most sources I could find recommended just replacing it with `-webkit-appearance: none` as the simplest way to fix as the feature itself is already non-functional (so far as I could find and prove at least).