### PR TITLE
[autocomplete-plus] Ensure editor is re-focused…

### DIFF
--- a/packages/autocomplete-plus/lib/suggestion-list.js
+++ b/packages/autocomplete-plus/lib/suggestion-list.js
@@ -326,7 +326,8 @@ class SuggestionList {
     } else if (this.overlayDecoration && this.overlayDecoration.destroy) {
       this.overlayDecoration.destroy()
     }
-    const editorElement = atom.views.getView(this.activeEditor)
+    const activeEditor = this.activeEditor
+    const editorElement = atom.views.getView(activeEditor)
     if (editorElement && editorElement.classList) {
       let timestamp = this.lastActiveAt
       atom.views.updateDocument(() => {
@@ -335,8 +336,11 @@ class SuggestionList {
         if (this.lastActiveAt > timestamp) return
         editorElement.classList.remove('autocomplete-active')
         // If the user clicked on the suggestion, focus moved onto the overlay
-        // before it was destroyed, so we'll move it back onto the editor.
-        editorElement.focus()
+        // before it was destroyed, so we'll move it back onto the editor. But
+        // first we ensure that this is still the active editor!
+        if (atom.workspace.getActiveTextEditor() === activeEditor) {
+          editorElement.focus()
+        }
       })
     }
     this.suggestionMarker = undefined

--- a/packages/autocomplete-plus/lib/suggestion-list.js
+++ b/packages/autocomplete-plus/lib/suggestion-list.js
@@ -334,6 +334,9 @@ class SuggestionList {
         // shouldn't remove this class name anymore.
         if (this.lastActiveAt > timestamp) return
         editorElement.classList.remove('autocomplete-active')
+        // If the user clicked on the suggestion, focus moved onto the overlay
+        // before it was destroyed, so we'll move it back onto the editor.
+        editorElement.focus()
       })
     }
     this.suggestionMarker = undefined

--- a/packages/autocomplete-plus/spec/autocomplete-manager-integration-spec.js
+++ b/packages/autocomplete-plus/spec/autocomplete-manager-integration-spec.js
@@ -2350,7 +2350,7 @@ defm`
       expect(items[0].innerText.trim()).toEqual('center')
     })
 
-    it('stops providing autocompletions when disposed.', async () => {
+    it('stops providing autocompletions when disposed', async () => {
       autocompleteDisposable.dispose()
       bottomEditorView.focus()
       triggerAutocompletion(bottomEditor)

--- a/packages/autocomplete-plus/spec/autocomplete-manager-integration-spec.js
+++ b/packages/autocomplete-plus/spec/autocomplete-manager-integration-spec.js
@@ -17,6 +17,12 @@ const path = require('path')
 
 let NodeTypeText = 3
 
+function simulateClick(element) {
+  element.dispatchEvent(new PointerEvent('mousedown', { bubbles: true, cancelable: true }));
+  element.dispatchEvent(new PointerEvent('mouseup', { bubbles: true, cancelable: true }));
+  element.dispatchEvent(new PointerEvent('click', { bubbles: true, cancelable: true }));
+}
+
 describe('Autocomplete Manager', () => {
   let autocompleteManager, editor, editorView, gutterWidth, mainModule, workspaceElement
 
@@ -141,7 +147,7 @@ describe('Autocomplete Manager', () => {
       expect(editorView.querySelector('.autocomplete-plus')).not.toExist()
     })
 
-    it('it refocuses the editor after pressing enter', async () => {
+    it('refocuses the editor after pressing enter', async () => {
       expect(editorView.querySelector('.autocomplete-plus')).not.toExist()
       editor.insertText('a')
       await waitForAutocomplete(editor)
@@ -1309,6 +1315,30 @@ describe('Autocomplete Manager', () => {
         atom.commands.dispatch(suggestionListView, 'autocomplete-plus:confirm')
 
         expect(editorView.querySelector('.autocomplete-plus')).not.toExist()
+      })
+
+      it('hides the suggestions list when a suggestion is clicked on', async () => {
+        triggerAutocompletion(editor, false, 'a')
+        await waitForAutocomplete(editor)
+
+        expect(editorView.querySelector('.autocomplete-plus')).toExist()
+
+        // Accept suggestion
+        let suggestionListView = editorView.querySelector('.autocomplete-plus autocomplete-suggestion-list')
+        let firstOption = suggestionListView.querySelector('li')
+
+        // Manually blurring the editor here matches our observation that, when
+        // an actual human clicks on a suggestion, it blurs the editor and ends
+        // up focusing the BODY indirectly.
+        document.activeElement.blur()
+        simulateClick(firstOption)
+
+        // Ensure the menu is closed…
+        expect(editorView.querySelector('.autocomplete-plus')).not.toExist()
+        // …and our editor still has focus.
+        await conditionPromise(() => {
+          return document.activeElement.closest('atom-text-editor') === editorView
+        })
       })
 
       describe('when the replacementPrefix is empty', () => {


### PR DESCRIPTION
…after the user selects a suggestion via the mouse.

@DeeDeeG observed this one in Discord and I was able to reproduce it, so I thought I'd get to the bottom of it while my attention span allowed me to!

Easy fix, ~~but I have not written tests, nor have I investigated how easily this could be tested in automated fashion. We'd have to simulate a click with enough fidelity that the focus actually moved onto the suggestion element. I might return to this to write the spec later, or someone might manually verify it and then approve it before I get around to it!~~ _(**EDIT:** Spec has been written!)_

### Testing

1. Trigger the autocompletion menu in an editor.
2. Instead of confirming a choice via the keyboard, click on the choice you want via the mouse/trackpad.
3. Without doing anything else, immediately start typing.

On `master`, nothing will happen, because focus isn't actually in the editor (even though you can see the cursor blinking).

On this PR branch, focus should return to the editor immediately so you can continue typing.