### PR TITLE
Temporarily point `@pulsar-edit/pathwatcher` to a branch…

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@pulsar-edit/fuzzy-native": "1.3.1",
     "@pulsar-edit/get-scrollbar-style": "^1.0.1",
     "@pulsar-edit/git-utils": "^7.0.1",
-    "@pulsar-edit/pathwatcher": "^9.0.2",
+    "@pulsar-edit/pathwatcher": "https://github.com/pulsar-edit/node-pathwatcher.git#6614e3cfce63935ce1c8d0b82b465fa693370176",
     "@pulsar-edit/scandal": "^4.0.0",
     "@pulsar-edit/superstring": "^3.0.5",
     "@pulsar-edit/text-buffer": "^14.0.4",
@@ -320,7 +320,7 @@
     "es5-ext": "https://github.com/pulsar-edit/es5-ext#169f6ae9b2675675269a0ba265f83c29c7b56244",
     "@electron/remote": "2.1.2",
     "@pulsar-edit/superstring": "3.0.5",
-    "@pulsar-edit/pathwatcher": "9.0.3",
+    "@pulsar-edit/pathwatcher": "https://github.com/pulsar-edit/node-pathwatcher.git#6614e3cfce63935ce1c8d0b82b465fa693370176",
     "**/underscore-plus": "npm:@pulsar-edit/underscore-plus@1.8.3"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1746,10 +1746,9 @@
     unbzip2-stream "^1.4.3"
     yauzl "^3.2.0"
 
-"@pulsar-edit/pathwatcher@9.0.3", "@pulsar-edit/pathwatcher@^9.0.2":
-  version "9.0.3"
-  resolved "https://registry.yarnpkg.com/@pulsar-edit/pathwatcher/-/pathwatcher-9.0.3.tgz#13dcbdbf4115904bfdf76509580612cf09e8043c"
-  integrity sha512-S8QwhsUf/x617g6FEuPixdu1c3Mt4kzZsGaTrbogkaCJuY1mMAEkqkp6zEp4MM+UfWFruRszAOkdZYbI5gWW9Q==
+"@pulsar-edit/pathwatcher@^9.0.2", "@pulsar-edit/pathwatcher@https://github.com/pulsar-edit/node-pathwatcher.git#6614e3cfce63935ce1c8d0b82b465fa693370176":
+  version "9.0.4"
+  resolved "https://github.com/pulsar-edit/node-pathwatcher.git#6614e3cfce63935ce1c8d0b82b465fa693370176"
   dependencies:
     async "~0.2.10"
     emissary "^1.3.2"


### PR DESCRIPTION
…to see if it fixes a crash.

This is the PR I made reference to in #1592 — the one that points to the version of `pathwatcher` from https://github.com/pulsar-edit/node-pathwatcher/pull/7. Once it produces binaries, we'll find out if it fixes the crash some people are experiencing on Linux.