### PR TITLE
Fix the `--target`/`-t` option of `yarn dist`…

### DIFF
--- a/script/electron-builder.js
+++ b/script/electron-builder.js
@@ -425,14 +425,12 @@ function whatToBuild() {
   if (!platform) {
     throw new Error(`Unrecognized platform: ${platform}`);
   }
-  let filteredOptions = { [platform]: options[platform] };
-  if (!ARGS.target) {
-    return filteredOptions;
+  if (ARGS.target) {
+    options[platform].target = options[platform].target.filter(
+      e => e.target === ARGS.target
+    );
   }
-  filteredOptions[platform].target = filteredOptions[platform].target.filter(
-    e => e.target === ARGS.target
-  );
-  return filteredOptions;
+  return options;
 }
 
 function generateVersionNumber(existingVersion, channel = '') {

--- a/script/electron-builder.js
+++ b/script/electron-builder.js
@@ -78,15 +78,9 @@ async function modifyMainPackageJson(
 
 // END Monkey-patch.
 
-// eslint-disable-next-line node/no-unpublished-require
 const builder = require('electron-builder');
 
 const ARGS = yargs(hideBin(process.argv))
-  .command('[platform]', 'build for a given platform', () => {
-    return yargs.positional('platform', {
-      describe: 'One of "mac", "linux", or "win".'
-    })
-  })
   .option('target', {
     alias: 't',
     type: 'string',
@@ -98,7 +92,6 @@ const ARGS = yargs(hideBin(process.argv))
     description: 'Builds a "canary" with a separate bundle identifier and app name so it can run alongside ordinary Pulsar.'
   })
   .parse();
-
 
 // The difference in base name matters for the app ID (which helps the OS
 // understand that PulsarNext is not the same as Pulsar), but also for other
@@ -119,7 +112,6 @@ const ICONS = {
   svg: `resources/app-icons/${iconName}.svg`,
   icns: `resources/app-icons/${iconName}.icns`
 };
-
 
 let options = {
   appId: `dev.pulsar-edit.${baseName}`,
@@ -352,7 +344,11 @@ let options = {
     extraResources: [
       { from: 'ppm/bin/ppm', to: `app/ppm/bin/${ppmBaseName}` },
       { from: 'ppm/bin/node', to: `app/ppm/bin/node` }
-    ]
+    ],
+    target: [
+      { target: 'dmg' },
+      { target: 'zip' }
+    ],
   },
 
   dmg: {
@@ -418,11 +414,25 @@ if (ARGS.next) {
   delete options.nsis.guid;
 }
 
+const PLATFORMS = {
+  darwin: 'mac',
+  win32: 'win',
+  linux: 'linux'
+};
+
 function whatToBuild() {
-  if (!ARGS.target) return options;
-  if (!(ARGS.platform in options)) return options;
-  options[ARGS.platform] = options[ARGS.platform].filter(e => e.target === ARGS.target);
-  return options;
+  let platform = PLATFORMS[process.platform];
+  if (!platform) {
+    throw new Error(`Unrecognized platform: ${platform}`);
+  }
+  let filteredOptions = { [platform]: options[platform] };
+  if (!ARGS.target) {
+    return filteredOptions;
+  }
+  filteredOptions[platform].target = filteredOptions[platform].target.filter(
+    e => e.target === ARGS.target
+  );
+  return filteredOptions;
 }
 
 function generateVersionNumber(existingVersion, channel = '') {

--- a/script/electron-builder.js
+++ b/script/electron-builder.js
@@ -426,9 +426,12 @@ function whatToBuild() {
     throw new Error(`Unrecognized platform: ${platform}`);
   }
   if (ARGS.target) {
-    options[platform].target = options[platform].target.filter(
-      e => e.target === ARGS.target
-    );
+    let targets = ARGS.target.split(',');
+    // Replace the `target` array with the targets provided by the user. It's
+    // up to the user to ensure these are valid targets for the given platform.
+    options[platform].target = targets.map(t => {
+      return { target: t }
+    });
   }
   return options;
 }


### PR DESCRIPTION
…and eliminate the positional `[platform]` argument.


I thought I’d have a crack at revisiting #1397 with a bit more care. We already have code for deciding which targets to build; it just misfires a bit.

1. All experimentation I’ve done suggests that you can’t actually do a cross-platform build. So the optional/positional `platform` argument (which never worked anyway because we used `yargs` wrong) is eliminated. We’ll just filter the options to include only the platform you’re actually on, since that’s what happens in effect anyway.
2. Since `platform` wasn’t implemented properly, the `target` keyword switch didn’t work either, since `whatToBuild` bailed early when `platform` was missing. And then we didn’t filter targets correctly anyway, so that needed fixing as well.
3. #1397’s target names overlapped only somewhat with the official target names from `electron-builder`. This time around I’m just reusing the target names that are already defined.

~~`--target` still accepts only one target — but if people want it to accept multiple (e.g., `--target=rpm,tar.gz`), that could be accomplished rather easily.~~ _(Now it supports multiple comma-separated targets.)_

## Testing

This works just fine in my experiments, but please feel free to test it out with commands like

```
yarn dist --target=dmg
```

or an appropriate target for your platform.
