### PR TITLE
Bump `@pulsar-edit/fuzzy-native` to 1.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@electron/remote": "2.1.2",
     "@formatjs/fast-memoize": "^2.2.6",
     "@pulsar-edit/atom-keymap": "^9.1.0",
-    "@pulsar-edit/fuzzy-native": "1.3.0",
+    "@pulsar-edit/fuzzy-native": "1.3.1",
     "@pulsar-edit/get-scrollbar-style": "^1.0.1",
     "@pulsar-edit/git-utils": "^7.0.1",
     "@pulsar-edit/pathwatcher": "^9.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1684,10 +1684,10 @@
     property-accessors "^1"
     season "^6.0.2"
 
-"@pulsar-edit/fuzzy-native@1.3.0":
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/@pulsar-edit/fuzzy-native/-/fuzzy-native-1.3.0.tgz#e163ab6f5ca2508493e27d417e93f67672df2ea1"
-  integrity sha512-vENyad38rMcgJZBiNf/Q0+y4fCrepj1MNwFnyf7ejqEJBFMrKCzJ77jtkvx1gNzSasjOfK3oHuJ2w7TMoFKj2g==
+"@pulsar-edit/fuzzy-native@1.3.1":
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/@pulsar-edit/fuzzy-native/-/fuzzy-native-1.3.1.tgz#fb1e5828408b2d2ade8f51e451862e1675c42d89"
+  integrity sha512-IQZRHllYhXTnAdI4ebaIh+cUid8DIyFri6cdKmNIY9so5j7Y7YdeBE7tno6GwkKjfT3OBXBRDS46dCeKuSljQQ==
   dependencies:
     nan "^2.18.0"
 


### PR DESCRIPTION
Fixes an annoyance with building Pulsar! Nice-to-have for 1.132.0, but isn't critical.

[fuzzy-native#8](https://github.com/pulsar-edit/fuzzy-native/issues/8) describes the issue (which was fixed by [fuzzy-native#9](https://github.com/pulsar-edit/fuzzy-native/pull/9) and published in 1.3.1).