### PR TITLE
Chore: Update licence copyright year

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022-2024 Pulsar-Edit
+Copyright (c) 2022-2026 Pulsar-Edit
 Original work copyright (c) 2011-2022 GitHub Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy


### PR DESCRIPTION
Looks like we missed two of these, better late than never.