### PR TITLE
Pin to specific `node-gyp`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -134,11 +134,11 @@ jobs:
       if: ${{ runner.os == 'Windows' }}
       run: (Get-Content package.json) -replace '[0-9]*-dev', (date -u +%Y%m%d%H) | Set-Content -Path package.json
 
-    - name: Reinstall Current Node-GYP NodeJS Headers
-      # Overwrite bad headers that get downloaded.
-      # NodeJS versions above 16 should come with `node-gyp@9.4.0` that has a fix
-      # for this issue. At that point this additional step can be removed.
-      run: npx node-gyp@12.4.0 install ${{ env.NODE_VERSION }}
+    # - name: Reinstall Current Node-GYP NodeJS Headers
+    #   # Overwrite bad headers that get downloaded.
+    #   # NodeJS versions above 16 should come with `node-gyp@9.4.0` that has a fix
+    #   # for this issue. At that point this additional step can be removed.
+    #   run: npx node-gyp@11.t.0 install ${{ env.NODE_VERSION }}
 
     - name: Explicitly Specify Python Path (Windows)
       if: ${{ runner.os == 'Windows' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -138,7 +138,7 @@ jobs:
       # Overwrite bad headers that get downloaded.
       # NodeJS versions above 16 should come with `node-gyp@9.4.0` that has a fix
       # for this issue. At that point this additional step can be removed.
-      run: npx node-gyp install ${{ env.NODE_VERSION }}
+      run: npx node-gyp@12.4.0 install ${{ env.NODE_VERSION }}
 
     - name: Explicitly Specify Python Path (Windows)
       if: ${{ runner.os == 'Windows' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -134,12 +134,6 @@ jobs:
       if: ${{ runner.os == 'Windows' }}
       run: (Get-Content package.json) -replace '[0-9]*-dev', (date -u +%Y%m%d%H) | Set-Content -Path package.json
 
-    # - name: Reinstall Current Node-GYP NodeJS Headers
-    #   # Overwrite bad headers that get downloaded.
-    #   # NodeJS versions above 16 should come with `node-gyp@9.4.0` that has a fix
-    #   # for this issue. At that point this additional step can be removed.
-    #   run: npx node-gyp@11.t.0 install ${{ env.NODE_VERSION }}
-
     - name: Explicitly Specify Python Path (Windows)
       if: ${{ runner.os == 'Windows' }}
       # The Windows image somehow gets confused about which Python it should


### PR DESCRIPTION
CI has started complaining about our request to install a version of `node-gyp` that isn't actually compatible with the version of Node we're using.

As a bugfix, we had been installing a purposefully brand-new version of `node-gyp` atop the specific Node installation we used for building the binaries. The comment itself on that job step says that it can be removed once we're on `node-gyp` 9.4.0 or later, so I've taken its advice! We probably could've done this months ago and saved a bit of time on each job.