### PR TITLE
Change `Pane::saveItems` to return a promise…

### DIFF
--- a/spec/pane-spec.js
+++ b/spec/pane-spec.js
@@ -4,6 +4,13 @@ const Grim = require('grim');
 const Pane = require('../src/pane');
 const PaneContainer = require('../src/pane-container');
 const { conditionPromise, timeoutPromise } = require('./helpers/async-spec-helpers');
+const fs = require('fs');
+const path = require('path');
+const temp = require('temp').track();
+
+async function wait (ms) {
+  return new Promise(r => setTimeout(r, ms));
+}
 
 describe('Pane', () => {
   let confirm, showSaveDialog, deserializerDisposable;
@@ -1721,6 +1728,52 @@ describe('Pane', () => {
 
       const newPane = Pane.deserialize(pane.serialize(), atom);
       expect(newPane.itemStack).toEqual([item2, item1, item3]);
+    });
+  });
+
+  describe('::saveItems', () => {
+    let editor1, editor2;
+    let filePath1, filePath2;
+    let bufferSubscription;
+    let pane;
+    beforeEach(async () => {
+      const tempDir = temp.mkdirSync({ prefix: 'atom-test-pane-' });
+      let fixturePath = path.join(__dirname, 'fixtures', 'sample.js');
+      filePath1 = path.join(tempDir, 'sample1.js');
+      filePath2 = path.join(tempDir, 'sample2.js');
+      fs.copyFileSync(fixturePath, filePath1);
+      fs.copyFileSync(fixturePath, filePath2);
+
+      editor1 = await atom.workspace.open(filePath1);
+      editor2 = await atom.workspace.open(filePath2);
+
+      pane = atom.workspace.paneForItem(editor1);
+      expect(atom.workspace.paneForItem(editor2)).toBe(pane);
+
+      bufferSubscription = editor2.getBuffer().onWillSave(async () => {
+        await wait(300);
+      });
+    });
+
+    afterEach(() => {
+      editor1?.destroy();
+      editor2?.destroy();
+      bufferSubscription?.dispose();
+    });
+
+    it('waits for all items to save before resolving', async () => {
+      jasmine.useRealClock();
+      for (let editor of [editor1, editor2]) {
+        editor.setCursorBufferPosition([Infinity, Infinity]);
+        editor.insertText('\n');
+      }
+
+      let saveItemsPromise = pane.saveItems();
+      expect(saveItemsPromise instanceof Promise).toBe(true);
+      expect(editor2.getBuffer().isModified()).toBe(true);
+
+      await saveItemsPromise;
+      expect(editor2.getBuffer().isModified()).toBe(false);
     });
   });
 });

--- a/src/pane.js
+++ b/src/pane.js
@@ -1138,13 +1138,17 @@ module.exports = class Pane {
     return saveDialogPromise;
   }
 
-  // Public: Save all items.
-  saveItems() {
+  // Public: Save all modified items in this pane.
+  //
+  // Returns a {Promise} that resolves when all items have been saved.
+  async saveItems() {
+    let promises = [];
     for (let item of this.getItems()) {
       if (typeof item.isModified === 'function' && item.isModified()) {
-        this.saveItem(item);
+        promises.push(this.saveItem(item));
       }
     }
+    return await Promise.all(promises);
   }
 
   // Public: Return the first item that matches the given URI or undefined if


### PR DESCRIPTION
…that resolves when all items have been saved.

I was doing some tending of the `types` repo and looking over our documentation for `Pane`. I realized that nearly all of our pane methods related to saving items returned promises — `Pane::saveItem`, `Pane::saveActiveItem`, `Pane::saveItemAs`, `Pane::saveActiveItemAs`. This reflects the fact that saving can go async for a couple of reasons:

* First, we might need to prompt the user if the item is conflicted to see how they want to handle the conflict.
* The `save` method on a pane item anticipates that saving itself might be an async process. (For instance: anything can attach an async `onWillSave` callback to a `TextBuffer`; when `TextBuffer::save` is called, it does not resolve until all those async callbacks resolve.)

So it's weird to me that `Pane::saveItems` _doesn't_ go async. When called, it finds all the items that need saving in a given pane (the ones for whom `isModified` is defined and returns `true`) and then calls `Pane::saveItem` on each in turn. But then it just returns!

I don't have a specific use case in mind, but it took me all of 15 minutes to enhance `Pane::saveItems` so that it goes async and doesn't resolve until all modified items in the pane have finished saving. This should have no effect on existing usages of `saveItems`, since that function did not have any return value previously.

### Testing

I added a new spec in the `Pane` suite; if CI likes it, that should be good enough to prove that this works.

The spec was added in isolation in the first commit of this PR; so if you like, you can check out that commit and run the new spec in order to verify that it fails. Then you can check out the second commit to verify that the new spec passes.