### PR TITLE
[settings-view] Fix rendering of setting descriptions with line breaks…

### DIFF
--- a/packages/settings-view/lib/rich-description.js
+++ b/packages/settings-view/lib/rich-description.js
@@ -1,6 +1,6 @@
 
 module.exports = {
-  getSettingDescription (keyPath) {
+  getSettingDescription(keyPath) {
     const schema = atom.config.getSchema(keyPath)
     let description = ''
     if (schema && schema.description) {
@@ -11,13 +11,20 @@ module.exports = {
     if (atom.i18n.isAutoTranslateLabel(description)) {
       description = atom.i18n.translateLabel(description);
     }
-    
-    return atom.ui.markdown.render(
+
+    let contents = atom.ui.markdown.render(
       description,
       {
         useTaskCheckbox: false,
         disableMode: "strict",
       }
-    ).replace(/<p>(.*)<\/p>/, "$1").trim();
+    )
+
+    // If the setting has no internal paragraph breaks, strip it of its
+    // surrounding `p` tag. Otherwise keep the `p`.
+    if ((contents.match(/<p>/g)?.length ?? 0) <= 1) {
+      contents = contents.replace(/<p>(.*)<\/p>/, "$1").trim()
+    }
+    return contents
   }
 }

--- a/packages/settings-view/lib/settings-panel.js
+++ b/packages/settings-view/lib/settings-panel.js
@@ -490,6 +490,7 @@ function elementForOptions (namespace, name, value, {radio = false}) {
 
   const label = document.createElement('label')
   label.classList.add('control-label')
+  label.dataset.settingKey = keyPath
 
   const titleDiv = document.createElement('div')
   titleDiv.classList.add('setting-title')
@@ -515,6 +516,7 @@ function elementForCheckbox (namespace, name, value) {
 
   const label = document.createElement('label')
   label.for = keyPath
+  label.dataset.settingKey = keyPath
 
   const input = document.createElement('input')
   input.id = keyPath
@@ -544,6 +546,7 @@ function elementForColor (namespace, name, value) {
 
   const label = document.createElement('label')
   label.for = keyPath
+  label.dataset.settingKey = keyPath
 
   const input = document.createElement('input')
   input.id = keyPath
@@ -572,6 +575,7 @@ function elementForEditor (namespace, name, value) {
 
   const label = document.createElement('label')
   label.classList.add('control-label')
+  label.dataset.settingKey = keyPath
 
   const titleDiv = document.createElement('div')
   titleDiv.classList.add('setting-title')
@@ -607,6 +611,7 @@ function elementForArray (namespace, name, value) {
 
   const label = document.createElement('label')
   label.classList.add('control-label')
+  label.dataset.settingKey = keyPath
 
   const titleDiv = document.createElement('div')
   titleDiv.classList.add('setting-title')

--- a/packages/settings-view/spec/.eslintrc.js
+++ b/packages/settings-view/spec/.eslintrc.js
@@ -5,7 +5,8 @@ module.exports = {
     node: true
   },
   globals: {
-    waitsForPromise: true
+    waitsForPromise: true,
+    advanceClock: true
   },
   rules: {
     "node/no-missing-require": "off",

--- a/packages/settings-view/spec/settings-panel-spec.js
+++ b/packages/settings-view/spec/settings-panel-spec.js
@@ -465,4 +465,57 @@ describe("SettingsPanel", () => {
       });
     });
   });
+
+  describe('settings rendering', () => {
+    beforeEach(() => {
+      const config = {
+        type: 'object',
+        properties: {
+          troz: {
+            title: 'troz',
+            // Testing paragraph breaks inside a description.
+            description: 'The troz setting.\n\nIgnored unless `zort` is also `true`.',
+            type: 'string',
+            default: 'troz',
+          },
+          minMax: {
+            name: 'minMax',
+            title: 'Min max',
+            description: 'The minMax setting',
+            type: 'integer',
+            default: 10,
+            minimum: 1,
+            maximum: 100
+          },
+          commaValueArray: {
+            name: 'commaValueArray',
+            title: 'Comma value in array',
+            description: 'An array with a comma value',
+            type: 'array',
+            default: []
+          }
+        }
+      };
+
+      atom.config.setSchema('foo', config);
+      settingsPanel = new SettingsPanel({namespace: 'foo', includeTitle: false});
+    });
+
+    it('renders a setting description as Markdown', () => {
+      // A setting with internal paragraph breaks should end up with two P
+      // elements…
+      const trozDescription = settingsPanel.element.querySelector(
+        `label[data-setting-key="foo.troz"] > .setting-description`
+      );
+      expect(trozDescription.querySelectorAll('p').length).toBe(2);
+
+      // …but a setting without any paragraph breaks should have its outer P
+      // element stripped.
+      const minMaxDescription = settingsPanel.element.querySelector(
+        `label[data-setting-key="foo.minMax"] > .setting-description`
+      );
+      expect(minMaxDescription.querySelectorAll('p').length).toBe(0);
+    });
+  });
+
 });


### PR DESCRIPTION
…so that each section is wrapped in a P tag when appropriate.

Here's an excerpt from the config schema for `pulsar-ide-typescript`:

```json
{
  "enable": {
    "order": 0,
    "title": "Enable",
    "type": "boolean",
    "default": false,
    "description": "Whether to enable automatic code formatting. When disabled, this package will not act as a code formatting provider under any circumstances. When enabled, you must still have a package such as `pulsar-code-format` to implement code formatting and to control whether it is applied on save, while you type, or only when you ask for it.\n\n**Before enabling**, please ensure that this behavior will not interfere with any other format-on-save behavior might be active in your project from integrations with (e.g.) ESLint or Prettier.\n\n(Takes effect after a window reload or a restart of Pulsar.)"
  },
}
```

You can see that this description uses Markdown-style paragraph breaks `\n\n` to break up the wall of text. This should work because we render setting descriptions as Markdown in `settings-view`.

But here's what it looks like:

<p><img width="780" height="215" alt="Screenshot 2026-08-02 at 1 26 23 PM" src="https://github.com/user-attachments/assets/5587c5be-bc6f-4b47-a3e3-0d8a2d1afd49" /></p>

If you dig into it, the issue is that the first paragraph isn't actually wrapped in a `p` tag. And since `one-dark` styles paragraph elements to have `margin-bottom` but no `margin-top`, there's no space between the first and second paragraphs.

This happens because `getRichDescription` explicitly strips the surrounding `p` tag after render — perhaps because it's viewed as extraneous. In a multi-paragraph snippet of HTML, that has the effect of stripping the first paragraph's opening `<p>` and the last paragraph's closing `</p>`. A missing closing tag is generally recoverable (and explicitly allowed in the case of `<p>`), so that's why the last paragraph survives… but removing the initial `<p>` means the first occurrence of `</p>` will be unpaired, and therefore ignored by the browser.

Anyway, stripping paragraph tags when there's just one paragraph is arguably fine — but not when we _want_ multiple paragraphs in our setting description.

This PR changes this behavior so that, if multiple paragraphs are detected in a setting's HTML, we skip the stripping of the outer `<p>` and `</p>`.

Now the setting description renders as intended:

<p><img width="772" height="237" alt="Screenshot 2026-08-02 at 1 25 56 PM" src="https://github.com/user-attachments/assets/b9e151cf-92e9-41fd-ab69-6c397fbbcf5e" /></p>

Added a spec to verify that this change does what it says and does not cause regressions for the vast majority of setting descriptions that _do not_ include internal paragraph breaks.