### PR TITLE
Pin to `windows-2022` when building binaries

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ macos-14, ubuntu-24.04-arm, ubuntu-latest, windows-latest ]
+        os: [ macos-14, ubuntu-24.04-arm, ubuntu-latest, windows-2022 ]
         node-architecture: [ '' ]
         include:
           - os: macos-14


### PR DESCRIPTION
GitHub updated the `windows-latest` images to use Visual Studio 2026 instead of 2022. So the step that installs the Windows 10 SDK by hard-coding `C:\Program Files\Microsoft Visual Studio\2022\Enterprise` is bound to fail.

We could fix this by updating the path, but it's not clear yet that the Windows 10 SDK is even available anymore from the Visual Studio 2026 installer. So pinning to `windows-2022` is the clearer short-term fix. The rest can wait until someone smarter at devops (like @DeeDeeG) can take a look at this.