### PR TITLE
[autocomplete-plus] Resolve an automatically-inserted suggestion…

### DIFF
--- a/packages/autocomplete-plus/lib/autocomplete-manager.js
+++ b/packages/autocomplete-plus/lib/autocomplete-manager.js
@@ -270,12 +270,12 @@ class AutocompleteManager {
     return this.getSuggestionsFromProviders({editor: this.editor, bufferPosition, scopeDescriptor, prefix, legacyPrefix, activatedManually})
   }
 
-  getSuggestionsFromProviders(options) {
+  async getSuggestionsFromProviders(options) {
     let suggestionsPromise
     const providers = this.providerManager.applicableProviders(this.editorLabels, options.scopeDescriptor)
 
     const providerPromises = []
-    providers.forEach(provider => {
+    for (let provider of providers) {
       const apiVersion = this.providerManager.apiVersionForProvider(provider)
 
       let getSuggestions
@@ -304,7 +304,7 @@ class AutocompleteManager {
         }
       }
 
-      return providerPromises.push(Promise.resolve(getSuggestions(upgradedOptions)).then(providerSuggestions => {
+      providerPromises.push(Promise.resolve(getSuggestions(upgradedOptions)).then(providerSuggestions => {
         if (providerSuggestions == null) { return }
 
         // TODO API: remove upgrading when 1.0 support is removed
@@ -361,7 +361,7 @@ class AutocompleteManager {
         }
         return providerSuggestions
       }))
-    })
+    }
 
     if (!providerPromises || !providerPromises.length) {
       return
@@ -369,13 +369,19 @@ class AutocompleteManager {
 
     suggestionsPromise = Promise.all(providerPromises)
     this.currentSuggestionsPromise = suggestionsPromise
+
     return this.currentSuggestionsPromise
       .then(this.mergeSuggestionsFromProviders)
       .then(suggestions => {
         if (this.currentSuggestionsPromise !== suggestionsPromise) { return }
         if (options.activatedManually && this.shouldDisplaySuggestions && this.autoConfirmSingleSuggestionEnabled && suggestions.length === 1) {
-          // When there is one suggestion in manual mode, just confirm it
-          return this.confirm(suggestions[0])
+          // When there is one suggestion in manual mode, just confirm it. But
+          // it might have extra metadata like `additionalTextEdits`, so we
+          // need to resolve that data first.
+          let [suggestion] = suggestions
+          return this.getDetailsOnSelect(suggestion).then(() => {
+            return this.confirm(suggestion)
+          })
         } else {
           return this.displaySuggestions(suggestions, options)
         }
@@ -621,10 +627,12 @@ See https://github.com/atom/autocomplete-plus/wiki/Provider-API`
 
   getDetailsOnSelect(suggestion) {
     if (suggestion != null && suggestion.provider && suggestion.provider.getSuggestionDetailsOnSelect) {
-      Promise.resolve(suggestion.provider.getSuggestionDetailsOnSelect(suggestion))
+      return Promise.resolve(suggestion.provider.getSuggestionDetailsOnSelect(suggestion))
         .then(detailedSuggestion => {
           this.suggestionList.replaceItem(suggestion, detailedSuggestion)
         })
+    } else {
+      return Promise.resolve();
     }
   }
 

--- a/packages/autocomplete-plus/lib/autocomplete-manager.js
+++ b/packages/autocomplete-plus/lib/autocomplete-manager.js
@@ -379,8 +379,8 @@ class AutocompleteManager {
           // it might have extra metadata like `additionalTextEdits`, so we
           // need to resolve that data first.
           let [suggestion] = suggestions
-          return this.getDetailsOnSelect(suggestion).then(() => {
-            return this.confirm(suggestion)
+          return this.getDetailsOnSelect(suggestion).then(detailedSuggestion => {
+            return this.confirm(detailedSuggestion)
           })
         } else {
           return this.displaySuggestions(suggestions, options)
@@ -626,13 +626,18 @@ See https://github.com/atom/autocomplete-plus/wiki/Provider-API`
   }
 
   getDetailsOnSelect(suggestion) {
-    if (suggestion != null && suggestion.provider && suggestion.provider.getSuggestionDetailsOnSelect) {
+    if (typeof suggestion?.provider?.getSuggestionDetailsOnSelect === 'function') {
       return Promise.resolve(suggestion.provider.getSuggestionDetailsOnSelect(suggestion))
         .then(detailedSuggestion => {
+          if (detailedSuggestion == null) { return suggestion }
+          // The provider may have given us a brand-new object; make sure it
+          // can still be traced back to its provider on insertion.
+          detailedSuggestion.provider = detailedSuggestion.provider ?? suggestion.provider
           this.suggestionList.replaceItem(suggestion, detailedSuggestion)
+          return detailedSuggestion
         })
     } else {
-      return Promise.resolve();
+      return Promise.resolve(suggestion)
     }
   }
 

--- a/packages/autocomplete-plus/spec/provider-api-spec.js
+++ b/packages/autocomplete-plus/spec/provider-api-spec.js
@@ -5,6 +5,7 @@ import {
   waitForAutocomplete,
   triggerAutocompletion,
   conditionPromise,
+  timeoutPromise,
   waitForAutocompleteToDisappear
 } from './spec-helper'
 import path from 'path'
@@ -608,6 +609,139 @@ describe('Provider API', () => {
       await confirmChoice(0)
 
       expect(editor.getText()).toEqual("\nips$0um\nkbye\n, world\name$0t\n")
+    })
+  })
+
+  describe('when a lone suggestion is confirmed automatically', () => {
+    function activate () {
+      atom.commands.dispatch(atom.views.getView(editor), 'autocomplete-plus:activate')
+    }
+
+    beforeEach(async () => {
+      // Auto-confirmation of a single suggestion only happens when the user
+      // asks for suggestions explicitly.
+      atom.config.set('autocomplete-plus.enableAutoActivation', false)
+      atom.config.set('autocomplete-plus.enableAutoConfirmSingleSuggestion', true)
+      await atom.packages.activatePackage('snippets')
+      editor.setText('lorem\nhello, world\n')
+      editor.setCursorBufferPosition([1, 5])
+      // Moving the cursor queues a request to hide the suggestion list; let it
+      // resolve before the specs start, lest it hide a list we mean to show.
+      await timeoutPromise(0)
+    })
+
+    it('resolves the suggestion before inserting it', async () => {
+      let insertedSuggestion = null
+      testProvider = {
+        scopeSelector: '.source.js',
+        inclusionPriority: 2,
+        excludeLowerPriority: true,
+        getSuggestions () {
+          return [{ text: 'ohai', replacementPrefix: 'hello' }]
+        },
+        getSuggestionDetailsOnSelect (suggestion) {
+          return {
+            ...suggestion,
+            additionalTextEdits: [
+              { range: [[0, 0], [0, 5]], newText: 'ipsum' }
+            ]
+          }
+        },
+        onDidInsertSuggestion ({ suggestion }) {
+          insertedSuggestion = suggestion
+        }
+      }
+      registration = atom.packages.serviceHub.provide('autocomplete.provider', '5.1.0', testProvider)
+
+      activate()
+      await conditionPromise(() => insertedSuggestion != null)
+
+      expect(insertedSuggestion.additionalTextEdits).toBeDefined()
+      expect(editor.getText()).toEqual('ipsum\nohai, world\n')
+    })
+
+    it('waits for asynchronous resolution before inserting the suggestion', async () => {
+      let insertedSuggestion = null
+      testProvider = {
+        scopeSelector: '.source.js',
+        inclusionPriority: 2,
+        excludeLowerPriority: true,
+        getSuggestions () {
+          return [{ text: 'ohai', replacementPrefix: 'hello' }]
+        },
+        async getSuggestionDetailsOnSelect (suggestion) {
+          await timeoutPromise(50)
+          return {
+            ...suggestion,
+            additionalTextEdits: [
+              { range: [[0, 0], [0, 5]], newText: 'ipsum' }
+            ]
+          }
+        },
+        onDidInsertSuggestion ({ suggestion }) {
+          insertedSuggestion = suggestion
+        }
+      }
+      registration = atom.packages.serviceHub.provide('autocomplete.provider', '5.1.0', testProvider)
+
+      activate()
+
+      // Nothing should have been inserted while the provider was still
+      // resolving the suggestion.
+      await timeoutPromise(25)
+      expect(insertedSuggestion).toBe(null)
+      expect(editor.getText()).toEqual('lorem\nhello, world\n')
+
+      await conditionPromise(() => insertedSuggestion != null)
+
+      expect(insertedSuggestion.additionalTextEdits).toBeDefined()
+      expect(editor.getText()).toEqual('ipsum\nohai, world\n')
+    })
+
+    it('inserts the suggestion when the provider cannot resolve suggestions', async () => {
+      let insertedSuggestion = null
+      testProvider = {
+        scopeSelector: '.source.js',
+        inclusionPriority: 2,
+        excludeLowerPriority: true,
+        getSuggestions () {
+          return [{ text: 'ohai', replacementPrefix: 'hello' }]
+        },
+        onDidInsertSuggestion ({ suggestion }) {
+          insertedSuggestion = suggestion
+        }
+      }
+      registration = atom.packages.serviceHub.provide('autocomplete.provider', '5.1.0', testProvider)
+
+      activate()
+      await conditionPromise(() => insertedSuggestion != null)
+
+      expect(editor.getText()).toEqual('lorem\nohai, world\n')
+    })
+
+    it('does not confirm anything when more than one suggestion is present', async () => {
+      testProvider = {
+        scopeSelector: '.source.js',
+        inclusionPriority: 2,
+        excludeLowerPriority: true,
+        getSuggestions () {
+          return [
+            { text: 'ohai', replacementPrefix: 'hello' },
+            { text: 'ohno', replacementPrefix: 'hello' }
+          ]
+        },
+        getSuggestionDetailsOnSelect (suggestion) {
+          return suggestion
+        }
+      }
+      registration = atom.packages.serviceHub.provide('autocomplete.provider', '5.1.0', testProvider)
+
+      activate()
+      await waitForAutocomplete(editor)
+
+      // The list is shown instead of anything being auto-confirmed.
+      expect(autocompleteManager.suggestionList.items.length).toBe(2)
+      expect(editor.getText()).toEqual('lorem\nhello, world\n')
     })
   })
 })


### PR DESCRIPTION
…before insertion so that all its metadata is known (like `additionalTextEdits`).

The bug I filed [against my own `atom-languageclient` fork](https://github.com/savetheclocktower/atom-languageclient/issues/11) ended up correct:

> Actually, I suspect it's a bug in autocomplete-plus. I wouldn't be surprised to learn that we consider `additionalTextEdits` when choosing an option from a menu, but not when automatically choosing the only candidate. I'll find out.

It's not quite this simple, but not far from it, either.

The LSP spec lets the server send some suggestion data initially and then fill in the rest later on an as-needed basis. That “enhancement” of a given suggestion is done by `autocomplete-plus` when the user selects the item in the menu; that's when we call `getDetailsOnSelect`, which in the case of an IDE package will ask the language server to “resolve” the suggestion with further metadata.

I don't have `autocomplete-plus` set up the ordinary way. I've configured it not to show the menu at all until I invoke the `autocomplete-plus:activate` command. But when the menu is invoked manually, it has a special behavior: if there's only one item in the suggestion list, it gets automatically accepted, and the menu never even opens.

That's great. But it means that we've lost our opportunity to load more metadata! Among that metadata is `additionalTextEdits` — the property that describes other edits that should be made to the document once the suggestion is accepted. This is typically used to add an `import` clause for whatever token is being completed (if necessary). So I got in the habit of opening the menu slightly earlier, with slightly fewer characters typed, so that I could choose the right option when it was still one among several possible candidates — on the logic that it would end up saving me time!

This is the fix, though: on the code path where we automatically insert the only suggestion in the menu, we first call `getDetailsOnSelect` and only then follow with a call to `confirm`. This guarantees we load all the text edits related to this suggestion.

### Testing

A few new specs! They revealed I'd made some bad assumptions the first time around, too.