### PR TITLE
Fixed opening up diffs for a worktree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ## [Unreleased]
 
+* Fix an issue where opening up git worktree doesn't show any git info on the editor
+
 ## 1.131.3
 
 * [settings-view] Fix regression with rendering badges on package search results.

--- a/src/git-repository-provider.js
+++ b/src/git-repository-provider.js
@@ -129,7 +129,9 @@ async function isValidGitDirectory(directory) {
   const commonDirFile = directory.getSubdirectory('commondir');
   let commonDir;
   if (await commonDirFile.exists()) {
-    const commonDirPathBuff = await fs.readFile(commonDirFile.getPath());
+    const commonDirPathBuff = await fs.promises.readFile(
+      commonDirFile.getPath()
+    );
     const commonDirPathString = commonDirPathBuff.toString().trim();
     commonDir = new Directory(directory.resolve(commonDirPathString));
     if (!(await commonDir.exists())) {
@@ -141,7 +143,7 @@ async function isValidGitDirectory(directory) {
   return (
     (await directory.getFile('HEAD').exists()) &&
     (await commonDir.getSubdirectory('objects').exists()) &&
-    commonDir.getSubdirectory('refs').exists()
+    (await commonDir.getSubdirectory('refs').exists())
   );
 }
 


### PR DESCRIPTION
I started to use worktrees at my job, and found that Pulsar wasn't showing any git info on worktrees. 

Also migrated `readFile` to the promises `fs` version, which is supposed to be more stable (we can do that now that we migrated to Electron 30).