### PR TITLE
Fix: Add UI scrollbar variable fallbacks

### DIFF
--- a/static/variables/ui-variables.less
+++ b/static/variables/ui-variables.less
@@ -57,8 +57,8 @@
 @tree-view-background-color: @tool-panel-background-color;
 @tree-view-border-color: @tool-panel-border-color;
 
-@scrollbar-color: @app-background-color;
-@scrollbar-background-color: @background-color-highlight;
+@scrollbar-color: @background-color-highlight;
+@scrollbar-background-color: @app-background-color;
 
 @ui-site-color-1: @background-color-success; // green
 @ui-site-color-2: @background-color-info; // blue

--- a/static/variables/ui-variables.less
+++ b/static/variables/ui-variables.less
@@ -57,6 +57,9 @@
 @tree-view-background-color: @tool-panel-background-color;
 @tree-view-border-color: @tool-panel-border-color;
 
+@scrollbar-color: @app-background-color;
+@scrollbar-background-color: @background-color-highlight;
+
 @ui-site-color-1: @background-color-success; // green
 @ui-site-color-2: @background-color-info; // blue
 @ui-site-color-3: @background-color-warning; // orange


### PR DESCRIPTION
Fixes https://github.com/pulsar-edit/terminal/issues/30 and https://github.com/pulsar-edit/pulsar/issues/1565

`terminal` specifies:

```less
 --terminal-scrollbar-background-color: color(@scrollbar-background-color); 
 --terminal-scrollbar-color: color(@scrollbar-color); 
```

But it seems prior to adding `terminal` to core, these were only ever needed as variables within the inbuilt themes and so had no fallback.

This adds what I think are some sane fallbacks based on a couple of themes I looked at so that they don't look obviously wrong. At the very least it doesn't cause Pulsar to freak out when starting.