### PR TITLE
Fix Markdown table-of-contents links

### DIFF
--- a/packages/markdown-preview/lib/markdown-preview-view.js
+++ b/packages/markdown-preview/lib/markdown-preview-view.js
@@ -23,6 +23,7 @@ module.exports = class MarkdownPreviewView {
     this.loaded = false
     this.disposables = new CompositeDisposable()
     this.registerScrollCommands()
+    this.registerAnchorScrolling()
     if (this.editorId != null) {
       this.resolveEditor(this.editorId)
     } else if (atom.packages.hasActivatedInitialPackages()) {
@@ -81,6 +82,40 @@ module.exports = class MarkdownPreviewView {
         }
       })
     )
+  }
+
+  // Pulsar's global link handler prevents native fragment navigation.
+  registerAnchorScrolling() {
+    const handleClick = event => this.scrollToAnchor(event)
+    this.element.addEventListener('click', handleClick)
+    this.disposables.add(
+      new Disposable(() =>
+        this.element.removeEventListener('click', handleClick)
+      )
+    )
+  }
+
+  scrollToAnchor(event) {
+    const anchor = event.target.closest('a[href^="#"]')
+    if (anchor == null) return
+
+    let id = anchor.getAttribute('href').slice(1)
+    try {
+      id = decodeURIComponent(id)
+    } catch (error) {
+      // Fall back to the raw fragment.
+    }
+    if (!id) return
+
+    // Prefer generated heading ids over colliding raw ids.
+    const prefixedId = `user-content-${id}`
+    const target =
+      this.element.querySelector(`[id="${CSS.escape(prefixedId)}"]`) ??
+      this.element.querySelector(`[id="${CSS.escape(id)}"]`)
+    if (target == null) return
+
+    event.preventDefault()
+    target.scrollIntoView()
   }
 
   onDidChangeTitle(callback) {

--- a/packages/markdown-preview/lib/renderer.js
+++ b/packages/markdown-preview/lib/renderer.js
@@ -4,7 +4,7 @@ const createDOMPurify = require('dompurify')
 const emoji = require('emoji-images')
 const fs = require('fs-plus')
 let marked = null // Defer until used
-let GithubSlugger = null
+let githubSlugger = null
 let innertext = null
 let renderer = null
 let cheerio = null
@@ -174,26 +174,26 @@ exports.toHTML = async function (text, filePath, grammar) {
 function render(text, filePath) {
   if (marked == null || yamlFrontMatter == null || cheerio == null) {
     marked = require('marked')
-    GithubSlugger = require('github-slugger')
+    const GithubSlugger = require('github-slugger')
     innertext = require('innertext')
     yamlFrontMatter = require('yaml-front-matter')
     cheerio = require('cheerio')
 
     renderer = new marked.Renderer()
+    githubSlugger = new GithubSlugger()
     renderer.listitem = function (text, isTask) {
       const listAttributes = isTask ? ' class="task-list-item"' : ''
 
       return `<li ${listAttributes}>${text}</li>\n`
     }
+    renderer.heading = function (text, level) {
+      const headingText = innertext(text)
+      const id = `user-content-${githubSlugger.slug(headingText)}`
+      return `<h${level} id="${id}">${text}</h${level}>\n`
+    }
   }
 
-  const githubSlugger = new GithubSlugger()
-  renderer.heading = function (text, level) {
-    const headingText = innertext(text)
-    const id = `user-content-${githubSlugger.slug(headingText)}`
-    return `<h${level} id="${id}">${text}</h${level}>\n`
-  }
-
+  githubSlugger.reset()
   marked.setOptions({
     breaks: atom.config.get('markdown-preview.breakOnSingleNewline'),
     renderer

--- a/packages/markdown-preview/lib/renderer.js
+++ b/packages/markdown-preview/lib/renderer.js
@@ -4,6 +4,8 @@ const createDOMPurify = require('dompurify')
 const emoji = require('emoji-images')
 const fs = require('fs-plus')
 let marked = null // Defer until used
+let GithubSlugger = null
+let innertext = null
 let renderer = null
 let cheerio = null
 let yamlFrontMatter = null
@@ -108,6 +110,7 @@ function chooseRender(text, filePath) {
       filePath: filePath,
       breaks: atom.config.get('markdown-preview.breakOnSingleNewline'),
       useDefaultEmoji: true,
+      useGitHubHeadings: true,
       sanitizeAllowUnknownProtocols: atom.config.get('markdown-preview.allowUnsafeProtocols')
     })
     return atom.ui.markdown.convertToDOM(html)
@@ -171,6 +174,8 @@ exports.toHTML = async function (text, filePath, grammar) {
 function render(text, filePath) {
   if (marked == null || yamlFrontMatter == null || cheerio == null) {
     marked = require('marked')
+    GithubSlugger = require('github-slugger')
+    innertext = require('innertext')
     yamlFrontMatter = require('yaml-front-matter')
     cheerio = require('cheerio')
 
@@ -180,6 +185,13 @@ function render(text, filePath) {
 
       return `<li ${listAttributes}>${text}</li>\n`
     }
+  }
+
+  const githubSlugger = new GithubSlugger()
+  renderer.heading = function (text, level) {
+    const headingText = innertext(text)
+    const id = `user-content-${githubSlugger.slug(headingText)}`
+    return `<h${level} id="${id}">${text}</h${level}>\n`
   }
 
   marked.setOptions({

--- a/packages/markdown-preview/package-lock.json
+++ b/packages/markdown-preview/package-lock.json
@@ -15,6 +15,8 @@
         "emoji-images": "^0.1.1",
         "fs-plus": "^3.0.0",
         "github-markdown-css": "^5.5.1",
+        "github-slugger": "^1.1.1",
+        "innertext": "^1.0.1",
         "marked": "5.0.3",
         "morphdom": "^2.7.2",
         "underscore-plus": "^1.0.0",
@@ -276,6 +278,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/github-slugger": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-1.5.0.tgz",
+      "integrity": "sha512-wIh+gKBI9Nshz2o46B0B3f5k/W+WI9ZAv6y5Dn5WJ5SK1t0TnDimB4WE5rmTD05ZAIn8HALCZVmCsvj0w0v0lw==",
+      "license": "ISC"
+    },
     "node_modules/glob": {
       "version": "7.1.3",
       "license": "ISC",
@@ -290,6 +298,12 @@
       "engines": {
         "node": "*"
       }
+    },
+    "node_modules/html-entities": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-1.4.0.tgz",
+      "integrity": "sha512-8nxjcBcd8wovbeKx7h3wTji4e6+rhaVuPNpMqwWgnHh+N9ToqsCs6XztWRBPQ+UtzsoMAdKZtUENoVzU/EMtZA==",
+      "license": "MIT"
     },
     "node_modules/htmlparser2": {
       "version": "9.1.0",
@@ -331,6 +345,15 @@
     "node_modules/inherits": {
       "version": "2.0.3",
       "license": "ISC"
+    },
+    "node_modules/innertext": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/innertext/-/innertext-1.0.3.tgz",
+      "integrity": "sha512-ZC410b7IbrTrmt8bQb27xUOJgXkJu+XL6MVncb9FGyxjRIHyQqNjpSDY20zvSUttkAiYj0dait/67/sXyWvwYg==",
+      "license": "ISC",
+      "dependencies": {
+        "html-entities": "^1.2.0"
+      }
     },
     "node_modules/js-yaml": {
       "version": "3.14.1",
@@ -719,6 +742,11 @@
       "resolved": "https://registry.npmjs.org/github-markdown-css/-/github-markdown-css-5.5.1.tgz",
       "integrity": "sha512-2osyhNgFt7DEHnGHbgIifWawAqlc68gjJiGwO1xNw/S48jivj8kVaocsVkyJqUi3fm7fdYIDi4C6yOtcqR/aEQ=="
     },
+    "github-slugger": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-1.5.0.tgz",
+      "integrity": "sha512-wIh+gKBI9Nshz2o46B0B3f5k/W+WI9ZAv6y5Dn5WJ5SK1t0TnDimB4WE5rmTD05ZAIn8HALCZVmCsvj0w0v0lw=="
+    },
     "glob": {
       "version": "7.1.3",
       "requires": {
@@ -729,6 +757,11 @@
         "once": "^1.3.0",
         "path-is-absolute": "^1.0.0"
       }
+    },
+    "html-entities": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-1.4.0.tgz",
+      "integrity": "sha512-8nxjcBcd8wovbeKx7h3wTji4e6+rhaVuPNpMqwWgnHh+N9ToqsCs6XztWRBPQ+UtzsoMAdKZtUENoVzU/EMtZA=="
     },
     "htmlparser2": {
       "version": "9.1.0",
@@ -758,6 +791,14 @@
     },
     "inherits": {
       "version": "2.0.3"
+    },
+    "innertext": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/innertext/-/innertext-1.0.3.tgz",
+      "integrity": "sha512-ZC410b7IbrTrmt8bQb27xUOJgXkJu+XL6MVncb9FGyxjRIHyQqNjpSDY20zvSUttkAiYj0dait/67/sXyWvwYg==",
+      "requires": {
+        "html-entities": "^1.2.0"
+      }
     },
     "js-yaml": {
       "version": "3.14.1",

--- a/packages/markdown-preview/package.json
+++ b/packages/markdown-preview/package.json
@@ -19,6 +19,8 @@
     "emoji-images": "^0.1.1",
     "fs-plus": "^3.0.0",
     "github-markdown-css": "^5.5.1",
+    "github-slugger": "^1.1.1",
+    "innertext": "^1.0.1",
     "marked": "5.0.3",
     "morphdom": "^2.7.2",
     "underscore-plus": "^1.0.0",

--- a/packages/markdown-preview/spec/markdown-preview-view-spec.js
+++ b/packages/markdown-preview/spec/markdown-preview-view-spec.js
@@ -117,6 +117,20 @@ describe('MarkdownPreviewView', function () {
       expect(htmlTarget).not.toBeNull()
     })
 
+    it('resets original parser heading ids between renders', async function () {
+      atom.config.set('markdown-preview.useOriginalParser', true)
+      const markdown = ['## Repeated', '', '## Repeated'].join('\n')
+
+      const firstRender = await renderer.toHTML(markdown)
+      const secondRender = await renderer.toHTML(markdown)
+
+      for (const html of [firstRender, secondRender]) {
+        expect(html).toContain('id="user-content-repeated"')
+        expect(html).toContain('id="user-content-repeated-1"')
+        expect(html).not.toContain('id="user-content-repeated-2"')
+      }
+    })
+
     it('prefers the generated prefixed id over a colliding raw id', function () {
       preview.element.innerHTML = [
         '<a href="#user-content-foo">User content foo</a>',

--- a/packages/markdown-preview/spec/markdown-preview-view-spec.js
+++ b/packages/markdown-preview/spec/markdown-preview-view-spec.js
@@ -10,6 +10,7 @@ const temp = require('temp').track()
 const url = require('url')
 const { TextEditor } = require('atom')
 const MarkdownPreviewView = require('../lib/markdown-preview-view')
+const renderer = require('../lib/renderer')
 const TextMateLanguageMode = new TextEditor().getBuffer().getLanguageMode()
   .constructor
 const { conditionPromise } = require('./async-spec-helpers')
@@ -61,6 +62,122 @@ describe('MarkdownPreviewView', function () {
 
       await preview.renderMarkdown()
       expect(preview.element.scrollTop).toBe(24)
+    })
+  })
+
+  describe('in-page anchor links', function () {
+    it('uses GitHub-compatible heading ids with the original parser', async function () {
+      atom.config.set('markdown-preview.useOriginalParser', true)
+      const html = await renderer.toHTML(
+        [
+          '[Launch](#-launch)',
+          '',
+          '## 🚀 Launch',
+          '',
+          '[Title](#title)',
+          '',
+          '## Title',
+          '',
+          '[HTML](#hello-world)',
+          '',
+          '## Hello<span>world</span>',
+          '',
+          '[Café](#caf%C3%A9)',
+          '',
+          '## Caf&eacute;'
+        ].join('\n')
+      )
+      preview.element.innerHTML = html
+
+      const launchLink = preview.element.querySelector('a[href="#-launch"]')
+      const launchTarget = preview.element.querySelector(
+        '#user-content--launch'
+      )
+      const titleTarget = preview.element.querySelector('#user-content-title')
+      const htmlTarget = preview.element.querySelector(
+        '#user-content-hello-world'
+      )
+      const entityLink = preview.element.querySelector(
+        'a[href="#caf%C3%A9"]'
+      )
+      const entityTarget = preview.element.querySelector('#user-content-café')
+      spyOn(launchTarget, 'scrollIntoView')
+      spyOn(entityTarget, 'scrollIntoView')
+
+      launchLink.dispatchEvent(
+        new MouseEvent('click', { bubbles: true, cancelable: true })
+      )
+      entityLink.dispatchEvent(
+        new MouseEvent('click', { bubbles: true, cancelable: true })
+      )
+
+      expect(launchTarget.scrollIntoView).toHaveBeenCalled()
+      expect(entityTarget.scrollIntoView).toHaveBeenCalled()
+      expect(titleTarget).not.toBeNull()
+      expect(htmlTarget).not.toBeNull()
+    })
+
+    it('prefers the generated prefixed id over a colliding raw id', function () {
+      preview.element.innerHTML = [
+        '<a href="#user-content-foo">User content foo</a>',
+        '<h2 id="user-content-foo">Foo</h2>',
+        '<h2 id="user-content-user-content-foo">User content foo</h2>'
+      ].join('')
+      const anchor = preview.element.querySelector(
+        'a[href="#user-content-foo"]'
+      )
+      const rawTarget = preview.element.querySelector('#user-content-foo')
+      const prefixedTarget = preview.element.querySelector(
+        '#user-content-user-content-foo'
+      )
+      spyOn(rawTarget, 'scrollIntoView')
+      spyOn(prefixedTarget, 'scrollIntoView')
+
+      anchor.dispatchEvent(
+        new MouseEvent('click', { bubbles: true, cancelable: true })
+      )
+
+      expect(prefixedTarget.scrollIntoView).toHaveBeenCalled()
+      expect(rawTarget.scrollIntoView).not.toHaveBeenCalled()
+    })
+
+    it('scrolls to the matching heading when a fragment link is clicked', function () {
+      preview.element.innerHTML =
+        '<p><a href="#install">Install</a></p><h2 id="install">Install</h2>'
+      const anchor = preview.element.querySelector('a[href="#install"]')
+      const target = preview.element.querySelector('#install')
+      spyOn(target, 'scrollIntoView')
+
+      anchor.dispatchEvent(
+        new MouseEvent('click', { bubbles: true, cancelable: true })
+      )
+
+      expect(target.scrollIntoView).toHaveBeenCalled()
+    })
+
+    it('scrolls to a safely prefixed GitHub heading', function () {
+      preview.element.innerHTML =
+        '<p><a href="#title">Title</a></p><h2 id="user-content-title">Title</h2>'
+      const anchor = preview.element.querySelector('a[href="#title"]')
+      const target = preview.element.querySelector('#user-content-title')
+      spyOn(target, 'scrollIntoView')
+
+      anchor.dispatchEvent(
+        new MouseEvent('click', { bubbles: true, cancelable: true })
+      )
+
+      expect(target.scrollIntoView).toHaveBeenCalled()
+    })
+
+    it('does nothing when the fragment has no matching target', function () {
+      preview.element.innerHTML = '<p><a href="#missing">Missing</a></p>'
+      const anchor = preview.element.querySelector('a[href="#missing"]')
+
+      expect(() =>
+        anchor.dispatchEvent(
+          new MouseEvent('click', { bubbles: true, cancelable: true })
+        )
+      ).not.toThrow()
     })
   })
 

--- a/packages/settings-view/lib/package-readme-view.js
+++ b/packages/settings-view/lib/package-readme-view.js
@@ -25,7 +25,8 @@ export default class PackageReadmeView {
 
     const markdownOpts = {
       breaks: false,
-      taskCheckboxDisabled: true
+      taskCheckboxDisabled: true,
+      useGitHubHeadings: true
     };
 
     if (readmeIsLocal) {
@@ -39,9 +40,35 @@ export default class PackageReadmeView {
     } catch(err) {
       this.packageReadme.innerHTML = "<h3>Error parsing README</h3>";
     }
+
+    // Pulsar's global link handler prevents native fragment navigation.
+    this.handleAnchorClick = (event) => {
+      const anchor = event.target.closest('a[href^="#"]');
+      if (anchor == null) return;
+
+      let id = anchor.getAttribute('href').slice(1);
+      try {
+        id = decodeURIComponent(id);
+      } catch (error) {
+        // Fall back to the raw fragment.
+      }
+      if (!id) return;
+
+      // Prefer generated heading ids over colliding raw ids.
+      const prefixedId = `user-content-${id}`;
+      const target =
+        this.packageReadme.querySelector(`[id="${CSS.escape(prefixedId)}"]`) ??
+        this.packageReadme.querySelector(`[id="${CSS.escape(id)}"]`);
+      if (target == null) return;
+
+      event.preventDefault();
+      target.scrollIntoView();
+    };
+    this.packageReadme.addEventListener('click', this.handleAnchorClick);
   }
 
   destroy () {
+    this.packageReadme.removeEventListener('click', this.handleAnchorClick);
     this.element.remove()
   }
 }

--- a/packages/settings-view/spec/package-readme-view-spec.js
+++ b/packages/settings-view/spec/package-readme-view-spec.js
@@ -1,0 +1,109 @@
+const PackageReadmeView = require('../lib/package-readme-view');
+
+describe('PackageReadmeView', () => {
+  let view = null;
+
+  const readme = [
+    '# Title',
+    '',
+    '## Table of contents',
+    '',
+    '- [Title](#title)',
+    '- [Install](#install)',
+    '- [User content foo](#user-content-foo)',
+    '',
+    '## Install',
+    '',
+    'Install instructions.',
+    '',
+    '## Foo',
+    '',
+    '## User content foo'
+  ].join('\n');
+
+  afterEach(() => {
+    if (view) {
+      view.destroy();
+    }
+    view = null;
+  });
+
+  describe('rendering a README with a table of contents', () => {
+    it('adds safely prefixed heading ids for fragment links', () => {
+      view = new PackageReadmeView(
+        readme,
+        'https://github.com/pulsar-edit/pulsar',
+        false
+      );
+      expect(
+        view.packageReadme.querySelector('#user-content-title')
+      ).not.toBeNull();
+      expect(
+        view.packageReadme.querySelector('#user-content-install')
+      ).not.toBeNull();
+    });
+
+    it('does not inject heading link icons', () => {
+      view = new PackageReadmeView(
+        readme,
+        'https://github.com/pulsar-edit/pulsar',
+        false
+      );
+      expect(view.packageReadme.querySelector('svg.octicon')).toBeNull();
+    });
+
+    it('preserves in-page fragment links for a remote README', () => {
+      view = new PackageReadmeView(
+        readme,
+        'https://github.com/pulsar-edit/pulsar',
+        false
+      );
+      expect(
+        view.packageReadme.querySelector('a[href="#install"]')
+      ).not.toBeNull();
+    });
+
+    it('scrolls to the matching heading when a fragment link is clicked', () => {
+      view = new PackageReadmeView(
+        readme,
+        'https://github.com/pulsar-edit/pulsar',
+        false
+      );
+      jasmine.attachToDOM(view.element);
+
+      const link = view.packageReadme.querySelector('a[href="#title"]');
+      const target = view.packageReadme.querySelector('#user-content-title');
+      spyOn(target, 'scrollIntoView');
+
+      link.dispatchEvent(
+        new MouseEvent('click', { bubbles: true, cancelable: true })
+      );
+
+      expect(target.scrollIntoView).toHaveBeenCalled();
+    });
+
+    it('prefers the generated prefixed id over a colliding raw id', () => {
+      view = new PackageReadmeView(
+        readme,
+        'https://github.com/pulsar-edit/pulsar',
+        false
+      );
+      const link = view.packageReadme.querySelector(
+        'a[href="#user-content-foo"]'
+      );
+      const rawTarget = view.packageReadme.querySelector('#user-content-foo');
+      const prefixedTarget = view.packageReadme.querySelector(
+        '#user-content-user-content-foo'
+      );
+      spyOn(rawTarget, 'scrollIntoView');
+      spyOn(prefixedTarget, 'scrollIntoView');
+
+      link.dispatchEvent(
+        new MouseEvent('click', { bubbles: true, cancelable: true })
+      );
+
+      expect(prefixedTarget.scrollIntoView).toHaveBeenCalled();
+      expect(rawTarget.scrollIntoView).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/spec/ui-spec.js
+++ b/spec/ui-spec.js
@@ -53,6 +53,57 @@ describe("Renders Markdown", () => {
         { rootDomain: "https://github.com/pulsar-edit/pulsar" }
       )).toBe('<p><a href="https://github.com/pulsar-edit/pulsar/blob/HEAD/readme.md">Hello</a></p>\n');
     });
+    it("preserves in-page fragment links", () => {
+      expect(atom.ui.markdown.render(
+        "[Install](#install)",
+        { rootDomain: "https://github.com/pulsar-edit/pulsar" }
+      )).toBe('<p><a href="#install">Install</a></p>\n');
+    });
+    it("still rewrites relative links that contain a fragment", () => {
+      expect(atom.ui.markdown.render(
+        "[Install](./README.md#install)",
+        { rootDomain: "https://github.com/pulsar-edit/pulsar" }
+      )).toBe('<p><a href="https://github.com/pulsar-edit/pulsar/blob/HEAD/README.md#install">Install</a></p>\n');
+    });
+  });
+
+  describe("handles GitHub headings", () => {
+    it("does not add heading ids unless enabled", () => {
+      const output = atom.ui.markdown.render("## Install");
+      expect(output).not.toContain('id=');
+      expect(output).not.toContain('<a');
+    });
+    it("adds a safely prefixed id while preserving the fragment href", () => {
+      const output = atom.ui.markdown.render(
+        "## Install",
+        { useGitHubHeadings: true }
+      );
+      expect(output).toContain('id="user-content-install"');
+      expect(output).toContain('href="#install"');
+    });
+    it("does not inject heading link icons", () => {
+      const output = atom.ui.markdown.render(
+        "## Install",
+        { useGitHubHeadings: true }
+      );
+      expect(output).not.toContain('<svg');
+      expect(output).not.toContain('octicon');
+    });
+    it("keeps DOM-clobbering heading ids after sanitization", () => {
+      const output = atom.ui.markdown.render(
+        "## Title",
+        { useGitHubHeadings: true, sanitize: true }
+      );
+      expect(output).toContain('id="user-content-title"');
+    });
+    it("does not rewrite the heading's own fragment href when a rootDomain is set", () => {
+      const output = atom.ui.markdown.render(
+        "## Install",
+        { useGitHubHeadings: true, rootDomain: "https://github.com/pulsar-edit/pulsar" }
+      );
+      expect(output).toContain('href="#install"');
+      expect(output).not.toContain('blob/HEAD');
+    });
   });
 
   describe("transforms images correctly", () => {

--- a/src/ui.js
+++ b/src/ui.js
@@ -137,7 +137,10 @@ function renderMarkdown(content, givenOpts = {}) {
   }
   if (opts.useGitHubHeadings) {
     mdComponents.deps.markdownItGitHubHeadings ??= require("markdown-it-github-headings");
-    md.use(mdComponents.deps.markdownItGitHubHeadings, {});
+    // Keep the default prefix so heading ids survive DOMPurify.
+    md.use(mdComponents.deps.markdownItGitHubHeadings, {
+      enableHeadingLinkIcons: false
+    });
   }
   if (opts.useTaskCheckbox) {
     mdComponents.deps.markdownItTaskCheckbox ??= require("markdown-it-task-checkbox");
@@ -224,7 +227,7 @@ function renderMarkdown(content, givenOpts = {}) {
                     attr[1] = `${cleanRootDomain()}/blob/HEAD/${link.replace(mdComponents.reg.localLinks.currentDir, "")}`;
                   } else if (opts.transformNonFqdnLinks && mdComponents.reg.localLinks.rootDir.test(link)) {
                     attr[1] = `${cleanRootDomain()}/blob/HEAD/${link.replace(mdComponents.reg.localLinks.rootDir, "")}`;
-                  } else if (opts.transformNonFqdnLinks && !link.startsWith("http")) {
+                  } else if (opts.transformNonFqdnLinks && !link.startsWith("http") && !link.startsWith("#")) {
                     attr[1] = `${cleanRootDomain()}/blob/HEAD/${link.replace(".git", "")}`;
                   }
                 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6833,6 +6833,8 @@ markdown-it@^14.1.0:
     emoji-images "^0.1.1"
     fs-plus "^3.0.0"
     github-markdown-css "^5.5.1"
+    github-slugger "^1.1.1"
+    innertext "^1.0.1"
     marked "5.0.3"
     morphdom "^2.7.2"
     underscore-plus "^1.0.0"


### PR DESCRIPTION
Preserve fragment links and generate safe GitHub-compatible heading IDs in package READMEs and Markdown Preview. Support both preview parsers  and scope scrolling to the current view.

---

Hi there,

I like using TOCs in MD files and I noticed Markdown Preview and Package info does not support it. This PR adds that support. 

Here's the example MD I used for validation + I tested  [my package](https://packages.pulsar-edit.dev/packages/pulsar-acp-agent) readme in Settings view. I built a deb package locally and tested with it. LLM was used to help. 

```
# Markdown Preview TOC anchor test

Use this file to compare an old Pulsar installation with the build containing
the TOC-anchor fixes.

## How to test

1. Open this file in Pulsar.
2. Open Markdown Preview with <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>M</kbd>.
3. Click each link in [Test cases](#test-cases).
4. After each test, scroll back to the top or use the **Back to test cases**
   link.
5. Repeat the tests with both values of:
   **Settings → Packages → Markdown Preview → Use Original Parser**
   - Checked: legacy `marked` parser.
   - Unchecked: shared `markdown-it` parser.

## Expected results

### Old Pulsar

- The in-page links below should appear inert and should not scroll to their
  headings.
- Some headings also have incompatible or sanitized-away IDs, particularly
  `Title`, emoji, inline HTML, and named-entity cases.
- The missing-target link should remain inert.

### Pulsar with the fix

- Tests 1–10 should scroll to the named target in the current preview pane.
- Test 9 must scroll to **User content foo**, not the earlier **Foo** heading.
- Test 10 verifies fallback support for a raw, unprefixed HTML ID.
- Test 11 intentionally has no target and should do nothing without producing
  an error.
- Results should be the same with both Markdown Preview parsers.

## Test cases

1. [Basic heading](#basic-heading)
2. [DOM-clobbering heading: Title](#title)
3. [Punctuation: CSS & Style](#css--style)
4. [Emoji heading](#-launch)
5. [Adjacent inline HTML](#hello-world)
6. [Named HTML entity](#caf%C3%A9)
7. [Unicode heading](#configuraci%C3%B3n)
8. [Second duplicate heading](#repeated-heading-1)
9. [Prefix-collision target: User content foo](#user-content-foo)
10. [Raw HTML ID fallback](#raw-target)
11. [Missing target — intentionally does nothing](#this-target-does-not-exist)

---

## Basic heading

**Expected target for test 1.**

[Back to test cases](#test-cases)

Lorem ipsum dolor sit amet, consectetur adipiscing elit. This text provides
some spacing so successful scrolling is visible.

---

## Title

**Expected target for test 2.**

This heading checks IDs that DOM sanitizers treat as possible DOM-clobbering
names.

[Back to test cases](#test-cases)

Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer posuere erat
a ante venenatis dapibus posuere velit aliquet.

---

## CSS & Style

**Expected target for test 3.**

The GitHub-compatible slug contains two hyphens: `css--style`.

[Back to test cases](#test-cases)

Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec sed odio dui.

---

## 🚀 Launch

**Expected target for test 4.**

The emoji is omitted from the GitHub-compatible slug, leaving `-launch`.

[Back to test cases](#test-cases)

Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla vitae elit
libero, a pharetra augue.

---

## Hello<span>world</span>

**Expected target for test 5.**

Adjacent inline HTML must be interpreted as the visible text “Hello world”,
producing `hello-world` rather than `helloworld` or `hello-spanworldspan`.

[Back to test cases](#test-cases)

Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas faucibus
mollis interdum.

---

## Caf&eacute;

**Expected target for test 6.**

The named entity must be decoded before creating the slug.

[Back to test cases](#test-cases)

Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras mattis consectetur
purus sit amet fermentum.

---

## Configuración

**Expected target for test 7.**

The percent-encoded fragment must be decoded before matching this Unicode ID.

[Back to test cases](#test-cases)

Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum id ligula
porta felis euismod semper.

---

## Repeated heading

**First duplicate — test 8 must not stop here.**

Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed posuere consectetur
est at lobortis.

## Repeated heading

**Expected target for test 8: the second duplicate.**

[Back to test cases](#test-cases)

Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean lacinia bibendum
nulla sed consectetur.

---

## Foo

**Wrong target for test 9.**

The generated ID for this heading can collide with the bare fragment intended
for the next heading.

Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cum sociis natoque
penatibus et magnis dis parturient montes.

## User content foo

**Expected target for test 9.**

The generated prefixed ID must be preferred over the colliding raw ID.

**Pass:** this heading is aligned at or near the top of the preview.

**Fail:** the earlier **Foo** heading is aligned at or near the top instead.

[Back to test cases](#test-cases)

Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam porta sem
malesuada magna mollis euismod.

<!-- Intentional space so either test-9 target can be aligned near the top. -->
<div aria-hidden="true">
<br><br><br><br><br><br><br><br><br><br>
<br><br><br><br><br><br><br><br><br><br>
<br><br><br><br><br><br><br><br><br><br>
<br><br><br><br><br><br><br><br><br><br>
</div>

---

<div id="raw-target"><strong>Expected target for test 10: raw HTML ID.</strong></div>

The handler should fall back to an exact unprefixed ID when no generated
`user-content-` target exists.

**Pass:** this raw-ID target is aligned at or near the top of the preview.

**Fail:** clicking test 10 does nothing or scrolls to a different element.

[Back to test cases](#test-cases)

<!-- Intentional space so the test-10 target can be aligned near the top. -->
<div aria-hidden="true">
<br><br><br><br><br><br><br><br><br><br>
<br><br><br><br><br><br><br><br><br><br>
<br><br><br><br><br><br><br><br><br><br>
<br><br><br><br><br><br><br><br><br><br>
</div>

---

## End of test file

If test 11 brings you here, it failed: its fragment intentionally has no
matching target.

[Back to test cases](#test-cases)
```
