### PR TITLE
Bump version (dummy PR to trick CirrusCI)

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "pulsar",
   "author": "Pulsar-Edit <admin@pulsar-edit.dev>",
   "productName": "Pulsar",
-  "version": "1.131.3-dev",
+  "version": "1.132.0",
   "description": "A Community-led Hyper-Hackable Text Editor",
   "branding": {
     "id": "pulsar",


### PR DESCRIPTION
**Ignore for all purposes except tricking CirrusCI into generating an ARM Linux binary for 1.132.0 release.**